### PR TITLE
Fixes for Rollup operation in highcharts

### DIFF
--- a/docs/2_slicer.rst
+++ b/docs/2_slicer.rst
@@ -318,7 +318,7 @@ For each |FeatureReference|, there are the following variations:
 
 .. code-block:: python
 
-    from fireant.slicer import WoW, DeltaMoM, DeltaQoQ
+    from fireant.slicer.references import WoW, DeltaMoM, DeltaQoQ
 
     slicer.notebook.column_index_table(
         metrics=['clicks', 'conversions'],
@@ -329,3 +329,29 @@ For each |FeatureReference|, there are the following variations:
 .. note::
 
     For any reference, the comparison is made for the same days of the week.
+
+
+Post-Processing Operations
+--------------------------
+
+Operations include extra computations that modify the final results.
+
+Totals
+""""""
+
+Totals adds ``ROLLUP`` to the SQL query to load the data and aggregated across dimensions.  It requires one or more dimension keys as parameters for the dimensions that should be totaled.  The below example will add an extra line with the total clicks and conversions for each date in addition to the three lines for each device type, desktop, mobile and tablet.
+
+.. code-block:: python
+
+    from fireant.slicer.operations import Totals
+
+    slicer.notebook.line_chart(
+        metrics=['clicks', 'conversions'],
+        dimensions=['date', 'device'],
+        operations=[Totals('device')],
+    )
+
+L1 and L2 Loss
+""""""""""""""
+
+Coming soon

--- a/fireant/slicer/__init__.py
+++ b/fireant/slicer/__init__.py
@@ -1,7 +1,5 @@
 # coding: utf-8
 from .filters import EqualityFilter, ContainsFilter, RangeFilter, WildcardFilter
 from .managers import SlicerException
-from .operations import Rollup
-from .references import WoW, MoM, QoQ, YoY, Delta, DeltaPercentage
 from .schemas import (Slicer, Metric, Dimension, CategoricalDimension, ContinuousDimension, NumericInterval,
                       UniqueDimension, DatetimeDimension, DatetimeInterval, DimensionValue, EqualityOperator, Join)

--- a/fireant/slicer/operations.py
+++ b/fireant/slicer/operations.py
@@ -13,9 +13,9 @@ class Operation(object):
         raise NotImplementedError
 
 
-class Rollup(Operation):
-    def __init__(self, dimension_keys):
-        super(Rollup, self).__init__('rollup')
+class Totals(Operation):
+    def __init__(self, *dimension_keys):
+        super(Totals, self).__init__('rollup')
         self.dimension_keys = dimension_keys
 
     def schemas(self, slicer):

--- a/fireant/slicer/transformers/datatables.py
+++ b/fireant/slicer/transformers/datatables.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 import numpy as np
 import pandas as pd
-from future.types import newstr
+from future.types.newstr import newstr
 
 from .base import Transformer
 

--- a/fireant/slicer/transformers/datatables.py
+++ b/fireant/slicer/transformers/datatables.py
@@ -1,16 +1,17 @@
 # coding: utf-8
 import numpy as np
 import pandas as pd
+from future.types import newstr
 
 from .base import Transformer
 
 
 def _format_data_point(value):
-    if isinstance(value, str):
-        return value
+    if isinstance(value, (str, newstr)):
+        return str(value)
     if isinstance(value, pd.Timestamp):
         return value.strftime('%Y-%m-%dT%H:%M:%S')
-    if np.isnan(value):
+    if value is None or np.isnan(value):
         return None
     if isinstance(value, np.int64):
         # Cannot transform np.int64 to json
@@ -73,24 +74,28 @@ class DataTablesRowIndexTransformer(Transformer):
         for dimension in row_dimensions:
             key = dimension['label']
 
-            if not isinstance(idx, tuple):
-                value = _format_data_point(idx)
-
-            elif 1 < len(dimension['id_fields']) or 'label_field' in dimension:
+            if 'label_field' in dimension:
                 fields = dimension['id_fields'] + [dimension.get('label_field')]
 
                 value = {id_field: idx[dim_ordinal[id_field]]
-                         for id_field in filter(None, fields)}
+                         for id_field in fields
+                         if id_field is not None}
 
-            else:
+                yield key, value
+                continue
+
+            if isinstance(idx, tuple):
                 id_field = dimension['id_fields'][0]
                 value = _format_data_point(idx[dim_ordinal[id_field]])
 
-                if value is None:
-                    value = 'Total'
+            else:
+                value = _format_data_point(idx)
 
-                if 'label_options' in dimension:
-                    value = dimension['label_options'].get(value, value)
+            if 'label_options' in dimension:
+                value = dimension['label_options'].get(value, value)
+
+            if value is None:
+                value = 'Total'
 
             yield key, value
 

--- a/fireant/tests/slicer/test_slicer_api.py
+++ b/fireant/tests/slicer/test_slicer_api.py
@@ -4,6 +4,8 @@ from unittest import TestCase
 
 from fireant import settings
 from fireant.slicer import *
+from fireant.slicer.operations import Totals
+from fireant.slicer.references import *
 from fireant.tests.database.mock_database import TestDatabase
 from pypika import functions as fn, Tables, Case
 
@@ -702,7 +704,7 @@ class SlicerSchemaReferenceTests(SlicerSchemaTests):
         query_schema = self.test_slicer.manager.query_schema(
             metrics=['foo'],
             dimensions=['date', 'locale', 'account'],
-            operations=[Rollup(['locale', 'account'])],
+            operations=[Totals('locale', 'account')],
         )
 
         self.assertTrue({'table', 'metrics', 'dimensions', 'rollup'}.issubset(query_schema.keys()))


### PR DESCRIPTION
Fixed for Highcharts

Line Charts
- Fixed the yAxis for metrics

Bar Charts
- Fixed the yAxis (should always be 0)
- Fixed the labels to correctly replace None and NaN values with 'Totals'