### PR TITLE
Fixing references for Highcharts line charts

### DIFF
--- a/fireant/slicer/managers.py
+++ b/fireant/slicer/managers.py
@@ -144,7 +144,8 @@ class SlicerManager(QueryManager):
             'metrics': {key: self.slicer.metrics[key].label
                         for key in metrics or []},
             'dimensions': self._display_dimensions(dimensions),
-            'references': [reference.key for reference in references or []]
+            'references': {reference.key: reference.label
+                           for reference in references or []}
         }
 
     def _metrics_schema(self, keys):

--- a/fireant/slicer/references.py
+++ b/fireant/slicer/references.py
@@ -7,43 +7,55 @@ class Reference(object):
 
 class WoW(Reference):
     key = 'wow'
+    label = 'WoW'
 
 
 class MoM(Reference):
     key = 'mom'
+    label = 'MoM'
 
 
 class QoQ(Reference):
     key = 'qoq'
+    label = 'QoQ'
 
 
 class YoY(Reference):
     key = 'yoy'
+    label = 'YoY'
 
 
 class Delta(object):
     class WoW(Reference):
         key = 'wow_d'
+        label = 'ΔWoW'
 
     class MoM(Reference):
         key = 'mom_d'
+        label = 'ΔMoM'
 
     class QoQ(Reference):
         key = 'qoq_d'
+        label = 'ΔQoQ'
 
     class YoY(Reference):
         key = 'yoy_d'
+        label = 'ΔYoY'
 
 
 class DeltaPercentage(object):
     class WoW(Reference):
         key = 'wow_p'
+        label = 'ΔWoW%'
 
     class MoM(Reference):
         key = 'mom_p'
+        label = 'ΔMoM%'
 
     class QoQ(Reference):
         key = 'qoq_p'
+        label = 'ΔQoQ%'
 
     class YoY(Reference):
         key = 'yoy_p'
+        label = 'ΔYoY%'

--- a/fireant/slicer/schemas.py
+++ b/fireant/slicer/schemas.py
@@ -149,7 +149,7 @@ class DimensionValue(object):
 
 
 class Join(object):
-    def __init__(self, key, table, criterion, join_type=JoinType.left):
+    def __init__(self, key, table, criterion, join_type=JoinType.inner):
         self.key = key
         self.table = table
         self.criterion = criterion

--- a/fireant/slicer/transformers/highcharts.py
+++ b/fireant/slicer/transformers/highcharts.py
@@ -4,10 +4,6 @@ import pandas as pd
 
 from .base import Transformer, TransformationException
 
-default_options = {
-
-}
-
 
 class HighchartsTransformer(Transformer):
     """
@@ -24,10 +20,21 @@ class HighchartsTransformer(Transformer):
 
         if isinstance(data_frame.index, pd.MultiIndex):
             data_frame = self._reorder_index_levels(data_frame, display_schema)
+        has_references = isinstance(data_frame.columns, pd.MultiIndex)
 
         dim_ordinal = {name: ordinal
                        for ordinal, name in enumerate(data_frame.index.names)}
         data_frame = self._prepare_data_frame(data_frame, dim_ordinal, display_schema['dimensions'])
+
+        if has_references:
+            series = sum(
+                [self._make_series(data_frame[level], dim_ordinal, display_schema, reference=level or None)
+                 for level in data_frame.columns.levels[0]],
+                []
+            )
+
+        else:
+            series = self._make_series(data_frame, dim_ordinal, display_schema)
 
         result = {
             'chart': {'type': self.chart_type},
@@ -35,7 +42,7 @@ class HighchartsTransformer(Transformer):
             'xAxis': self.xaxis_options(data_frame, dim_ordinal, display_schema),
             'yAxis': self.yaxis_options(data_frame, dim_ordinal, display_schema),
             'tooltip': {'shared': True},
-            'series': self._make_series(data_frame, dim_ordinal, display_schema)
+            'series': series
         }
 
         return result
@@ -67,10 +74,10 @@ class HighchartsTransformer(Transformer):
                                               for level in dimension_orders)
         return reordered
 
-    def _make_series(self, data_frame, dim_ordinal, display_schema):
+    def _make_series(self, data_frame, dim_ordinal, display_schema, reference=None):
         # Convert dates to millis
-        if isinstance(data_frame.index, pd.DatetimeIndex):
-            data_frame.index = data_frame.index.astype(int) // 1e6
+        # if isinstance(data_frame.index, pd.DatetimeIndex):
+        #     data_frame.index = data_frame.index.astype(int) // 1e6
 
         # This value represents how many iterations over data_frame items per yAxis we have.  It's the product of
         # non-metric levels of the data_frame's columns. We want metrics to share the same yAxis for all dimensions.
@@ -78,11 +85,16 @@ class HighchartsTransformer(Transformer):
                       if isinstance(data_frame.columns, pd.MultiIndex)
                       else 1)
 
-        return [{
-                    'name': self._format_label(idx, dim_ordinal, display_schema),
-                    'data': self._format_data(item),
-                    'yAxis': int(i // yaxis_span),
-                } for i, (idx, item) in enumerate(data_frame.iteritems())]
+        return [self._make_series_item(idx, item, dim_ordinal, display_schema, int(i // yaxis_span), reference)
+                for i, (idx, item) in enumerate(data_frame.iteritems())]
+
+    def _make_series_item(self, idx, item, dim_ordinal, display_schema, y_axis, reference):
+        return {
+            'name': self._format_label(idx, dim_ordinal, display_schema, reference),
+            'data': self._format_data(item),
+            'yAxis': y_axis,
+            'dashStyle': 'Dot' if reference else 'Solid'
+        }
 
     def _validate_dimensions(self, data_frame, dimensions):
         if not 0 < len(dimensions):
@@ -108,11 +120,21 @@ class HighchartsTransformer(Transformer):
 
         return data_frame
 
-    def _format_label(self, idx, dim_ordinal, display_schema):
-        if not isinstance(idx, tuple):
-            return display_schema['metrics'].get(idx, idx)
+    def _format_label(self, idx, dim_ordinal, display_schema, reference):
+        is_multidimensional = isinstance(idx, tuple)
+        if is_multidimensional:
+            metric_label = display_schema['metrics'].get(idx[0], idx[0])
+        else:
+            metric_label = display_schema['metrics'].get(idx, idx)
 
-        metric_label = display_schema['metrics'].get(idx[0], idx[0])
+        if reference:
+            metric_label += ' {reference}'.format(
+                reference=display_schema['references'][reference]
+            )
+
+        if not is_multidimensional:
+            return metric_label
+
         dim_labels = [self._format_dimension_label(dim_ordinal, dimension, idx)
                       for dimension in display_schema['dimensions'][1:]]
         dim_labels = [dim_label  # filter out the NaNs
@@ -137,14 +159,22 @@ class HighchartsTransformer(Transformer):
             dim_label = dimension['label_options'].get(dim_label, dim_label)
         return dim_label
 
-    @staticmethod
-    def _format_data(column):
+    def _format_data(self, column):
         if isinstance(column, float):
             return [column]
 
-        return [(key, np.round(value, 2))
+        return [self._format_point(key, value)
                 for key, value in column.iteritems()
                 if not np.isnan(value)]
+
+    @staticmethod
+    def _format_point(x, y):
+        # return {'x': x, 'y': y}
+        return (
+            int(x.asm8) // int(1e6) if isinstance(x, pd.Timestamp) else x,
+            # FIXME make this configurable
+            round(y, 2)
+        )
 
     def _unstack_levels(self, dimensions, dim_ordinal):
         for dimension in dimensions:
@@ -162,6 +192,13 @@ class HighchartsColumnTransformer(HighchartsTransformer):
     def __init__(self, chart_type=column):
         super(HighchartsColumnTransformer, self).__init__(chart_type)
 
+    def _make_series_item(self, idx, item, dim_ordinal, display_schema, y_axis, reference):
+        return {
+            'name': self._format_label(idx, dim_ordinal, display_schema, reference),
+            'data': self._format_data(item),
+            'yAxis': y_axis
+        }
+
     def xaxis_options(self, data_frame, dim_ordinal, display_schema):
         result = {'type': 'categorical'}
 
@@ -170,9 +207,6 @@ class HighchartsColumnTransformer(HighchartsTransformer):
             result['categories'] = categories
 
         return result
-
-    # def yaxis_options(self, data_frame, dim_ordinal, display_schema):
-    #     return {'title': None}
 
     def _validate_dimensions(self, data_frame, dimensions):
         if 1 < len(dimensions) and 1 < len(data_frame.columns):
@@ -197,8 +231,7 @@ class HighchartsColumnTransformer(HighchartsTransformer):
 
         return data_frame
 
-    @staticmethod
-    def _format_data(column):
+    def _format_data(self, column):
         return list(column)
 
     @staticmethod

--- a/fireant/tests/slicer/test_slicer_api.py
+++ b/fireant/tests/slicer/test_slicer_api.py
@@ -727,7 +727,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
             {
                 'metrics': {'foo': 'Foo'},
                 'dimensions': [],
-                'references': [],
+                'references': {},
             },
             display_schema
         )
@@ -741,7 +741,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
             {
                 'metrics': {'bar': 'FizBuz'},
                 'dimensions': [],
-                'references': [],
+                'references': {},
             },
             display_schema
         )
@@ -759,7 +759,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
                     {'label': 'Date',
                      'id_fields': ['date']},
                 ],
-                'references': [],
+                'references': {},
             },
             display_schema
         )
@@ -777,7 +777,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
                     {'label': 'Clicks CUSTOM LABEL',
                      'id_fields': ['clicks']},
                 ],
-                'references': [],
+                'references': {},
             },
             display_schema
         )
@@ -796,7 +796,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
                      'label_options': {'us': 'United States',
                                        'de': 'Germany'}},
                 ],
-                'references': [],
+                'references': {},
             },
             display_schema
         )
@@ -814,7 +814,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
                      'id_fields': ['account_id0'],
                      'label_field': 'account_label'},
                 ],
-                'references': [],
+                'references': {},
             },
             display_schema
         )
@@ -833,7 +833,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
                      'id_fields': ['keyword_id0', 'keyword_id1'],
                      'label_field': 'keyword_label'},
                 ],
-                'references': [],
+                'references': {},
             },
             display_schema
         )
@@ -859,7 +859,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
                      'id_fields': ['account_id0'],
                      'label_field': 'account_label'},
                 ],
-                'references': [],
+                'references': {},
             },
             display_schema
         )
@@ -878,7 +878,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
                     {'label': 'Date',
                      'id_fields': ['date']},
                 ],
-                'references': ['wow'],
+                'references': {'wow': 'WoW'},
             },
             display_schema
         )

--- a/fireant/tests/slicer/transformers/base.py
+++ b/fireant/tests/slicer/transformers/base.py
@@ -145,6 +145,16 @@ class BaseTransformerTests(unittest.TestCase):
         'metrics': {'one': 'One'},
         'dimensions': [time_dim]
     }
+    time_dim_single_metric_ref_df = pd.DataFrame(
+        np.random.randint(0, 10, size=(8, 2)),
+        columns=[['', 'wow'], ['one', 'one']],
+        index=datetime_idx
+    )
+    time_dim_single_metric_ref_schema = {
+        'metrics': {'one': 'One'},
+        'dimensions': [time_dim],
+        'references': {'wow': 'WoW'}
+    }
 
     # Test DF with continuous and categorical dimensions and one metric column
     cont_cat_dims_single_metric_df = pd.DataFrame(

--- a/fireant/tests/slicer/transformers/test_highcharts.py
+++ b/fireant/tests/slicer/transformers/test_highcharts.py
@@ -21,9 +21,9 @@ class HighChartsLineTransformerTests(BaseTransformerTests):
         for data, (_, row) in zip(result_data, df.iteritems()):
             self.assertListEqual(list(row.iteritems()), data)
 
-    def evaluate_chart_options(self, result, n_results=1, xaxis_type='linear', dash_style='Solid'):
+    def evaluate_chart_options(self, result, num_series=1, xaxis_type='linear', dash_style='Solid'):
         self.assertSetEqual({'title', 'series', 'chart', 'tooltip', 'xAxis', 'yAxis'}, set(result.keys()))
-        self.assertEqual(n_results, len(result['series']))
+        self.assertEqual(num_series, len(result['series']))
 
         self.assertSetEqual({'text'}, set(result['title'].keys()))
         self.assertIsNone(result['title']['text'])
@@ -57,7 +57,7 @@ class HighChartsLineTransformerTests(BaseTransformerTests):
 
         result = self.hc_tx.transform(df, self.cont_dim_multi_metric_schema)
 
-        self.evaluate_chart_options(result, n_results=2)
+        self.evaluate_chart_options(result, num_series=2)
 
         self.assertSetEqual(
             {'One', 'Two'},
@@ -68,14 +68,14 @@ class HighChartsLineTransformerTests(BaseTransformerTests):
 
     def test_time_series_date_to_millis(self):
         # Tests transformation of a single-metric, single-dimension result
-        df = self.time_dim_single_metric_df
+        df = self.time_dim_single_metric_ref_df
 
-        result = self.hc_tx.transform(df, self.time_dim_single_metric_schema)
+        result = self.hc_tx.transform(df, self.time_dim_single_metric_ref_schema)
 
-        self.evaluate_chart_options(result, xaxis_type='datetime')
+        self.evaluate_chart_options(result, num_series=2, xaxis_type='datetime')
 
         self.assertSetEqual(
-            {'One'},
+            {'One', 'One WoW'},
             {series['name'] for series in result['series']}
         )
 
@@ -89,7 +89,7 @@ class HighChartsLineTransformerTests(BaseTransformerTests):
 
         result = self.hc_tx.transform(df, self.cont_uni_dims_single_metric_schema)
 
-        self.evaluate_chart_options(result, n_results=4)
+        self.evaluate_chart_options(result, num_series=4)
 
         self.assertSetEqual(
             {'One (Uni2_1)', 'One (Uni2_2)', 'One (Uni2_3)', 'One (Uni2_4)'},
@@ -104,7 +104,7 @@ class HighChartsLineTransformerTests(BaseTransformerTests):
 
         result = self.hc_tx.transform(df, self.cont_uni_dims_multi_metric_schema)
 
-        self.evaluate_chart_options(result, n_results=8)
+        self.evaluate_chart_options(result, num_series=8)
 
         self.assertSetEqual(
             {'One (Uni2_1)', 'One (Uni2_2)', 'One (Uni2_3)', 'One (Uni2_4)',
@@ -120,7 +120,7 @@ class HighChartsLineTransformerTests(BaseTransformerTests):
 
         result = self.hc_tx.transform(df, self.cont_cat_dims_single_metric_schema)
 
-        self.evaluate_chart_options(result, n_results=2)
+        self.evaluate_chart_options(result, num_series=2)
 
         self.assertSetEqual(
             {'One (A)', 'One (B)'},
@@ -135,7 +135,7 @@ class HighChartsLineTransformerTests(BaseTransformerTests):
 
         result = self.hc_tx.transform(df, self.cont_cat_dims_multi_metric_schema)
 
-        self.evaluate_chart_options(result, n_results=4)
+        self.evaluate_chart_options(result, num_series=4)
 
         self.assertSetEqual(
             {'One (A)', 'One (B)', 'Two (A)', 'Two (B)'},
@@ -150,7 +150,7 @@ class HighChartsLineTransformerTests(BaseTransformerTests):
 
         result = self.hc_tx.transform(df, self.cont_cat_cat_dims_multi_metric_schema)
 
-        self.evaluate_chart_options(result, n_results=8)
+        self.evaluate_chart_options(result, num_series=8)
 
         self.assertSetEqual(
             {'One (A, Y)', 'One (A, Z)', 'One (B, Y)', 'One (B, Z)',
@@ -166,7 +166,7 @@ class HighChartsLineTransformerTests(BaseTransformerTests):
 
         result = self.hc_tx.transform(df, self.cont_cat_uni_dims_multi_metric_schema)
 
-        self.evaluate_chart_options(result, n_results=16)
+        self.evaluate_chart_options(result, num_series=16)
 
         self.assertSetEqual(
             {'One (A, Uni2_1)', 'One (A, Uni2_2)', 'One (A, Uni2_3)', 'One (A, Uni2_4)',
@@ -184,7 +184,7 @@ class HighChartsLineTransformerTests(BaseTransformerTests):
 
         result = self.hc_tx.transform(df, self.rollup_cont_cat_cat_dims_multi_metric_schema)
 
-        self.evaluate_chart_options(result, n_results=14)
+        self.evaluate_chart_options(result, num_series=14)
 
         self.assertSetEqual(
             {'One', 'One (A)', 'One (A, Y)', 'One (A, Z)', 'One (B)', 'One (B, Y)', 'One (B, Z)',

--- a/fireant/tests/slicer/transformers/test_highcharts.py
+++ b/fireant/tests/slicer/transformers/test_highcharts.py
@@ -68,6 +68,23 @@ class HighChartsLineTransformerTests(BaseTransformerTests):
 
     def test_time_series_date_to_millis(self):
         # Tests transformation of a single-metric, single-dimension result
+        df = self.time_dim_single_metric_df
+
+        result = self.hc_tx.transform(df, self.time_dim_single_metric_schema)
+
+        self.evaluate_chart_options(result, xaxis_type='datetime')
+
+        self.assertSetEqual(
+            {'One'},
+            {series['name'] for series in result['series']}
+        )
+
+        df2 = df
+        df2.index = df2.index.astype(int) // int(1e6)
+        self.evaluate_result(df2, result)
+
+    def test_time_series_date_with_ref(self):
+        # Tests transformation of a single-metric, single-dimension result using a WoW reference
         df = self.time_dim_single_metric_ref_df
 
         result = self.hc_tx.transform(df, self.time_dim_single_metric_ref_schema)

--- a/fireant/tests/slicer/transformers/test_highcharts.py
+++ b/fireant/tests/slicer/transformers/test_highcharts.py
@@ -21,7 +21,7 @@ class HighChartsLineTransformerTests(BaseTransformerTests):
         for data, (_, row) in zip(result_data, df.iteritems()):
             self.assertListEqual(list(row.iteritems()), data)
 
-    def evaluate_chart_options(self, result, n_results=1, xaxis_type='linear'):
+    def evaluate_chart_options(self, result, n_results=1, xaxis_type='linear', dash_style='Solid'):
         self.assertSetEqual({'title', 'series', 'chart', 'tooltip', 'xAxis', 'yAxis'}, set(result.keys()))
         self.assertEqual(n_results, len(result['series']))
 
@@ -34,7 +34,7 @@ class HighChartsLineTransformerTests(BaseTransformerTests):
         self.assertEqual(xaxis_type, result['xAxis']['type'])
 
         for series in result['series']:
-            self.assertSetEqual({'name', 'data', 'yAxis'}, set(series.keys()))
+            self.assertSetEqual({'name', 'data', 'yAxis', 'dashStyle'}, set(series.keys()))
 
     def test_series_single_metric(self):
         # Tests transformation of a single-metric, single-dimension result
@@ -80,7 +80,7 @@ class HighChartsLineTransformerTests(BaseTransformerTests):
         )
 
         df2 = df
-        df2.index = df2.index.astype(int) // 1e6
+        df2.index = df2.index.astype(int) // int(1e6)
         self.evaluate_result(df2, result)
 
     def test_cont_uni_dim_single_metric(self):

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     install_requires=[
         'six',
         'pandas',
-        'pypika==0.0.21'
+        'pypika==0.0.26'
     ],
     tests_require=[
         'mock',


### PR DESCRIPTION
Fixed end-to-end references for line charts, now all the bugs should be eliminated.

This was a bit more complex than I had originally planned, however it can probably be simplified in the future.  The data frame builds a wrapper query that selects from the original query and joins all of the reference queries.