### PR TITLE
Widgetgroup labels fix

### DIFF
--- a/fireant/slicer/managers.py
+++ b/fireant/slicer/managers.py
@@ -98,7 +98,9 @@ class SlicerManager(QueryManager):
 
     def display_schema(self, metrics=None, dimensions=None, references=None):
         """
-        Builds a display schema for
+        Builds a display schema for a request.  This is used in combination with the results of the query that is
+        executed by the Slicer manager to transform the results with display labels.  The display schema carries
+        meta-data pertaining to displaying the results of the query.
 
         :param metrics:
             Type: list[str]

--- a/fireant/slicer/transformers/highcharts.py
+++ b/fireant/slicer/transformers/highcharts.py
@@ -35,7 +35,7 @@ def _format_data_point(value):
     return value
 
 
-class HighchartsLineTransformer(Transformer):
+class  HighchartsLineTransformer(Transformer):
     """
     Transforms data frames into Highcharts format for several chart types, particularly line or bar charts.
     """


### PR DESCRIPTION
Fix for widget group that corrects the resulting data frame so that the labels are applied in the correct order.