### PR TITLE
Multi-axis metrics

### DIFF
--- a/fireant/slicer/managers.py
+++ b/fireant/slicer/managers.py
@@ -226,20 +226,20 @@ class SlicerManager(QueryManager, OperationManager):
 
     def _filters_schema(self, elements, filters, default_value_func, element_label='dimension'):
         filters_schema = []
-        for filter in filters:
-            if isinstance(filter.element_key, (tuple, list)):
-                element_key, modifier = filter.element_key
+        for filter_item in filters:
+            if isinstance(filter_item.element_key, (tuple, list)):
+                element_key, modifier = filter_item.element_key
             else:
-                element_key, modifier = filter.element_key, None
+                element_key, modifier = filter_item.element_key, None
 
             element = elements.get(element_key)
             if not element:
                 raise SlicerException(
                     'Unable to apply filter [{filter}].  '
                     'No such {element} with key [{key}].'.format(
-                        filter=filter,
+                        filter=filter_item,
                         element=element_label,
-                        key=filter.element_key
+                        key=filter_item.element_key
                     ))
 
             if hasattr(element, 'display_field') and 'display' == modifier:
@@ -248,7 +248,7 @@ class SlicerManager(QueryManager, OperationManager):
             else:
                 definition = element.definition or default_value_func(element.key)
 
-            filters_schema.append(filter.schemas(definition))
+            filters_schema.append(filter_item.schemas(definition))
 
         return filters_schema
 

--- a/fireant/slicer/transformers/highcharts.py
+++ b/fireant/slicer/transformers/highcharts.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 import numpy as np
 import pandas as pd
-
 from fireant import settings, utils
+
 from .base import Transformer, TransformationException
 
 COLORS = {
@@ -96,9 +96,9 @@ class HighchartsLineTransformer(Transformer):
         }
 
     def yaxis_options(self, dataframe, dim_ordinal, display_schema):
-        return [{
-            'title': None
-        }] * len(display_schema['metrics'])
+        axes = {metric_schema.get('axis')
+                for metric_schema in display_schema['metrics'].values()}
+        return [{'title': None}] * len(axes)
 
     def _make_series(self, dataframe, dim_ordinal, display_schema, reference=None):
         metrics = list(dataframe.columns.levels[0]
@@ -117,7 +117,7 @@ class HighchartsLineTransformer(Transformer):
             'name': self._format_label(idx, dim_ordinal, display_schema, reference),
             'data': self._format_data(item),
             'tooltip': self._format_tooltip(display_schema['metrics'][metric_key]),
-            'yAxis': metrics.index(utils.slice_first(idx)),
+            'yAxis': display_schema['metrics'][metric_key].get('axis', 0),
             'color': color,
             'dashStyle': 'Dot' if reference else 'Solid'
         }

--- a/fireant/slicer/transformers/highcharts.py
+++ b/fireant/slicer/transformers/highcharts.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 import numpy as np
 import pandas as pd
-from fireant import settings, utils
 
+from fireant import settings, utils
 from .base import Transformer, TransformationException
 
 COLORS = {
@@ -221,9 +221,9 @@ class HighchartsColumnTransformer(HighchartsLineTransformer):
     def prevalidate_request(self, slicer, metrics, dimensions,
                             metric_filters, dimension_filters,
                             references, operations):
-        super(HighchartsLineTransformer, self).prevalidate_request(slicer, metrics, dimensions,
-                                                                   metric_filters, dimension_filters,
-                                                                   references, operations)
+        super(HighchartsColumnTransformer, self).prevalidate_request(slicer, metrics, dimensions,
+                                                                     metric_filters, dimension_filters,
+                                                                     references, operations)
 
         if dimensions and 2 < len(dimensions):
             # Too many dimensions

--- a/fireant/slicer/transformers/highcharts.py
+++ b/fireant/slicer/transformers/highcharts.py
@@ -50,10 +50,6 @@ class HighchartsLineTransformer(Transformer):
     def prevalidate_request(self, slicer, metrics, dimensions,
                             metric_filters, dimension_filters,
                             references, operations):
-        super(HighchartsLineTransformer, self).prevalidate_request(slicer, metrics, dimensions,
-                                                                   metric_filters, dimension_filters,
-                                                                   references, operations)
-
         if not dimensions or not slicer.dimensions:
             raise TransformationException(MISSING_CONT_DIM_MESSAGE)
 
@@ -221,10 +217,6 @@ class HighchartsColumnTransformer(HighchartsLineTransformer):
     def prevalidate_request(self, slicer, metrics, dimensions,
                             metric_filters, dimension_filters,
                             references, operations):
-        super(HighchartsColumnTransformer, self).prevalidate_request(slicer, metrics, dimensions,
-                                                                     metric_filters, dimension_filters,
-                                                                     references, operations)
-
         if dimensions and 2 < len(dimensions):
             # Too many dimensions
             raise TransformationException('Highcharts bar and column charts support at a maximum two dimensions.  '

--- a/fireant/tests/slicer/test_managers.py
+++ b/fireant/tests/slicer/test_managers.py
@@ -108,8 +108,8 @@ class ManagerInitializationTests(TestCase):
         request = {
             'metrics': ['foo', 'bar'],
             'dimensions': ['cont'],
-            'metric_filters': tuple(), 'dimension_filters': tuple(),
-            'references': tuple(), 'operations': tuple(),
+            'metric_filters': (), 'dimension_filters': (),
+            'references': (), 'operations': (),
         }
         self._test_transform(self.slicer.highcharts.line_chart, mock_transform, request)
 
@@ -118,8 +118,8 @@ class ManagerInitializationTests(TestCase):
         request = {
             'metrics': ['foo', 'bar'],
             'dimensions': ['date'],
-            'metric_filters': tuple(), 'dimension_filters': tuple(),
-            'references': tuple(), 'operations': tuple(),
+            'metric_filters': (), 'dimension_filters': (),
+            'references': (), 'operations': (),
         }
         self._test_transform(self.slicer.highcharts.line_chart, mock_transform, request)
 
@@ -150,8 +150,8 @@ class ManagerInitializationTests(TestCase):
         request = {
             'metrics': ['foo'],
             'dimensions': [],
-            'metric_filters': tuple(), 'dimension_filters': tuple(),
-            'references': tuple(), 'operations': tuple(),
+            'metric_filters': (), 'dimension_filters': (),
+            'references': (), 'operations': (),
         }
         self._test_transform(self.slicer.highcharts.column_chart, mock_transform, request)
 
@@ -179,8 +179,8 @@ class ManagerInitializationTests(TestCase):
     def test_transform_highcharts_bar_chart(self, mock_transform):
         request = {
             'metrics': ['foo'], 'dimensions': [],
-            'metric_filters': tuple(), 'dimension_filters': tuple(),
-            'references': tuple(), 'operations': tuple(),
+            'metric_filters': (), 'dimension_filters': (),
+            'references': (), 'operations': (),
         }
         self._test_transform(self.slicer.highcharts.bar_chart, mock_transform, request)
 
@@ -209,8 +209,8 @@ class ManagerInitializationTests(TestCase):
         request = {
             'metrics': ['foo', 'bar'],
             'dimensions': ['cat', 'uni'],
-            'metric_filters': tuple(), 'dimension_filters': tuple(),
-            'references': tuple(), 'operations': tuple(),
+            'metric_filters': (), 'dimension_filters': (),
+            'references': (), 'operations': (),
         }
 
         self._test_transform(self.slicer.datatables.row_index_table, mock_transform, request)
@@ -220,8 +220,8 @@ class ManagerInitializationTests(TestCase):
         request = {
             'metrics': ['foo', 'bar'],
             'dimensions': ['cat', 'uni'],
-            'metric_filters': tuple(), 'dimension_filters': tuple(),
-            'references': tuple(), 'operations': tuple(),
+            'metric_filters': (), 'dimension_filters': (),
+            'references': (), 'operations': (),
         }
 
         self._test_transform(self.slicer.datatables.column_index_table, mock_transform, request)
@@ -231,8 +231,8 @@ class ManagerInitializationTests(TestCase):
         request = {
             'metrics': ['foo', 'bar'],
             'dimensions': ['cat', 'uni'],
-            'metric_filters': tuple(), 'dimension_filters': tuple(),
-            'references': tuple(), 'operations': tuple(),
+            'metric_filters': (), 'dimension_filters': (),
+            'references': (), 'operations': (),
         }
 
         self._test_transform(self.slicer.datatables.row_index_csv, mock_transform, request)
@@ -242,8 +242,8 @@ class ManagerInitializationTests(TestCase):
         request = {
             'metrics': ['foo', 'bar'],
             'dimensions': ['cat', 'uni'],
-            'metric_filters': tuple(), 'dimension_filters': tuple(),
-            'references': tuple(), 'operations': tuple(),
+            'metric_filters': (), 'dimension_filters': (),
+            'references': (), 'operations': (),
         }
 
         self._test_transform(self.slicer.datatables.column_index_csv, mock_transform, request)

--- a/fireant/tests/slicer/test_operations.py
+++ b/fireant/tests/slicer/test_operations.py
@@ -51,6 +51,7 @@ class TotalsTests(TestCase):
             dimensions=['dim'],
             operations=[Totals('dim')]
         )
-        self.assertDictEqual(display_schema['metrics'], {'foo': {'label': 'Foo'}, 'bar': {'label': 'Bar'}})
+        self.assertDictEqual(display_schema['metrics'], {'foo': {'label': 'Foo', 'axis': 0},
+                                                         'bar': {'label': 'Bar', 'axis': 1}})
         self.assertDictEqual(display_schema['dimensions'], {'dim': {'label': 'Dim', 'display_options': {}}})
         self.assertDictEqual(display_schema['references'], {})

--- a/fireant/tests/slicer/test_slicer_api.py
+++ b/fireant/tests/slicer/test_slicer_api.py
@@ -930,7 +930,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
 
         self.assertDictEqual(
             {
-                'metrics': {'foo': {'label': 'Foo'}},
+                'metrics': {'foo': {'label': 'Foo', 'axis': 0}},
                 'dimensions': {},
                 'references': {},
             },
@@ -944,7 +944,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
 
         self.assertDictEqual(
             {
-                'metrics': {'bar': {'label': 'FizBuz'}},
+                'metrics': {'bar': {'label': 'FizBuz', 'axis': 0}},
                 'dimensions': {},
                 'references': {},
             },
@@ -959,7 +959,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
 
         self.assertDictEqual(
             {
-                'metrics': {'foo': {'label': 'Foo'}},
+                'metrics': {'foo': {'label': 'Foo', 'axis': 0}},
                 'dimensions': {
                     'date': {'label': 'Date'}
                 },
@@ -976,7 +976,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
 
         self.assertDictEqual(
             {
-                'metrics': {'foo': {'label': 'Foo'}},
+                'metrics': {'foo': {'label': 'Foo', 'axis': 0}},
                 'dimensions': {
                     'clicks': {'label': 'My Clicks'}
                 },
@@ -992,7 +992,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
         )
         self.assertDictEqual(
             {
-                'metrics': {'foo': {'label': 'Foo'}},
+                'metrics': {'foo': {'label': 'Foo', 'axis': 0}},
                 'dimensions': {
                     'locale': {'label': 'Locale', 'display_options': {'us': 'United States', 'de': 'Germany'}},
                 },
@@ -1008,7 +1008,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
         )
         self.assertDictEqual(
             {
-                'metrics': {'foo': {'label': 'Foo'}},
+                'metrics': {'foo': {'label': 'Foo', 'axis': 0}},
                 'dimensions': {
                     'account': {'label': 'Account', 'display_field': 'account_display'},
                 },
@@ -1026,8 +1026,8 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
         self.assertDictEqual(
             {
                 'metrics': {
-                    'foo': {'label': 'Foo'},
-                    'bar': {'label': 'FizBuz'},
+                    'foo': {'label': 'Foo', 'axis': 0},
+                    'bar': {'label': 'FizBuz', 'axis': 1},
                 },
                 'dimensions': {
                     'date': {'label': 'Date'},
@@ -1049,7 +1049,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
 
         self.assertDictEqual(
             {
-                'metrics': {'foo': {'label': 'Foo'}},
+                'metrics': {'foo': {'label': 'Foo', 'axis': 0}},
                 'dimensions': {
                     'date': {'label': 'Date'},
                 },
@@ -1065,7 +1065,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
 
         self.assertDictEqual(
             {
-                'metrics': {'foo_cumsum': {'label': 'Foo cum. sum'}},
+                'metrics': {'foo_cumsum': {'label': 'Foo cum. sum', 'axis': 0}},
                 'dimensions': {},
                 'references': {},
             },
@@ -1079,7 +1079,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
 
         self.assertDictEqual(
             {
-                'metrics': {'foo_cummean': {'label': 'Foo cum. mean'}},
+                'metrics': {'foo_cummean': {'label': 'Foo cum. mean', 'axis': 0}},
                 'dimensions': {},
                 'references': {},
             },
@@ -1093,7 +1093,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
 
         self.assertDictEqual(
             {
-                'metrics': {'foo_l1loss': {'label': 'Foo L1 loss'}},
+                'metrics': {'foo_l1loss': {'label': 'Foo L1 loss', 'axis': 0}},
                 'dimensions': {},
                 'references': {},
             },
@@ -1107,7 +1107,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
 
         self.assertDictEqual(
             {
-                'metrics': {'foo_l2loss': {'label': 'Foo L2 loss'}},
+                'metrics': {'foo_l2loss': {'label': 'Foo L2 loss', 'axis': 0}},
                 'dimensions': {},
                 'references': {},
             },
@@ -1123,8 +1123,8 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
         self.assertDictEqual(
             {
                 'metrics': {
-                    'bar': {'label': 'FizBuz'},
-                    'foo_cumsum': {'label': 'Foo cum. sum'}
+                    'bar': {'label': 'FizBuz', 'axis': 0},
+                    'foo_cumsum': {'label': 'Foo cum. sum', 'axis': 1}
                 },
                 'dimensions': {},
                 'references': {},
@@ -1141,8 +1141,8 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
         self.assertDictEqual(
             {
                 'metrics': {
-                    'foo': {'label': 'Foo'},
-                    'foo_cumsum': {'label': 'Foo cum. sum'}
+                    'foo': {'label': 'Foo', 'axis': 0},
+                    'foo_cumsum': {'label': 'Foo cum. sum', 'axis': 1}
                 },
                 'dimensions': {},
                 'references': {},
@@ -1159,7 +1159,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
         self.assertDictEqual(
             {
                 'metrics': {
-                    'decimal': {'label': 'Decimal', 'precision': 2},
+                    'decimal': {'label': 'Decimal', 'axis': 0, 'precision': 2},
                 },
                 'dimensions': {
                     'date': {'label': 'Date'}
@@ -1178,7 +1178,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
         self.assertDictEqual(
             {
                 'metrics': {
-                    'dollar': {'label': 'Dollar', 'prefix': '$'},
+                    'dollar': {'label': 'Dollar', 'axis': 0, 'prefix': '$'},
                 },
                 'dimensions': {
                     'date': {'label': 'Date'}
@@ -1197,7 +1197,7 @@ class SlicerDisplaySchemaTests(SlicerSchemaTests):
         self.assertDictEqual(
             {
                 'metrics': {
-                    'euro': {'label': 'Euro', 'suffix': '€'},
+                    'euro': {'label': 'Euro', 'axis': 0, 'suffix': '€'},
                 },
                 'dimensions': {
                     'date': {'label': 'Date'}

--- a/fireant/utils.py
+++ b/fireant/utils.py
@@ -1,7 +1,4 @@
 # coding: utf-8
-import itertools
-
-import pandas as pd
 
 
 def dimension_levels(dimension_key, dimension):
@@ -12,6 +9,10 @@ def dimension_levels(dimension_key, dimension):
 
 def wrap_list(value):
     return value if isinstance(value, (tuple, list)) else [value]
+
+
+def flatten(items):
+    return [item for level in items for item in wrap_list(level)]
 
 
 def slice_first(item):


### PR DESCRIPTION
Changed transformer APIs to accept metrics as a list of list of metric keys to express which axis each metric should go on.  Does not break backwards compatibility since a list of metric keys will still work and render each metric on its own axis which is the same as the previous behavior.