### PR TITLE
Added fix for operations not appearing when using widget groups

### DIFF
--- a/fireant/dashboards/managers.py
+++ b/fireant/dashboards/managers.py
@@ -2,6 +2,7 @@
 import pandas as pd
 
 from fireant import utils
+from fireant.slicer.managers import Totals
 
 
 class WidgetGroupManager(object):
@@ -25,24 +26,31 @@ class WidgetGroupManager(object):
         )
 
         return list(self._transform_widgets(self.widget_group.widgets, dataframe,
-                                            combined_dimensions, combined_references))
+                                            combined_dimensions, combined_references, combined_operations))
 
-    def _transform_widgets(self, widgets, dataframe, dimensions, references):
+    def _transform_widgets(self, widgets, dataframe, dimensions, references, operations):
         for widget in widgets:
             display_schema = self.widget_group.slicer.manager.display_schema(
                 metrics=widget.metrics,
                 dimensions=dimensions,
                 references=references,
+                operations=operations,
             )
+
+            # Temporary fix to enable operations to get output properly. Can removed when the Fireant API is refactored.
+            operation_columns = ['{}_{}'.format(operation.metric_key, operation.key)
+                                 for operation in operations if operation.key != Totals.key]
+
+            columns = utils.flatten(widget.metrics) + operation_columns
 
             if references:
                 # This escapes a pandas bug where a data frame subset of columns still returns the columns of the
                 # original data frame
                 reference_keys = [''] + [ref.key for ref in references]
-                subset_columns = pd.MultiIndex.from_product([reference_keys, utils.flatten(widget.metrics)])
+                subset_columns = pd.MultiIndex.from_product([reference_keys, columns])
                 subset = pd.DataFrame(dataframe[subset_columns], columns=subset_columns)
 
             else:
-                subset = dataframe[utils.flatten(widget.metrics)]
+                subset = dataframe[columns]
 
             yield widget.transformer.transform(subset, display_schema)

--- a/fireant/slicer/operations.py
+++ b/fireant/slicer/operations.py
@@ -51,7 +51,7 @@ class L1Loss(Operation):
 
 class L2Loss(L1Loss):
     """
-    Performs L1 Loss (mean sqr. error) operation on a metric using another metric as the target.
+    Performs L2 Loss (mean sqr. error) operation on a metric using another metric as the target.
     """
     key = 'l2loss'
     label = 'L2 loss'

--- a/fireant/tests/dashboards/test_dashboard_api.py
+++ b/fireant/tests/dashboards/test_dashboard_api.py
@@ -4,12 +4,12 @@ from unittest import TestCase
 
 import pandas as pd
 from mock import Mock, patch, call
+from pypika import Table, functions as fn
 
 from fireant.dashboards import *
 from fireant.slicer import *
 from fireant.slicer.references import WoW
 from fireant.tests.database.mock_database import TestDatabase
-from pypika import Table, functions as fn
 
 
 class DashboardTests(TestCase):
@@ -63,7 +63,8 @@ class DashboardTests(TestCase):
             operations=operations or [],
         )
 
-    def assert_result_transformed(self, widgets, dimensions, mock_transformer, tx_generator, references=[]):
+    def assert_result_transformed(self, widgets, dimensions, mock_transformer, tx_generator, references=[],
+                                  operations=[]):
         # Assert that there is a result for each widget
         self.assertEqual(len(widgets), len(list(tx_generator)))
 
@@ -72,6 +73,7 @@ class DashboardTests(TestCase):
                 dimensions=dimensions or [],
                 metrics=widget.metrics,
                 references=references,
+                operations=operations,
             ) for widget in widgets]
         )
 


### PR DESCRIPTION
Added temporary fix that stops operations from being left out of the output when you use the widget group manager. This can be removed when we refactor the Fireant API.