### PR TITLE
Renamed label_field and label_options

### DIFF
--- a/docs/2_slicer.rst
+++ b/docs/2_slicer.rst
@@ -43,12 +43,12 @@ Date/Time Dimensions are a special type of continuous dimension which contain so
 Unique Dimensions
 """""""""""""""""
 
-Lastly, a unique dimension represents a column that has one or more identifier columns and optionally a display label column.  This is useful when your data contains a significant number of values that cannot be represented by a small list of categories and is akin to using a foreign key in a SQL table.  In conjunction with a join on a foreign key, a display value can be selected from a second table and used when rendering your widgets.
+Lastly, a unique dimension represents a column that has one or more identifier columns and optionally a display field column.  This is useful when your data contains a significant number of values that cannot be represented by a small list of categories and is akin to using a foreign key in a SQL table.  In conjunction with a join on a foreign key, a display value can be selected from a second table and used when rendering your widgets.
 
 
 .. warning::
 
-    If the column your |FeatureDimension| uses contains ``null`` values, it is advised to define the dimension using the ``COALESE`` function in order to specify some label for that value.  |Brand| makes use of advanced queries that could lead to collisions with null values.
+    If the column your |FeatureDimension| uses contains ``null`` values, it is advised to define the dimension using the ``COALESE`` function in order to specify some default value.  |Brand| makes use of rollup queries that could result in collisions with null values.
 
 
 .. _config_slicer_start:
@@ -63,9 +63,9 @@ Here is a concrete example of a |FeatureSlicer| configuration. It includes a par
     :end-before:  _slicer_example_end:
 
 
-In our example, the first couple of metrics pass ``key`` and ``label`` parameters.  The key is a unique identifier for the |FeatureSlicer| and cannot be shared by other |FeatureSlicer| elements.  The label is used when transforming the data into widgets to represent the field.  The last three metrics also provide a ``definition`` parameter which is a PyPika_ expression used to select the data from the database.  When a ``definition`` parameter is not supplied, the key of the metric is wrapped in a ``Sum`` function as a default.  The metric for ``impressions`` will get the definition ``fn.Sum(analytics.impressions)``.
+In our example, the first couple of metrics pass ``key`` and ``label`` parameters.  The key is a unique identifier for the |FeatureSlicer| and cannot be shared by other |FeatureSlicer| elements.  The label is used as a name for metric in the component.  The last three metrics also provide a ``definition`` parameter which is a PyPika_ expression used to select the data from the database.  When a ``definition`` parameter is not supplied, the key of the metric is wrapped in a ``Sum`` function as a default.  The metric for ``impressions`` will get the definition ``fn.Sum(analytics.impressions)``.
 
-Here a few dimensions as also defined.  A |ClassDateDimension| is used with a custom definition which maps to the ``dt`` column in the database.  The Device dimension uses the column with the same name as the key ``device`` as a default. There are three possible values for a device: 'desktop', 'tablet', or 'mobile', so a  |ClassCatDimension| is a good fit. Last there is a  |ClassUniqueDimension| which uses the column ``account_id`` as an identifier but the column ``account_name`` as a display label.  Both columns will be included in the query.
+Here a few dimensions as also defined.  A |ClassDateDimension| is used with a custom definition which maps to the ``dt`` column in the database.  The Device dimension uses the column with the same name as the key ``device`` as a default. There are three possible values for a device: 'desktop', 'tablet', or 'mobile', so a  |ClassCatDimension| is a good fit. Last there is a  |ClassUniqueDimension| which uses the column ``account_id`` as an identifier but the column ``account_name`` as a display field for each account value.  Both columns will be included in the query.
 
 .. _config_slicer_end:
 
@@ -97,7 +97,7 @@ A join requires three parameters, a *key*, a *table*, and a *criterion*.  The *k
 
         dimension=[
             UniqueDimension('customer', id_fields=[customers.id],
-                            label_field=fn.Concat(customers.fname, ' ', customers.lname),
+                            display_field=fn.Concat(customers.fname, ' ', customers.lname),
                             joins=['customers'])
         ],
     )

--- a/fireant/slicer/managers.py
+++ b/fireant/slicer/managers.py
@@ -196,8 +196,8 @@ class SlicerManager(QueryManager):
                         key=f.element_key
                     ))
 
-            if 'label' == modifier:
-                definition = element.label_field
+            if hasattr(element, 'display_field') and 'display' == modifier:
+                definition = element.display_field
 
             else:
                 definition = element.definition or default_value_func(element.key)
@@ -217,12 +217,12 @@ class SlicerManager(QueryManager):
             dimension = self.slicer.dimensions[key]
             display_dim = {'label': dimension.label}
 
-            if hasattr(dimension, 'options'):
-                display_dim['label_options'] = {opt.key: opt.label
-                                                for opt in dimension.options}
+            if hasattr(dimension, 'display_options'):
+                display_dim['display_options'] = {opt.key: opt.label
+                                                  for opt in dimension.display_options}
 
-            if hasattr(dimension, 'label_field'):
-                display_dim['label_field'] = '%s_label' % dimension.key
+            if hasattr(dimension, 'display_field'):
+                display_dim['display_field'] = '%s_display' % dimension.key
 
             display_dims[key] = display_dim
 

--- a/fireant/slicer/schemas.py
+++ b/fireant/slicer/schemas.py
@@ -116,20 +116,19 @@ class DatetimeDimension(ContinuousDimension):
 
 
 class CategoricalDimension(Dimension):
-    def __init__(self, key, label=None, definition=None, options=tuple(), joins=None):
+    def __init__(self, key, label=None, definition=None, display_options=tuple(), joins=None):
         super(CategoricalDimension, self).__init__(key=key, label=label, definition=definition, joins=joins)
-        self.options = options
+        self.display_options = display_options
 
 
 class UniqueDimension(Dimension):
-    def __init__(self, key, label=None, definition=None, label_field=None, joins=None):
+    def __init__(self, key, label=None, definition=None, display_field=None, joins=None):
         super(UniqueDimension, self).__init__(key=key, label=label, definition=definition, joins=joins)
-        # TODO label_field and definition here are redundant
-        self.label_field = label_field
+        self.display_field = display_field
 
     def schemas(self, *args):
         id_field_schemas = [('{key}'.format(key=self.key), self.definition)]
-        return id_field_schemas + [('{key}_label'.format(key=self.key), self.label_field)]
+        return id_field_schemas + [('{key}_display'.format(key=self.key), self.display_field)]
 
 
 class BooleanDimension(Dimension):

--- a/fireant/slicer/transformers/highcharts.py
+++ b/fireant/slicer/transformers/highcharts.py
@@ -23,71 +23,71 @@ class HighchartsLineTransformer(Transformer):
 
     chart_type = 'line'
 
-    def transform(self, data_frame, display_schema):
-        self._validate_dimensions(data_frame, display_schema['dimensions'])
+    def transform(self, dataframe, display_schema):
+        self._validate_dimensions(dataframe, display_schema['dimensions'])
 
-        if isinstance(data_frame.index, pd.MultiIndex):
-            data_frame = self._reorder_index_levels(data_frame, display_schema)
-        has_references = isinstance(data_frame.columns, pd.MultiIndex)
+        if isinstance(dataframe.index, pd.MultiIndex):
+            dataframe = self._reorder_index_levels(dataframe, display_schema)
+        has_references = isinstance(dataframe.columns, pd.MultiIndex)
 
         dim_ordinal = {name: ordinal
-                       for ordinal, name in enumerate(data_frame.index.names)}
-        data_frame = self._prepare_data_frame(data_frame, dim_ordinal, display_schema['dimensions'])
+                       for ordinal, name in enumerate(dataframe.index.names)}
+        dataframe = self._prepare_dataframe(dataframe, dim_ordinal, display_schema['dimensions'])
 
         if has_references:
             series = sum(
-                [self._make_series(data_frame[level], dim_ordinal, display_schema, reference=level or None)
-                 for level in data_frame.columns.levels[0]],
+                [self._make_series(dataframe[level], dim_ordinal, display_schema, reference=level or None)
+                 for level in dataframe.columns.levels[0]],
                 []
             )
 
         else:
-            series = self._make_series(data_frame, dim_ordinal, display_schema)
+            series = self._make_series(dataframe, dim_ordinal, display_schema)
 
         result = {
             'chart': {'type': self.chart_type},
             'title': {'text': None},
-            'xAxis': self.xaxis_options(data_frame, dim_ordinal, display_schema),
-            'yAxis': self.yaxis_options(data_frame, dim_ordinal, display_schema),
+            'xAxis': self.xaxis_options(dataframe, dim_ordinal, display_schema),
+            'yAxis': self.yaxis_options(dataframe, dim_ordinal, display_schema),
             'tooltip': {'shared': True},
             'series': series
         }
 
         return result
 
-    def xaxis_options(self, data_frame, dim_ordinal, display_schema):
+    def xaxis_options(self, dataframe, dim_ordinal, display_schema):
         return {
-            'type': 'datetime' if isinstance(data_frame.index, pd.DatetimeIndex) else 'linear'
+            'type': 'datetime' if isinstance(dataframe.index, pd.DatetimeIndex) else 'linear'
         }
 
-    def yaxis_options(self, data_frame, dim_ordinal, display_schema):
-        if isinstance(data_frame.columns, pd.MultiIndex):
-            num_metrics = len(data_frame.columns.levels[0])
+    def yaxis_options(self, dataframe, dim_ordinal, display_schema):
+        if isinstance(dataframe.columns, pd.MultiIndex):
+            num_metrics = len(dataframe.columns.levels[0])
         else:
-            num_metrics = len(data_frame.columns)
+            num_metrics = len(dataframe.columns)
 
         return [{
             'title': None
         }] * num_metrics
 
-    def _reorder_index_levels(self, data_frame, display_schema):
+    def _reorder_index_levels(self, dataframe, display_schema):
         dimension_orders = [order
                             for key, dimension in display_schema['dimensions'].items()
-                            for order in [key] + ([dimension['label_field']]
-                                                  if 'label_field' in dimension
+                            for order in [key] + ([dimension['display_field']]
+                                                  if 'display_field' in dimension
                                                   else [])]
 
-        reordered = data_frame.reorder_levels(data_frame.index.names.index(level)
-                                              for level in dimension_orders)
+        reordered = dataframe.reorder_levels(dataframe.index.names.index(level)
+                                             for level in dimension_orders)
         return reordered
 
-    def _make_series(self, data_frame, dim_ordinal, display_schema, reference=None):
-        metrics = list(data_frame.columns.levels[0]
-                       if isinstance(data_frame.columns, pd.MultiIndex)
-                       else data_frame.columns)
+    def _make_series(self, dataframe, dim_ordinal, display_schema, reference=None):
+        metrics = list(dataframe.columns.levels[0]
+                       if isinstance(dataframe.columns, pd.MultiIndex)
+                       else dataframe.columns)
 
         return [self._make_series_item(idx, item, dim_ordinal, display_schema, metrics, reference)
-                for idx, item in data_frame.iteritems()]
+                for idx, item in dataframe.iteritems()]
 
     def _make_series_item(self, idx, item, dim_ordinal, display_schema, metrics, reference):
         return {
@@ -97,29 +97,29 @@ class HighchartsLineTransformer(Transformer):
             'dashStyle': 'Dot' if reference else 'Solid'
         }
 
-    def _validate_dimensions(self, data_frame, dimensions):
+    def _validate_dimensions(self, dataframe, dimensions):
         if not 0 < len(dimensions):
             raise TransformationException('Cannot transform %s chart.  '
                                           'At least one dimension is required.' % self.chart_type)
 
     @staticmethod
-    def _make_categories(data_frame, dim_ordinal, display_schema):
+    def _make_categories(dataframe, dim_ordinal, display_schema):
         return None
 
-    def _prepare_data_frame(self, data_frame, dim_ordinal, dimensions):
+    def _prepare_dataframe(self, dataframe, dim_ordinal, dimensions):
         # Replaces invalid values and unstacks the data frame for line charts.
 
         # Force all fields to be float (Safer for highcharts)
-        data_frame = data_frame.astype(np.float).replace([np.inf, -np.inf], np.nan)
+        dataframe = dataframe.astype(np.float).replace([np.inf, -np.inf], np.nan)
 
         # Unstack multi-indices
         if 1 < len(dimensions):
             # We need to unstack all of the dimensions here after the first dimension, which is the first dimension in
             # the dimensions list, not necessarily the one in the dataframe
             unstack_levels = list(self._unstack_levels(list(dimensions.items())[1:], dim_ordinal))
-            data_frame = data_frame.unstack(level=unstack_levels)
+            dataframe = dataframe.unstack(level=unstack_levels)
 
-        return data_frame
+        return dataframe
 
     def _format_label(self, idx, dim_ordinal, display_schema, reference):
         is_multidimensional = isinstance(idx, tuple)
@@ -136,28 +136,31 @@ class HighchartsLineTransformer(Transformer):
         if not is_multidimensional:
             return metric_label
 
-        dim_labels = [self._format_dimension_label(dim_ordinal, key, dimension, idx)
-                      for key, dimension in list(display_schema['dimensions'].items())[1:]]
-        dim_labels = [dim_label  # filter out the NaNs
-                      for dim_label in dim_labels
-                      if dim_label is not np.nan]
+        dimension_labels = [self._format_dimension_display(dim_ordinal, key, dimension, idx)
+                            for key, dimension in list(display_schema['dimensions'].items())[1:]]
+        dimension_labels = [dimension_label  # filter out the NaNs
+                            for dimension_label in dimension_labels
+                            if dimension_label is not np.nan]
 
         return (
-            '{metric} ({dimensions})'.format(metric=metric_label, dimensions=', '.join(map(str, dim_labels)))
-            if dim_labels else
-            metric_label
+            '{metric} ({dimensions})'.format(
+                metric=metric_label,
+                dimensions=', '.join(map(str, dimension_labels))
+            )
+            if dimension_labels
+            else metric_label
         )
 
     @staticmethod
-    def _format_dimension_label(dim_ordinal, key, dimension, idx):
-        if 'label_field' in dimension:
-            label_field = dimension['label_field']
-            return idx[dim_ordinal[label_field]]
+    def _format_dimension_display(dim_ordinal, key, dimension, idx):
+        if 'display_field' in dimension:
+            display_field = dimension['display_field']
+            return idx[dim_ordinal[display_field]]
 
-        dim_label = idx[dim_ordinal[key]]
-        if 'label_options' in dimension:
-            dim_label = dimension['label_options'].get(dim_label, dim_label)
-        return dim_label
+        dimension_value = idx[dim_ordinal[key]]
+        if 'display_options' in dimension:
+            dimension_value = dimension['display_options'].get(dimension_value, dimension_value)
+        return dimension_value
 
     def _format_data(self, column):
         if isinstance(column, float):
@@ -175,8 +178,8 @@ class HighchartsLineTransformer(Transformer):
         for key, dimension in dimensions:
             yield dim_ordinal[key]
 
-            if 'label_field' in dimension:
-                yield dim_ordinal[dimension['label_field']]
+            if 'display_field' in dimension:
+                yield dim_ordinal[dimension['display_field']]
 
 
 class HighchartsColumnTransformer(HighchartsLineTransformer):
@@ -191,50 +194,50 @@ class HighchartsColumnTransformer(HighchartsLineTransformer):
             'yAxis': metrics.index(idx[0] if isinstance(idx, tuple) else idx),
         }
 
-    def xaxis_options(self, data_frame, dim_ordinal, display_schema):
+    def xaxis_options(self, dataframe, dim_ordinal, display_schema):
         result = {'type': 'categorical'}
 
-        categories = self._make_categories(data_frame, dim_ordinal, display_schema)
+        categories = self._make_categories(dataframe, dim_ordinal, display_schema)
         if categories is not None:
             result['categories'] = categories
 
         return result
 
-    def _validate_dimensions(self, data_frame, dimensions):
-        if 1 < len(dimensions) and 1 < len(data_frame.columns):
+    def _validate_dimensions(self, dataframe, dimensions):
+        if 1 < len(dimensions) and 1 < len(dataframe.columns):
             raise TransformationException('Cannot transform %s chart.  '
                                           'No more than 1 dimension or 2 dimensions '
                                           'with 1 metric are allowed.' % self.chart_type)
 
-    def _prepare_data_frame(self, data_frame, dim_ordinal, dimensions):
+    def _prepare_dataframe(self, dataframe, dim_ordinal, dimensions):
         # Replaces invalid values and unstacks the data frame for line charts.
 
         # Force all fields to be float (Safer for highcharts)
-        data_frame = data_frame.replace([np.inf, -np.inf], np.nan)
+        dataframe = dataframe.replace([np.inf, -np.inf], np.nan)
 
         # Unstack multi-indices
         if 1 < len(dimensions):
             unstack_levels = list(self._unstack_levels(list(dimensions.items())[1:], dim_ordinal))
-            data_frame = data_frame.unstack(level=unstack_levels)
+            dataframe = dataframe.unstack(level=unstack_levels)
 
-        return data_frame
+        return dataframe
 
     @staticmethod
-    def _make_categories(data_frame, dim_ordinal, display_schema):
+    def _make_categories(dataframe, dim_ordinal, display_schema):
         if not display_schema['dimensions']:
             return None
 
         category_dimension = list(display_schema['dimensions'].values())[0]
-        if 'label_options' in category_dimension:
-            return [category_dimension['label_options'].get(dim, dim)
+        if 'display_options' in category_dimension:
+            return [category_dimension['display_options'].get(dim, dim)
                     # Pandas gives both NaN or None in the index depending on whether a level was unstacked
                     if dim and not (isinstance(dim, float) and np.isnan(dim))
                     else 'Totals'
-                    for dim in data_frame.index]
+                    for dim in dataframe.index]
 
-        if 'label_field' in category_dimension:
-            label_field = category_dimension['label_field']
-            return data_frame.index.get_level_values(label_field, ).unique().tolist()
+        if 'display_field' in category_dimension:
+            display_field = category_dimension['display_field']
+            return dataframe.index.get_level_values(display_field).unique().tolist()
 
 
 class HighchartsBarTransformer(HighchartsColumnTransformer):

--- a/fireant/slicer/transformers/notebook.py
+++ b/fireant/slicer/transformers/notebook.py
@@ -36,16 +36,16 @@ class PlotlyTransformer(Transformer):
             for id_field in dimension['id_fields']:
                 yield dim_ordinal[id_field]
 
-            if 'label_field' in dimension:
-                yield dim_ordinal[dimension['label_field']]
+            if 'display_field' in dimension:
+                yield dim_ordinal[dimension['display_field']]
 
     def _reorder_index_levels(self, data_frame, display_schema):
         dimension_orders = [id_field
                             for d in display_schema['dimensions']
                             for id_field in
                             (d['id_fields'] + (
-                                [d['label_field']]
-                                if 'label_field' in d
+                                [d['display_field']]
+                                if 'display_field' in d
                                 else []))]
         reordered = data_frame.reorder_levels(data_frame.index.names.index(level)
                                               for level in dimension_orders)

--- a/fireant/tests/dashboards/test_dashboard_api.py
+++ b/fireant/tests/dashboards/test_dashboard_api.py
@@ -37,12 +37,12 @@ class DashboardTests(TestCase):
 
                 # Categorical dimension with fixed options
                 CategoricalDimension('locale', 'Locale', definition=test_table.locale,
-                                     options=[DimensionValue('us', 'United States'),
-                                              DimensionValue('de', 'Germany')]),
+                                     display_options=[DimensionValue('us', 'United States'),
+                                                      DimensionValue('de', 'Germany')]),
 
                 # Unique Dimension with single ID field
                 UniqueDimension('account', 'Account', definition=test_table.account_id,
-                                label_field=test_table.account_name),
+                                display_field=test_table.account_name),
             ]
         )
 

--- a/fireant/tests/slicer/test_slicer_api.py
+++ b/fireant/tests/slicer/test_slicer_api.py
@@ -55,20 +55,20 @@ class SlicerSchemaTests(TestCase):
                 DatetimeDimension('date', definition=cls.test_table.dt),
 
                 # Continuous integer dimension
-                ContinuousDimension('clicks', label='Clicks CUSTOM LABEL', definition=cls.test_table.clicks),
+                ContinuousDimension('clicks', label='My Clicks', definition=cls.test_table.clicks),
 
-                # Categorical dimension with fixed option
+                # Categorical dimension with display options
                 CategoricalDimension('locale', 'Locale', definition=cls.test_table.locale,
-                                     options=[DimensionValue('us', 'United States'),
-                                              DimensionValue('de', 'Germany')]),
+                                     display_options=[DimensionValue('us', 'United States'),
+                                                      DimensionValue('de', 'Germany')]),
 
                 # Unique Dimension with single ID field
                 UniqueDimension('account', 'Account', definition=cls.test_table.account_id,
-                                label_field=cls.test_table.account_name),
+                                display_field=cls.test_table.account_name),
 
                 # Unique Dimension with composite ID field
                 UniqueDimension('keyword', 'Keyword', definition=cls.test_table.keyword_id,
-                                label_field=cls.test_table.keyword_name),
+                                display_field=cls.test_table.keyword_name),
 
                 # Dimension with joined columns
                 CategoricalDimension('blah', 'Blah', definition=cls.test_join_table.blah,
@@ -191,9 +191,9 @@ class SlicerSchemaDimensionTests(SlicerSchemaTests):
         self.assertSetEqual({'foo'}, set(query_schema['metrics'].keys()))
         self.assertEqual('SUM("test"."foo")', str(query_schema['metrics']['foo']))
 
-        self.assertSetEqual({'account', 'account_label'}, set(query_schema['dimensions'].keys()))
+        self.assertSetEqual({'account', 'account_display'}, set(query_schema['dimensions'].keys()))
         self.assertEqual('"test"."account_id"', str(query_schema['dimensions']['account']))
-        self.assertEqual('"test"."account_name"', str(query_schema['dimensions']['account_label']))
+        self.assertEqual('"test"."account_name"', str(query_schema['dimensions']['account_display']))
 
     def test_multiple_metrics_and_dimensions(self):
         query_schema = self.test_slicer.manager.query_schema(
@@ -208,12 +208,12 @@ class SlicerSchemaDimensionTests(SlicerSchemaTests):
         self.assertEqual('SUM("test"."foo")', str(query_schema['metrics']['foo']))
         self.assertEqual('SUM("test"."fiz"+"test"."buz")', str(query_schema['metrics']['bar']))
 
-        self.assertSetEqual({'date', 'clicks', 'locale', 'account', 'account_label'},
+        self.assertSetEqual({'date', 'clicks', 'locale', 'account', 'account_display'},
                             set(query_schema['dimensions'].keys()))
         self.assertEqual('MOD("test"."clicks"+100,50)', str(query_schema['dimensions']['clicks']))
         self.assertEqual('"test"."locale"', str(query_schema['dimensions']['locale']))
         self.assertEqual('"test"."account_id"', str(query_schema['dimensions']['account']))
-        self.assertEqual('"test"."account_name"', str(query_schema['dimensions']['account_label']))
+        self.assertEqual('"test"."account_name"', str(query_schema['dimensions']['account_display']))
 
 
 class SlicerSchemaFilterTests(SlicerSchemaTests):
@@ -406,9 +406,9 @@ class SlicerSchemaFilterTests(SlicerSchemaTests):
         self.assertSetEqual({'foo'}, set(query_schema['metrics'].keys()))
         self.assertEqual('SUM("test"."foo")', str(query_schema['metrics']['foo']))
 
-        self.assertSetEqual({'account', 'account_label'}, set(query_schema['dimensions'].keys()))
+        self.assertSetEqual({'account', 'account_display'}, set(query_schema['dimensions'].keys()))
         self.assertEqual('"test"."account_id"', str(query_schema['dimensions']['account']))
-        self.assertEqual('"test"."account_name"', str(query_schema['dimensions']['account_label']))
+        self.assertEqual('"test"."account_name"', str(query_schema['dimensions']['account_display']))
 
         self.assertListEqual(['"test"."account_id"=1'], [str(f) for f in query_schema['dfilters']])
 
@@ -425,9 +425,9 @@ class SlicerSchemaFilterTests(SlicerSchemaTests):
         self.assertSetEqual({'foo'}, set(query_schema['metrics'].keys()))
         self.assertEqual('SUM("test"."foo")', str(query_schema['metrics']['foo']))
 
-        self.assertSetEqual({'account', 'account_label'}, set(query_schema['dimensions'].keys()))
+        self.assertSetEqual({'account', 'account_display'}, set(query_schema['dimensions'].keys()))
         self.assertEqual('"test"."account_id"', str(query_schema['dimensions']['account']))
-        self.assertEqual('"test"."account_name"', str(query_schema['dimensions']['account_label']))
+        self.assertEqual('"test"."account_name"', str(query_schema['dimensions']['account_display']))
 
         self.assertListEqual(['"test"."account_id" IN (1,2,3)'], [str(f) for f in query_schema['dfilters']])
 
@@ -435,7 +435,7 @@ class SlicerSchemaFilterTests(SlicerSchemaTests):
         query_schema = self.test_slicer.manager.query_schema(
             metrics=['foo'],
             dimensions=['account'],
-            dimension_filters=[WildcardFilter('account.label', 'nam%')],
+            dimension_filters=[WildcardFilter('account.display', 'nam%')],
         )
 
         self.assertSetEqual(QUERY_BUILDER_PARAMS, set(query_schema.keys()))
@@ -444,9 +444,9 @@ class SlicerSchemaFilterTests(SlicerSchemaTests):
         self.assertSetEqual({'foo'}, set(query_schema['metrics'].keys()))
         self.assertEqual('SUM("test"."foo")', str(query_schema['metrics']['foo']))
 
-        self.assertSetEqual({'account', 'account_label'}, set(query_schema['dimensions'].keys()))
+        self.assertSetEqual({'account', 'account_display'}, set(query_schema['dimensions'].keys()))
         self.assertEqual('"test"."account_id"', str(query_schema['dimensions']['account']))
-        self.assertEqual('"test"."account_name"', str(query_schema['dimensions']['account_label']))
+        self.assertEqual('"test"."account_name"', str(query_schema['dimensions']['account_display']))
 
         self.assertListEqual(['"test"."account_name" LIKE \'nam%\''], [str(f) for f in query_schema['dfilters']])
 
@@ -691,10 +691,10 @@ class SlicerSchemaReferenceTests(SlicerSchemaTests):
         self.assertSetEqual({'foo'}, set(query_schema['metrics'].keys()))
         self.assertEqual('SUM("test"."foo")', str(query_schema['metrics']['foo']))
 
-        self.assertSetEqual({'date', 'locale', 'account', 'account_label'}, set(query_schema['dimensions'].keys()))
+        self.assertSetEqual({'date', 'locale', 'account', 'account_display'}, set(query_schema['dimensions'].keys()))
         self.assertEqual('ROUND("test"."dt",\'DD\')', str(query_schema['dimensions']['date']))
 
-        self.assertListEqual(['locale', 'account', 'account_label'], query_schema['rollup'])
+        self.assertListEqual(['locale', 'account', 'account_display'], query_schema['rollup'])
 
 
 class SlicerDisplaySchemaTests(SlicerSchemaTests):
@@ -753,7 +753,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
             {
                 'metrics': {'foo': 'Foo'},
                 'dimensions': {
-                    'clicks': {'label': 'Clicks CUSTOM LABEL'}
+                    'clicks': {'label': 'My Clicks'}
                 },
                 'references': {},
             },
@@ -769,7 +769,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
             {
                 'metrics': {'foo': 'Foo'},
                 'dimensions': {
-                    'locale': {'label': 'Locale', 'label_options': {'us': 'United States', 'de': 'Germany'}},
+                    'locale': {'label': 'Locale', 'display_options': {'us': 'United States', 'de': 'Germany'}},
                 },
                 'references': {},
             },
@@ -785,7 +785,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
             {
                 'metrics': {'foo': 'Foo'},
                 'dimensions': {
-                    'account': {'label': 'Account', 'label_field': 'account_label'},
+                    'account': {'label': 'Account', 'display_field': 'account_display'},
                 },
                 'references': {},
             },
@@ -803,9 +803,9 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
                 'metrics': {'foo': 'Foo', 'bar': 'FizBuz'},
                 'dimensions': {
                     'date': {'label': 'Date'},
-                    'clicks': {'label': 'Clicks CUSTOM LABEL'},
-                    'locale': {'label': 'Locale', 'label_options': {'us': 'United States', 'de': 'Germany'}},
-                    'account': {'label': 'Account', 'label_field': 'account_label'},
+                    'clicks': {'label': 'My Clicks'},
+                    'locale': {'label': 'Locale', 'display_options': {'us': 'United States', 'de': 'Germany'}},
+                    'account': {'label': 'Account', 'display_field': 'account_display'},
                 },
                 'references': {},
             },

--- a/fireant/tests/slicer/transformers/base.py
+++ b/fireant/tests/slicer/transformers/base.py
@@ -25,9 +25,9 @@ class BaseTransformerTests(unittest.TestCase):
 
     cont_dim = {'label': 'Cont'}
     datetime_dim = {'label': 'Date'}
-    uni_dim = {'label': 'Uni', 'label_field': 'uni_label'}
-    cat1_dim = {'label': 'Cat1', 'label_options': {'a': 'A', 'b': 'B'}}
-    cat2_dim = {'label': 'Cat2', 'label_options': {'y': 'Y', 'z': 'Z'}}
+    uni_dim = {'label': 'Uni', 'display_field': 'uni_label'}
+    cat1_dim = {'label': 'Cat1', 'display_options': {'a': 'A', 'b': 'B'}}
+    cat2_dim = {'label': 'Cat2', 'display_options': {'y': 'Y', 'z': 'Z'}}
 
     shortcuts = {
         'a': 'A',

--- a/fireant/tests/slicer/transformers/test_datatables.py
+++ b/fireant/tests/slicer/transformers/test_datatables.py
@@ -455,7 +455,6 @@ class DataTablesColumnIndexTransformerTests(BaseTransformerTests):
     def test_time_series_date_with_ref(self):
         # Tests transformation of a single-metric, single-dimension result using a WoW reference
         result = self.dt_tx.transform(self.time_dim_single_metric_ref_df, self.time_dim_single_metric_ref_schema)
-        print(result)
         self.assertDictEqual({
             'columns': [{'data': 'date.display', 'title': 'Date'},
                         {'data': 'one', 'title': 'One'},

--- a/fireant/tests/slicer/transformers/test_highcharts.py
+++ b/fireant/tests/slicer/transformers/test_highcharts.py
@@ -107,7 +107,7 @@ class HighchartsLineTransformerTests(BaseTransformerTests):
         self.evaluate_result(df2, result)
 
     def test_cont_uni_dim_single_metric(self):
-        # Tests transformation of a metric with a unique dimension with one key and label
+        # Tests transformation of a metric and a unique dimension
         df = self.cont_uni_dims_single_metric_df
 
         result = self.hc_tx.transform(df, self.cont_uni_dims_single_metric_schema)
@@ -122,7 +122,7 @@ class HighchartsLineTransformerTests(BaseTransformerTests):
         self.evaluate_result(df.unstack(level=[1, 2]), result)
 
     def test_cont_uni_dim_multi_metric(self):
-        # Tests transformation of two metrics with a unique dimension with two keys and label
+        # Tests transformation of two metrics and a unique dimension
         df = self.cont_uni_dims_multi_metric_df
 
         result = self.hc_tx.transform(df, self.cont_uni_dims_multi_metric_schema)
@@ -320,7 +320,7 @@ class HighchartsColumnTransformerTests(BaseTransformerTests):
         self.evaluate_result(df.unstack(), result)
 
     def test_uni_dim_single_metric(self):
-        # Tests transformation of a metric with a unique dimension with one key and label
+        # Tests transformation of a metric and a unique dimension
         df = self.uni_dim_single_metric_df
 
         result = self.hc_tx.transform(df, self.uni_dim_single_metric_schema)
@@ -335,7 +335,7 @@ class HighchartsColumnTransformerTests(BaseTransformerTests):
         self.evaluate_result(df, result)
 
     def test_uni_dim_multi_metric(self):
-        # Tests transformation of two metrics with a unique dimension with two keys and label
+        # Tests transformation of two metrics and a unique dimension
         df = self.uni_dim_multi_metric_df
 
         result = self.hc_tx.transform(df, self.uni_dim_multi_metric_schema)


### PR DESCRIPTION
Renamed  label_field and label_options in the dimension classes to avoid confusing with the label which is the display value for the dimension or metric as opposed the display values for the query results