### PR TITLE
Fixes for Data Tables transformer

### DIFF
--- a/fireant/tests/slicer/transformers/test_highcharts.py
+++ b/fireant/tests/slicer/transformers/test_highcharts.py
@@ -79,7 +79,7 @@ class HighChartsLineTransformerTests(BaseTransformerTests):
             {series['name'] for series in result['series']}
         )
 
-        df2 = df
+        df2 = df.copy()
         df2.index = df2.index.astype(int) // int(1e6)
         self.evaluate_result(df2, result)
 
@@ -96,7 +96,7 @@ class HighChartsLineTransformerTests(BaseTransformerTests):
             {series['name'] for series in result['series']}
         )
 
-        df2 = df
+        df2 = df.copy()
         df2.index = df2.index.astype(int) // int(1e6)
         self.evaluate_result(df2, result)
 


### PR DESCRIPTION
Fixed:
- Dates are now formatted correctly as ISO strings
- Reference labels are now formatted correctly.