### PR TITLE
pandas.read_sql returns DF with binary string col names

### DIFF
--- a/fireant/slicer/queries.py
+++ b/fireant/slicer/queries.py
@@ -117,7 +117,8 @@ class QueryManager(object):
             print("Executing query:\n----START----\n{query}\n-----END-----".format(query=querystring))
 
         dataframe = settings.database.fetch_dataframe(querystring)
-        dataframe.columns = [col.decode('utf-8') for col in dataframe.columns]
+        dataframe.columns = [col.decode('utf-8') if isinstance(col, bytes) else col
+                             for col in dataframe.columns]
         dataframe = dataframe.set_index(
             # Removed the reference keys for now
             list(dimensions.keys())  # + ['{1}_{0}'.format(*ref) for ref in references.items()]

--- a/fireant/slicer/queries.py
+++ b/fireant/slicer/queries.py
@@ -116,7 +116,9 @@ class QueryManager(object):
         if getattr(settings, 'debug', False):
             print("Executing query:\n----START----\n{query}\n-----END-----".format(query=querystring))
 
-        dataframe = settings.database.fetch_dataframe(querystring).set_index(
+        dataframe = settings.database.fetch_dataframe(querystring)
+        dataframe.columns = [col.decode('utf-8') for col in dataframe.columns]
+        dataframe = dataframe.set_index(
             # Removed the reference keys for now
             list(dimensions.keys())  # + ['{1}_{0}'.format(*ref) for ref in references.items()]
         ).sort_index()

--- a/fireant/slicer/transformers/datatables.py
+++ b/fireant/slicer/transformers/datatables.py
@@ -11,10 +11,12 @@ class TableIndex(object):
 
 
 def format_data_point(value):
-    if value is np.nan:
-        value = None
+    if isinstance(value, str):
+        return value
     if isinstance(value, pd.Timestamp):
-        return value.isoformat()
+        return value.strftime('%Y-%m-%dT%H:%M:%S')
+    if np.isnan(value):
+        return None
     if isinstance(value, np.int64):
         # Cannot transform np.int64 to json
         return int(value)

--- a/fireant/tests/database/test_databases.py
+++ b/fireant/tests/database/test_databases.py
@@ -15,7 +15,19 @@ class DatabaseTests(TestCase):
 
         result = Database().fetch('SELECT 1')
 
-        self.assertEqual('OK', result)
+        self.assertEqual(mock_cursor.fetchall.return_value, result)
         mock_cursor_func.assert_called_once_with()
         mock_cursor.execute.assert_called_once_with('SELECT 1')
         mock_cursor.fetchall.assert_called_once_with()
+
+    @patch('pandas.read_sql', name='mock_read_sql')
+    @patch('fireant.database.Database.connect', name='mock_connect')
+    def test_fetch_dataframe(self, mock_connect, mock_read_sql):
+        query = 'SELECT 1'
+        mock_read_sql.return_value = 'OK'
+
+        result = Database().fetch_dataframe(query)
+
+        self.assertEqual(mock_read_sql.return_value, result)
+
+        mock_read_sql.assert_called_once_with(query, mock_connect().__enter__())

--- a/fireant/tests/slicer/transformers/test_datatables.py
+++ b/fireant/tests/slicer/transformers/test_datatables.py
@@ -419,7 +419,7 @@ class DataTablesColumnIndexTransformerTests(BaseTransformerTests):
                             break
 
 
-class HighChartsUtilityTests(TestCase):
+class DatatablesUtilityTests(TestCase):
     def test_nan_data_point(self):
         # Needs to be cast to python int
         result = datatables.format_data_point(np.nan)
@@ -436,5 +436,5 @@ class HighChartsUtilityTests(TestCase):
 
     def test_datetime_data_point(self):
         # Needs to be converted to milliseconds
-        result = datatables.format_data_point(pd.Timestamp(2000, 1, 1))
+        result = datatables.format_data_point(pd.Timestamp(2000, 1, 1, 0, 0, 0))
         self.assertEqual('1970-01-01T00:00:00', result)

--- a/fireant/tests/slicer/transformers/test_datatables.py
+++ b/fireant/tests/slicer/transformers/test_datatables.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from datetime import date
 from unittest import TestCase
 
 import numpy as np
@@ -436,5 +437,5 @@ class DatatablesUtilityTests(TestCase):
 
     def test_datetime_data_point(self):
         # Needs to be converted to milliseconds
-        result = datatables.format_data_point(pd.Timestamp(2000, 1, 1, 0, 0, 0))
-        self.assertEqual('1970-01-01T00:00:00', result)
+        result = datatables.format_data_point(pd.Timestamp(date(2000, 1, 1)))
+        self.assertEqual('2000-01-01T00:00:00', result)

--- a/fireant/tests/slicer/transformers/test_datatables.py
+++ b/fireant/tests/slicer/transformers/test_datatables.py
@@ -1,8 +1,11 @@
 # coding: utf-8
+from unittest import TestCase
 
 import numpy as np
+import pandas as pd
 
 from fireant.slicer.transformers import TableIndex, DataTablesTransformer
+from fireant.slicer.transformers import datatables
 from fireant.tests.slicer.transformers.base import BaseTransformerTests
 
 
@@ -414,3 +417,24 @@ class DataTablesColumnIndexTransformerTests(BaseTransformerTests):
                         # skip the rest of the level if the previous level is rolled up
                         if label1 is None:
                             break
+
+
+class HighChartsUtilityTests(TestCase):
+    def test_nan_data_point(self):
+        # Needs to be cast to python int
+        result = datatables.format_data_point(np.nan)
+        self.assertIsNone(result)
+
+    def test_str_data_point(self):
+        result = datatables.format_data_point('abc')
+        self.assertEqual('abc', result)
+
+    def test_int64_data_point(self):
+        # Needs to be cast to python int
+        result = datatables.format_data_point(np.int64(1))
+        self.assertEqual(int(1), result)
+
+    def test_datetime_data_point(self):
+        # Needs to be converted to milliseconds
+        result = datatables.format_data_point(pd.Timestamp(2000, 1, 1))
+        self.assertEqual('1970-01-01T00:00:00', result)

--- a/fireant/tests/slicer/transformers/test_highcharts.py
+++ b/fireant/tests/slicer/transformers/test_highcharts.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-from datetime import date
 from unittest import TestCase
 
 import numpy as np
@@ -360,7 +359,7 @@ class HighChartsBarTransformerTests(HighChartsColumnTransformerTests):
     type = HighchartsColumnTransformer.bar
 
 
-class HighChartsUtilityTests(TestCase):
+class HighchartsUtilityTests(TestCase):
     def test_str_data_point(self):
         result = highcharts.format_data_point('abc')
         self.assertEqual('abc', result)
@@ -372,5 +371,5 @@ class HighChartsUtilityTests(TestCase):
 
     def test_datetime_data_point(self):
         # Needs to be converted to milliseconds
-        result = highcharts.format_data_point(pd.Timestamp(date(2000, 1, 1)))
+        result = highcharts.format_data_point(pd.Timestamp(2000, 1, 1, 0, 0, 0))
         self.assertEqual(946684800000, result)

--- a/fireant/tests/slicer/transformers/test_highcharts.py
+++ b/fireant/tests/slicer/transformers/test_highcharts.py
@@ -1,7 +1,12 @@
 # coding: utf-8
+from datetime import date
+from unittest import TestCase
 
+import numpy as np
+import pandas as pd
 
 from fireant.slicer.transformers import HighchartsTransformer, TransformationException, HighchartsColumnTransformer
+from fireant.slicer.transformers import highcharts
 from fireant.tests.slicer.transformers.base import BaseTransformerTests
 
 
@@ -353,3 +358,19 @@ class HighChartsColumnTransformerTests(BaseTransformerTests):
 
 class HighChartsBarTransformerTests(HighChartsColumnTransformerTests):
     type = HighchartsColumnTransformer.bar
+
+
+class HighChartsUtilityTests(TestCase):
+    def test_str_data_point(self):
+        result = highcharts.format_data_point('abc')
+        self.assertEqual('abc', result)
+
+    def test_int64_data_point(self):
+        # Needs to be cast to python int
+        result = highcharts.format_data_point(np.int64(1))
+        self.assertEqual(int(1), result)
+
+    def test_datetime_data_point(self):
+        # Needs to be converted to milliseconds
+        result = highcharts.format_data_point(pd.Timestamp(date(2000, 1, 1)))
+        self.assertEqual(946684800000, result)

--- a/fireant/tests/slicer/transformers/test_highcharts.py
+++ b/fireant/tests/slicer/transformers/test_highcharts.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from datetime import date
 from unittest import TestCase
 
 import numpy as np
@@ -371,5 +372,5 @@ class HighchartsUtilityTests(TestCase):
 
     def test_datetime_data_point(self):
         # Needs to be converted to milliseconds
-        result = highcharts.format_data_point(pd.Timestamp(2000, 1, 1, 0, 0, 0))
+        result = highcharts.format_data_point(pd.Timestamp(date(2000, 1, 1)))
         self.assertEqual(946684800000, result)


### PR DESCRIPTION
- Converted the column names to unicode
- Added test coverage for highcharts and datatables data point formatter functions
- Added test coverage for database.fetch_dataframe
- Fixed checks for np.nan to use np.isnan instead of value is np.nan