### PR TITLE
Fixed datatables column sorting

### DIFF
--- a/fireant/slicer/transformers/datatables.py
+++ b/fireant/slicer/transformers/datatables.py
@@ -40,7 +40,7 @@ def _pretty(value, schema):
 
 def _format_value(value, metric):
     raw_value = _safe(value)
-    return {'value': raw_value, 'display': _pretty(raw_value, metric)}
+    return {'value': raw_value, 'display': _pretty(raw_value, metric) if raw_value is not None else None}
 
 
 def _format_column_display(csv_df, metrics, dimensions):
@@ -103,11 +103,14 @@ class DataTablesRowIndexTransformer(Transformer):
         if 'display_field' in dimension or 'display_options' in dimension:
             render = {
                 '_': 'display',
-                'type': 'value',
+                'type': 'display',
+                'sort': 'display'
             }
         else:
             render = {
                 '_': 'value',
+                'type': 'value',
+                'sort': 'value'
             }
 
         return {'title': dimension['label'],
@@ -119,7 +122,7 @@ class DataTablesRowIndexTransformer(Transformer):
         if not isinstance(metric_column, tuple):
             return {'title': metrics[metric_column]['label'],
                     'data': metric_column,
-                    'render': {'type': 'value', '_': 'display'}}
+                    'render': {'type': 'value', '_': 'display', 'sort': 'value'}}
 
         references = display_schema.get('references')
         metric_key_idx = 1 if references else 0
@@ -141,7 +144,7 @@ class DataTablesRowIndexTransformer(Transformer):
         return {
             'title': metric_label,
             'data': path,
-            'render': {'type': 'value', '_': 'display'}
+            'render': {'type': 'value', '_': 'display', 'sort': 'value'}
         }
 
     def _render_data(self, dataframe, display_schema):
@@ -270,7 +273,7 @@ class DataTablesColumnIndexTransformer(DataTablesRowIndexTransformer):
         return {
             'title': metric_label,
             'data': data,
-            'render': {'type': 'value', '_': 'display'}
+            'render': {'type': 'value', '_': 'display', 'sort': 'value'}
         }
 
     def _recurse_dimensions(self, dataframe, dimensions, metrics, reference=None):

--- a/fireant/tests/slicer/transformers/test_datatables.py
+++ b/fireant/tests/slicer/transformers/test_datatables.py
@@ -20,14 +20,17 @@ class DataTablesRowIndexTransformerTests(TestCase):
         # Tests transformation of a single metric with a single continuous dimension
         result = self.dt_tx.transform(mock_df.no_dims_multi_metric_df, mock_df.no_dims_multi_metric_schema)
         self.assertDictEqual({
-            'columns': [{'title': 'One', 'render': {'type': 'value', '_': 'display'}, 'data': 'one'},
-                        {'title': 'Two', 'render': {'type': 'value', '_': 'display'}, 'data': 'two'},
-                        {'title': 'Three', 'render': {'type': 'value', '_': 'display'}, 'data': 'three'},
-                        {'title': 'Four', 'render': {'type': 'value', '_': 'display'}, 'data': 'four'},
-                        {'title': 'Five', 'render': {'type': 'value', '_': 'display'}, 'data': 'five'},
-                        {'title': 'Six', 'render': {'type': 'value', '_': 'display'}, 'data': 'six'},
-                        {'title': 'Seven', 'render': {'type': 'value', '_': 'display'}, 'data': 'seven'},
-                        {'title': 'Eight', 'render': {'type': 'value', '_': 'display'}, 'data': 'eight'}],
+            'columns': [{'title': 'One', 'render': {'type': 'value', '_': 'display', 'sort': 'value'}, 'data': 'one'},
+                        {'title': 'Two', 'render': {'type': 'value', '_': 'display', 'sort': 'value'}, 'data': 'two'},
+                        {'title': 'Three', 'render': {'type': 'value', '_': 'display', 'sort': 'value'},
+                         'data': 'three'},
+                        {'title': 'Four', 'render': {'type': 'value', '_': 'display', 'sort': 'value'}, 'data': 'four'},
+                        {'title': 'Five', 'render': {'type': 'value', '_': 'display', 'sort': 'value'}, 'data': 'five'},
+                        {'title': 'Six', 'render': {'type': 'value', '_': 'display', 'sort': 'value'}, 'data': 'six'},
+                        {'title': 'Seven', 'render': {'type': 'value', '_': 'display', 'sort': 'value'},
+                         'data': 'seven'},
+                        {'title': 'Eight', 'render': {'type': 'value', '_': 'display', 'sort': 'value'},
+                         'data': 'eight'}],
             'data': [{'six': {'value': 5, 'display': '5'}, 'seven': {'value': 6, 'display': '6'},
                       'three': {'value': 2, 'display': '2'}, 'one': {'value': 0, 'display': '0'},
                       'two': {'value': 1, 'display': '1'}, 'four': {'value': 3, 'display': '3'},
@@ -37,8 +40,8 @@ class DataTablesRowIndexTransformerTests(TestCase):
         # Tests transformation of a single metric with a single continuous dimension
         result = self.dt_tx.transform(mock_df.cont_dim_single_metric_df, mock_df.cont_dim_single_metric_schema)
         self.assertDictEqual({
-            'columns': [{'data': 'cont', 'render': {'_': 'value'}, 'title': 'Cont'},
-                        {'data': 'one', 'render': {'type': 'value', '_': 'display'}, 'title': 'One'}],
+            'columns': [{'data': 'cont', 'render': {'_': 'value', 'sort': 'value', 'type': 'value'}, 'title': 'Cont'},
+                        {'data': 'one', 'render': {'type': 'value', '_': 'display', 'sort': 'value'}, 'title': 'One'}],
             'data': [{'cont': {'value': i}, 'one': {'value': i, 'display': str(i)}}
                      for i in range(8)]}, result)
 
@@ -46,9 +49,9 @@ class DataTablesRowIndexTransformerTests(TestCase):
         # Tests transformation of two metrics with a single continuous dimension
         result = self.dt_tx.transform(mock_df.cont_dim_multi_metric_df, mock_df.cont_dim_multi_metric_schema)
         self.assertDictEqual({
-            'columns': [{'title': 'Cont', 'data': 'cont', 'render': {'_': 'value'}},
-                        {'title': 'One', 'data': 'one', 'render': {'type': 'value', '_': 'display'}},
-                        {'title': 'Two', 'data': 'two', 'render': {'type': 'value', '_': 'display'}}],
+            'columns': [{'title': 'Cont', 'data': 'cont', 'render': {'_': 'value', 'sort': 'value', 'type': 'value'}},
+                        {'title': 'One', 'data': 'one', 'render': {'type': 'value', '_': 'display', 'sort': 'value'}},
+                        {'title': 'Two', 'data': 'two', 'render': {'type': 'value', '_': 'display', 'sort': 'value'}}],
             'data': [{
                          'cont': {'value': i},
                          'one': {'value': i, 'display': str(i)},
@@ -59,8 +62,8 @@ class DataTablesRowIndexTransformerTests(TestCase):
         # Tests transformation of a single-metric, single-dimension result
         result = self.dt_tx.transform(mock_df.time_dim_single_metric_df, mock_df.time_dim_single_metric_schema)
         self.assertDictEqual({
-            'columns': [{'render': {'_': 'value'}, 'data': 'date', 'title': 'Date'},
-                        {'render': {'type': 'value', '_': 'display'}, 'data': 'one', 'title': 'One'}],
+            'columns': [{'render': {'_': 'value', 'sort': 'value', 'type': 'value'}, 'data': 'date', 'title': 'Date'},
+                        {'render': {'type': 'value', '_': 'display', 'sort': 'value'}, 'data': 'one', 'title': 'One'}],
             'data': [{'date': {'value': '2000-01-0%d' % (1 + i)}, 'one': {'value': i, 'display': str(i)}}
                      for i in range(8)]}, result)
 
@@ -68,9 +71,10 @@ class DataTablesRowIndexTransformerTests(TestCase):
         # Tests transformation of a single-metric, single-dimension result using a WoW reference
         result = self.dt_tx.transform(mock_df.time_dim_single_metric_ref_df, mock_df.time_dim_single_metric_ref_schema)
         self.assertDictEqual({
-            'columns': [{'render': {'_': 'value'}, 'data': 'date', 'title': 'Date'},
-                        {'render': {'type': 'value', '_': 'display'}, 'data': 'one', 'title': 'One'},
-                        {'render': {'type': 'value', '_': 'display'}, 'data': 'wow.one', 'title': 'One WoW'}],
+            'columns': [{'render': {'_': 'value', 'sort': 'value', 'type': 'value'}, 'data': 'date', 'title': 'Date'},
+                        {'render': {'type': 'value', '_': 'display', 'sort': 'value'}, 'data': 'one', 'title': 'One'},
+                        {'render': {'type': 'value', '_': 'display', 'sort': 'value'}, 'data': 'wow.one',
+                         'title': 'One WoW'}],
             'data': [{
                          'date': {'value': '2000-01-0%d' % (1 + i)},
                          'one': {'value': i, 'display': str(i)},
@@ -81,8 +85,9 @@ class DataTablesRowIndexTransformerTests(TestCase):
         # Tests transformation of a metric with a unique dimension with one key and display
         result = self.dt_tx.transform(mock_df.uni_dim_single_metric_df, mock_df.uni_dim_single_metric_schema)
         self.assertDictEqual({
-            'columns': [{'data': 'uni', 'render': {'type': 'value', '_': 'display'}, 'title': 'Uni'},
-                        {'data': 'one', 'render': {'type': 'value', '_': 'display'}, 'title': 'One'}],
+            'columns': [
+                {'data': 'uni', 'render': {'type': 'display', '_': 'display', 'sort': 'display'}, 'title': 'Uni'},
+                {'data': 'one', 'render': {'type': 'value', '_': 'display', 'sort': 'value'}, 'title': 'One'}],
             'data': [{'one': {'value': 0, 'display': '0'}, 'uni': {'display': 'Aa', 'value': 1}},
                      {'one': {'value': 1, 'display': '1'}, 'uni': {'display': 'Bb', 'value': 2}},
                      {'one': {'value': 2, 'display': '2'}, 'uni': {'display': 'Cc', 'value': 3}}]}, result)
@@ -91,9 +96,10 @@ class DataTablesRowIndexTransformerTests(TestCase):
         # Tests transformation of a metric with a unique dimension with one key and display
         result = self.dt_tx.transform(mock_df.uni_dim_multi_metric_df, mock_df.uni_dim_multi_metric_schema)
         self.assertDictEqual({
-            'columns': [{'render': {'_': 'display', 'type': 'value'}, 'title': 'Uni', 'data': 'uni'},
-                        {'render': {'_': 'display', 'type': 'value'}, 'title': 'One', 'data': 'one'},
-                        {'render': {'_': 'display', 'type': 'value'}, 'title': 'Two', 'data': 'two'}],
+            'columns': [
+                {'render': {'_': 'display', 'type': 'display', 'sort': 'display'}, 'title': 'Uni', 'data': 'uni'},
+                {'render': {'_': 'display', 'type': 'value', 'sort': 'value'}, 'title': 'One', 'data': 'one'},
+                {'render': {'_': 'display', 'type': 'value', 'sort': 'value'}, 'title': 'Two', 'data': 'two'}],
             'data': [{'one': {'value': 0, 'display': '0'}, 'two': {'value': 0, 'display': '0'},
                       'uni': {'value': 1, 'display': 'Aa'}},
                      {'one': {'value': 1, 'display': '1'}, 'two': {'value': 2, 'display': '2'},
@@ -105,9 +111,10 @@ class DataTablesRowIndexTransformerTests(TestCase):
         # Tests transformation of a single metric with two categorical dimensions
         result = self.dt_tx.transform(mock_df.cat_cat_dims_single_metric_df, mock_df.cat_cat_dims_single_metric_schema)
         self.assertDictEqual({
-            'columns': [{'render': {'_': 'display', 'type': 'value'}, 'title': 'Cat1', 'data': 'cat1'},
-                        {'render': {'_': 'display', 'type': 'value'}, 'title': 'Cat2', 'data': 'cat2'},
-                        {'render': {'_': 'display', 'type': 'value'}, 'title': 'One', 'data': 'one'}],
+            'columns': [
+                {'render': {'_': 'display', 'type': 'display', 'sort': 'display'}, 'title': 'Cat1', 'data': 'cat1'},
+                {'render': {'_': 'display', 'type': 'display', 'sort': 'display'}, 'title': 'Cat2', 'data': 'cat2'},
+                {'render': {'_': 'display', 'type': 'value', 'sort': 'value'}, 'title': 'One', 'data': 'one'}],
             'data': [{'cat1': {'display': 'A', 'value': 'a'}, 'cat2': {'display': 'Y', 'value': 'y'},
                       'one': {'display': '0', 'value': 0}},
                      {'cat1': {'display': 'A', 'value': 'a'}, 'cat2': {'display': 'Z', 'value': 'z'},
@@ -129,21 +136,25 @@ class DataTablesRowIndexTransformerTests(TestCase):
                       'cat2': {'display': 'Y', 'value': 'y'}, 'cat1': {'display': 'B', 'value': 'b'}},
                      {'one': {'value': 3, 'display': '3'}, 'two': {'value': 6, 'display': '6'},
                       'cat2': {'display': 'Z', 'value': 'z'}, 'cat1': {'display': 'B', 'value': 'b'}}],
-            'columns': [{'title': 'Cat1', 'render': {'_': 'display', 'type': 'value'}, 'data': 'cat1'},
-                        {'title': 'Cat2', 'render': {'_': 'display', 'type': 'value'}, 'data': 'cat2'},
-                        {'title': 'One', 'render': {'_': 'display', 'type': 'value'}, 'data': 'one'},
-                        {'title': 'Two', 'render': {'_': 'display', 'type': 'value'}, 'data': 'two'}]}, result)
+            'columns': [
+                {'title': 'Cat1', 'render': {'_': 'display', 'type': 'display', 'sort': 'display'}, 'data': 'cat1'},
+                {'title': 'Cat2', 'render': {'_': 'display', 'type': 'display', 'sort': 'display'}, 'data': 'cat2'},
+                {'title': 'One', 'render': {'_': 'display', 'type': 'value', 'sort': 'value'}, 'data': 'one'},
+                {'title': 'Two', 'render': {'_': 'display', 'type': 'value', 'sort': 'value'}, 'data': 'two'}]},
+            result)
 
-    def test_rollup_cont_cat_cat_dim_multi_metric(self):
-        # Tests transformation of two metrics with two categorical dimensions
+    def test_rollup_cont_cat_cat_dims_multi_metric_df(self):
+        # Tests transformation of two metrics with a continuous and two categorical dimensions
         result = self.dt_tx.transform(mock_df.rollup_cont_cat_cat_dims_multi_metric_df,
                                       mock_df.rollup_cont_cat_cat_dims_multi_metric_schema)
         self.assertDictEqual({
-            'columns': [{'title': 'Cont', 'render': {'_': 'value'}, 'data': 'cont'},
-                        {'title': 'Cat1', 'render': {'type': 'value', '_': 'display'}, 'data': 'cat1'},
-                        {'title': 'Cat2', 'render': {'type': 'value', '_': 'display'}, 'data': 'cat2'},
-                        {'title': 'One', 'render': {'type': 'value', '_': 'display'}, 'data': 'one'},
-                        {'title': 'Two', 'render': {'type': 'value', '_': 'display'}, 'data': 'two'}],
+            'columns': [{'title': 'Cont', 'render': {'_': 'value', 'sort': 'value', 'type': 'value'}, 'data': 'cont'},
+                        {'title': 'Cat1', 'render': {'type': 'display', '_': 'display', 'sort': 'display'},
+                         'data': 'cat1'},
+                        {'title': 'Cat2', 'render': {'type': 'display', '_': 'display', 'sort': 'display'},
+                         'data': 'cat2'},
+                        {'title': 'One', 'render': {'type': 'value', '_': 'display', 'sort': 'value'}, 'data': 'one'},
+                        {'title': 'Two', 'render': {'type': 'value', '_': 'display', 'sort': 'value'}, 'data': 'two'}],
             'data': [
                 {'one': {'value': 12, 'display': '12'}, 'two': {'value': 24, 'display': '24'}, 'cont': {'value': 0},
                  'cat1': {'value': None, 'display': 'Total'}, 'cat2': {'value': None, 'display': 'Total'}},
@@ -272,21 +283,24 @@ class DataTablesColumnIndexTransformerTests(TestCase):
                       'seven': {'value': 6, 'display': '6'}, 'four': {'value': 3, 'display': '3'},
                       'three': {'value': 2, 'display': '2'}, 'five': {'value': 4, 'display': '4'},
                       'six': {'value': 5, 'display': '5'}, 'two': {'value': 1, 'display': '1'}}],
-            'columns': [{'render': {'type': 'value', '_': 'display'}, 'title': 'One', 'data': 'one'},
-                        {'render': {'type': 'value', '_': 'display'}, 'title': 'Two', 'data': 'two'},
-                        {'render': {'type': 'value', '_': 'display'}, 'title': 'Three', 'data': 'three'},
-                        {'render': {'type': 'value', '_': 'display'}, 'title': 'Four', 'data': 'four'},
-                        {'render': {'type': 'value', '_': 'display'}, 'title': 'Five', 'data': 'five'},
-                        {'render': {'type': 'value', '_': 'display'}, 'title': 'Six', 'data': 'six'},
-                        {'render': {'type': 'value', '_': 'display'}, 'title': 'Seven', 'data': 'seven'},
-                        {'render': {'type': 'value', '_': 'display'}, 'title': 'Eight', 'data': 'eight'}]}, result)
+            'columns': [{'render': {'type': 'value', '_': 'display', 'sort': 'value'}, 'title': 'One', 'data': 'one'},
+                        {'render': {'type': 'value', '_': 'display', 'sort': 'value'}, 'title': 'Two', 'data': 'two'},
+                        {'render': {'type': 'value', '_': 'display', 'sort': 'value'}, 'title': 'Three',
+                         'data': 'three'},
+                        {'render': {'type': 'value', '_': 'display', 'sort': 'value'}, 'title': 'Four', 'data': 'four'},
+                        {'render': {'type': 'value', '_': 'display', 'sort': 'value'}, 'title': 'Five', 'data': 'five'},
+                        {'render': {'type': 'value', '_': 'display', 'sort': 'value'}, 'title': 'Six', 'data': 'six'},
+                        {'render': {'type': 'value', '_': 'display', 'sort': 'value'}, 'title': 'Seven',
+                         'data': 'seven'},
+                        {'render': {'type': 'value', '_': 'display', 'sort': 'value'}, 'title': 'Eight',
+                         'data': 'eight'}]}, result)
 
     def test_cont_dim_single_metric(self):
         # Tests transformation of a single metric with a single continuous dimension
         result = self.dt_tx.transform(mock_df.cont_dim_single_metric_df, mock_df.cont_dim_single_metric_schema)
         self.assertDictEqual({
-            'columns': [{'title': 'Cont', 'data': 'cont', 'render': {'_': 'value'}},
-                        {'title': 'One', 'data': 'one', 'render': {'type': 'value', '_': 'display'}}],
+            'columns': [{'title': 'Cont', 'data': 'cont', 'render': {'_': 'value', 'sort': 'value', 'type': 'value'}},
+                        {'title': 'One', 'data': 'one', 'render': {'type': 'value', '_': 'display', 'sort': 'value'}}],
             'data': [{
                          'cont': {'value': i},
                          'one': {'value': i, 'display': str(i)},
@@ -296,9 +310,9 @@ class DataTablesColumnIndexTransformerTests(TestCase):
         # Tests transformation of two metrics with a single continuous dimension
         result = self.dt_tx.transform(mock_df.cont_dim_multi_metric_df, mock_df.cont_dim_multi_metric_schema)
         self.assertDictEqual({
-            'columns': [{'data': 'cont', 'render': {'_': 'value'}, 'title': 'Cont'},
-                        {'data': 'one', 'render': {'_': 'display', 'type': 'value'}, 'title': 'One'},
-                        {'data': 'two', 'render': {'_': 'display', 'type': 'value'}, 'title': 'Two'}],
+            'columns': [{'data': 'cont', 'render': {'_': 'value', 'sort': 'value', 'type': 'value'}, 'title': 'Cont'},
+                        {'data': 'one', 'render': {'_': 'display', 'type': 'value', 'sort': 'value'}, 'title': 'One'},
+                        {'data': 'two', 'render': {'_': 'display', 'type': 'value', 'sort': 'value'}, 'title': 'Two'}],
             'data': [{
                          'cont': {'value': i},
                          'one': {'value': i, 'display': str(i)},
@@ -309,8 +323,8 @@ class DataTablesColumnIndexTransformerTests(TestCase):
         # Tests transformation of a single-metric, single-dimension result
         result = self.dt_tx.transform(mock_df.time_dim_single_metric_df, mock_df.time_dim_single_metric_schema)
         self.assertDictEqual({
-            'columns': [{'data': 'date', 'render': {'_': 'value'}, 'title': 'Date'},
-                        {'data': 'one', 'render': {'_': 'display', 'type': 'value'}, 'title': 'One'}],
+            'columns': [{'data': 'date', 'render': {'_': 'value', 'sort': 'value', 'type': 'value'}, 'title': 'Date'},
+                        {'data': 'one', 'render': {'_': 'display', 'type': 'value', 'sort': 'value'}, 'title': 'One'}],
             'data': [{
                          'date': {'value': '2000-01-0%d' % (i + 1)},
                          'one': {'value': i, 'display': str(i)}
@@ -320,9 +334,10 @@ class DataTablesColumnIndexTransformerTests(TestCase):
         # Tests transformation of a single-metric, single-dimension result using a WoW reference
         result = self.dt_tx.transform(mock_df.time_dim_single_metric_ref_df, mock_df.time_dim_single_metric_ref_schema)
         self.assertDictEqual({
-            'columns': [{'data': 'date', 'render': {'_': 'value'}, 'title': 'Date'},
-                        {'data': 'one', 'render': {'_': 'display', 'type': 'value'}, 'title': 'One'},
-                        {'data': 'wow.one', 'render': {'_': 'display', 'type': 'value'}, 'title': 'One WoW'}],
+            'columns': [{'data': 'date', 'render': {'_': 'value', 'sort': 'value', 'type': 'value'}, 'title': 'Date'},
+                        {'data': 'one', 'render': {'_': 'display', 'type': 'value', 'sort': 'value'}, 'title': 'One'},
+                        {'data': 'wow.one', 'render': {'_': 'display', 'type': 'value', 'sort': 'value'},
+                         'title': 'One WoW'}],
             'data': [{
                          'date': {'value': '2000-01-0%d' % (i + 1)},
                          'one': {'value': i, 'display': str(i)},
@@ -334,9 +349,11 @@ class DataTablesColumnIndexTransformerTests(TestCase):
         result = self.dt_tx.transform(mock_df.cont_cat_dims_single_metric_df,
                                       mock_df.cont_cat_dims_single_metric_schema)
         self.assertDictEqual({
-            'columns': [{'data': 'cont', 'title': 'Cont', 'render': {'_': 'value'}},
-                        {'data': 'a.one', 'title': 'One (A)', 'render': {'type': 'value', '_': 'display'}},
-                        {'data': 'b.one', 'title': 'One (B)', 'render': {'type': 'value', '_': 'display'}}],
+            'columns': [{'data': 'cont', 'title': 'Cont', 'render': {'_': 'value', 'sort': 'value', 'type': 'value'}},
+                        {'data': 'a.one', 'title': 'One (A)',
+                         'render': {'type': 'value', '_': 'display', 'sort': 'value'}},
+                        {'data': 'b.one', 'title': 'One (B)',
+                         'render': {'type': 'value', '_': 'display', 'sort': 'value'}}],
             'data': [{'b': {'one': {'value': 1, 'display': '1'}}, 'a': {'one': {'value': 0, 'display': '0'}},
                       'cont': {'value': 0}},
                      {'b': {'one': {'value': 3, 'display': '3'}}, 'a': {'one': {'value': 2, 'display': '2'}},
@@ -383,11 +400,15 @@ class DataTablesColumnIndexTransformerTests(TestCase):
                      {'b': {'one': {'display': '15', 'value': 15}, 'two': {'display': '30', 'value': 30}},
                       'a': {'one': {'display': '14', 'value': 14}, 'two': {'display': '28', 'value': 28}},
                       'cont': {'value': 7}}],
-            'columns': [{'title': 'Cont', 'render': {'_': 'value'}, 'data': 'cont'},
-                        {'title': 'One (A)', 'render': {'_': 'display', 'type': 'value'}, 'data': 'a.one'},
-                        {'title': 'One (B)', 'render': {'_': 'display', 'type': 'value'}, 'data': 'b.one'},
-                        {'title': 'Two (A)', 'render': {'_': 'display', 'type': 'value'}, 'data': 'a.two'},
-                        {'title': 'Two (B)', 'render': {'_': 'display', 'type': 'value'}, 'data': 'b.two'}]}, result)
+            'columns': [{'title': 'Cont', 'render': {'_': 'value', 'sort': 'value', 'type': 'value'}, 'data': 'cont'},
+                        {'title': 'One (A)', 'render': {'_': 'display', 'type': 'value', 'sort': 'value'},
+                         'data': 'a.one'},
+                        {'title': 'One (B)', 'render': {'_': 'display', 'type': 'value', 'sort': 'value'},
+                         'data': 'b.one'},
+                        {'title': 'Two (A)', 'render': {'_': 'display', 'type': 'value', 'sort': 'value'},
+                         'data': 'a.two'},
+                        {'title': 'Two (B)', 'render': {'_': 'display', 'type': 'value', 'sort': 'value'},
+                         'data': 'b.two'}]}, result)
 
     def test_cont_cat_cat_dim_multi_metric(self):
         # Tests transformation of two metrics with a continuous and two categorical dimensions
@@ -434,15 +455,23 @@ class DataTablesColumnIndexTransformerTests(TestCase):
                          'a': {'z': {'one': {'value': 29, 'display': '29'}, 'two': {'value': 58, 'display': '58'}},
                                'y': {'one': {'value': 28, 'display': '28'}, 'two': {'value': 56, 'display': '56'}}},
                          'cont': {'value': 7}}],
-            'columns': [{'data': 'cont', 'title': 'Cont', 'render': {'_': 'value'}},
-                        {'data': 'a.y.one', 'title': 'One (A, Y)', 'render': {'type': 'value', '_': 'display'}},
-                        {'data': 'a.z.one', 'title': 'One (A, Z)', 'render': {'type': 'value', '_': 'display'}},
-                        {'data': 'b.y.one', 'title': 'One (B, Y)', 'render': {'type': 'value', '_': 'display'}},
-                        {'data': 'b.z.one', 'title': 'One (B, Z)', 'render': {'type': 'value', '_': 'display'}},
-                        {'data': 'a.y.two', 'title': 'Two (A, Y)', 'render': {'type': 'value', '_': 'display'}},
-                        {'data': 'a.z.two', 'title': 'Two (A, Z)', 'render': {'type': 'value', '_': 'display'}},
-                        {'data': 'b.y.two', 'title': 'Two (B, Y)', 'render': {'type': 'value', '_': 'display'}},
-                        {'data': 'b.z.two', 'title': 'Two (B, Z)', 'render': {'type': 'value', '_': 'display'}}]},
+            'columns': [{'data': 'cont', 'title': 'Cont', 'render': {'_': 'value', 'sort': 'value', 'type': 'value'}},
+                        {'data': 'a.y.one', 'title': 'One (A, Y)',
+                         'render': {'type': 'value', '_': 'display', 'sort': 'value'}},
+                        {'data': 'a.z.one', 'title': 'One (A, Z)',
+                         'render': {'type': 'value', '_': 'display', 'sort': 'value'}},
+                        {'data': 'b.y.one', 'title': 'One (B, Y)',
+                         'render': {'type': 'value', '_': 'display', 'sort': 'value'}},
+                        {'data': 'b.z.one', 'title': 'One (B, Z)',
+                         'render': {'type': 'value', '_': 'display', 'sort': 'value'}},
+                        {'data': 'a.y.two', 'title': 'Two (A, Y)',
+                         'render': {'type': 'value', '_': 'display', 'sort': 'value'}},
+                        {'data': 'a.z.two', 'title': 'Two (A, Z)',
+                         'render': {'type': 'value', '_': 'display', 'sort': 'value'}},
+                        {'data': 'b.y.two', 'title': 'Two (B, Y)',
+                         'render': {'type': 'value', '_': 'display', 'sort': 'value'}},
+                        {'data': 'b.z.two', 'title': 'Two (B, Z)',
+                         'render': {'type': 'value', '_': 'display', 'sort': 'value'}}]},
             result)
 
     def test_cont_cat_uni_dim_multi_metric(self):
@@ -506,19 +535,31 @@ class DataTablesColumnIndexTransformerTests(TestCase):
                       'a': {1: {'one': {'display': '42', 'value': 42}, 'two': {'display': '142', 'value': 142}},
                             2: {'one': {'display': '43', 'value': 43}, 'two': {'display': '143', 'value': 143}},
                             3: {'one': {'display': '44', 'value': 44}, 'two': {'display': '144', 'value': 144}}}}],
-            'columns': [{'data': 'cont', 'title': 'Cont', 'render': {'_': 'value'}},
-                        {'data': 'a.1.one', 'title': 'One (A, Aa)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'a.2.one', 'title': 'One (A, Bb)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'a.3.one', 'title': 'One (A, Cc)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'b.1.one', 'title': 'One (B, Aa)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'b.2.one', 'title': 'One (B, Bb)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'b.3.one', 'title': 'One (B, Cc)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'a.1.two', 'title': 'Two (A, Aa)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'a.2.two', 'title': 'Two (A, Bb)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'a.3.two', 'title': 'Two (A, Cc)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'b.1.two', 'title': 'Two (B, Aa)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'b.2.two', 'title': 'Two (B, Bb)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'b.3.two', 'title': 'Two (B, Cc)', 'render': {'_': 'display', 'type': 'value'}}]},
+            'columns': [{'data': 'cont', 'title': 'Cont', 'render': {'_': 'value', 'sort': 'value', 'type': 'value'}},
+                        {'data': 'a.1.one', 'title': 'One (A, Aa)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'a.2.one', 'title': 'One (A, Bb)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'a.3.one', 'title': 'One (A, Cc)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'b.1.one', 'title': 'One (B, Aa)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'b.2.one', 'title': 'One (B, Bb)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'b.3.one', 'title': 'One (B, Cc)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'a.1.two', 'title': 'Two (A, Aa)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'a.2.two', 'title': 'Two (A, Bb)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'a.3.two', 'title': 'Two (A, Cc)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'b.1.two', 'title': 'Two (B, Aa)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'b.2.two', 'title': 'Two (B, Bb)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'b.3.two', 'title': 'Two (B, Cc)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}}]},
             result)
 
     def test_rollup_cont_cat_cat_dims_multi_metric_df(self):
@@ -526,21 +567,33 @@ class DataTablesColumnIndexTransformerTests(TestCase):
         result = self.dt_tx.transform(mock_df.rollup_cont_cat_cat_dims_multi_metric_df,
                                       mock_df.rollup_cont_cat_cat_dims_multi_metric_schema)
         self.assertDictEqual({
-            'columns': [{'data': 'cont', 'title': 'Cont', 'render': {'_': 'value'}},
-                        {'data': 'one', 'title': 'One', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'a.one', 'title': 'One (A)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'a.y.one', 'title': 'One (A, Y)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'a.z.one', 'title': 'One (A, Z)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'b.one', 'title': 'One (B)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'b.y.one', 'title': 'One (B, Y)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'b.z.one', 'title': 'One (B, Z)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'two', 'title': 'Two', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'a.two', 'title': 'Two (A)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'a.y.two', 'title': 'Two (A, Y)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'a.z.two', 'title': 'Two (A, Z)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'b.two', 'title': 'Two (B)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'b.y.two', 'title': 'Two (B, Y)', 'render': {'_': 'display', 'type': 'value'}},
-                        {'data': 'b.z.two', 'title': 'Two (B, Z)', 'render': {'_': 'display', 'type': 'value'}}],
+            'columns': [{'data': 'cont', 'title': 'Cont', 'render': {'_': 'value', 'sort': 'value', 'type': 'value'}},
+                        {'data': 'one', 'title': 'One', 'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'a.one', 'title': 'One (A)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'a.y.one', 'title': 'One (A, Y)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'a.z.one', 'title': 'One (A, Z)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'b.one', 'title': 'One (B)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'b.y.one', 'title': 'One (B, Y)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'b.z.one', 'title': 'One (B, Z)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'two', 'title': 'Two', 'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'a.two', 'title': 'Two (A)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'a.y.two', 'title': 'Two (A, Y)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'a.z.two', 'title': 'Two (A, Z)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'b.two', 'title': 'Two (B)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'b.y.two', 'title': 'Two (B, Y)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}},
+                        {'data': 'b.z.two', 'title': 'Two (B, Z)',
+                         'render': {'_': 'display', 'type': 'value', 'sort': 'value'}}],
             'data': [{'b': {'y': {'one': {'display': '2', 'value': 2}, 'two': {'display': '4', 'value': 4}},
                             'z': {'one': {'display': '3', 'value': 3}, 'two': {'display': '6', 'value': 6}}},
                       'cont': {'value': 0},
@@ -607,7 +660,7 @@ class DataTablesColumnIndexTransformerTests(TestCase):
 
 class DatatablesUtilityTests(TestCase):
     def test_nan_data_point(self):
-        # Needs to be cast to python int
+        # np.nan is converted to None
         result = datatables._safe(np.nan)
         self.assertIsNone(result)
 
@@ -641,3 +694,19 @@ class DatatablesUtilityTests(TestCase):
     def test_suffix(self):
         result = datatables._pretty(0.12, {'suffix': '€'})
         self.assertEqual('0.12€', result)
+
+    def test_format_value_does_not_prettify_none_string(self):
+        value = datatables._format_value('None', {})
+        self.assertDictEqual(value, {'value': 'None', 'display': 'None'})
+
+    def test_format_value_does_prettify_non_none_strings(self):
+        value = datatables._format_value('abcde', {})
+        self.assertDictEqual(value, {'value': 'abcde', 'display': 'abcde'})
+
+    def test_format_value_does_prettify_int_values(self):
+        value = datatables._format_value(123, {})
+        self.assertDictEqual(value, {'value': 123, 'display': '123'})
+
+    def test_format_value_does_prettify_pandas_date_objects(self):
+        value = datatables._format_value(pd.Timestamp(date(2016, 5, 10)), {})
+        self.assertDictEqual(value, {'value': '2016-05-10', 'display': '2016-05-10'})


### PR DESCRIPTION
This pull request fixes sorting issues when using Fireant's datatables JSON. Now, columns with prefix/suffix can be sorted, even if they contain null values.

If there is a null value, the prefix/suffix is also now not shown, as before for example 'None%' was shown.

This should solve issue https://github.com/kayak/fireant/issues/80