### PR TITLE
Refactored References to not require a selected dimension

### DIFF
--- a/fireant/slicer/references.py
+++ b/fireant/slicer/references.py
@@ -3,11 +3,25 @@ from pypika import Interval, functions as fn
 
 
 class Reference(object):
+    key = None
+    label = None
     interval = None
     modifier = None
 
     def __init__(self, element_key):
         self.element_key = element_key
+
+    def __eq__(self, other):
+        if not isinstance(other, Reference):
+            return False
+
+        return all([
+            self.key == other.key,
+            self.element_key == other.element_key,
+        ])
+
+    def __hash__(self):
+        return hash('%s:%s' % (self.key, self.element_key))
 
 
 class Delta(Reference):

--- a/fireant/tests/slicer/test_slicer_api.py
+++ b/fireant/tests/slicer/test_slicer_api.py
@@ -756,9 +756,16 @@ class SlicerSchemaReferenceTests(SlicerSchemaTests):
         self.assertEqual('SUM("test"."foo")', str(query_schema['metrics']['foo']))
         self.assertSetEqual({'date'}, set(query_schema['dimensions'].keys()))
         self.assertEqual('ROUND("test"."dt",\'DD\')', str(query_schema['dimensions']['date']))
+
+        # Cast definition to string for comparison
+        query_schema['references'][reference.key]['definition'] = str(
+            query_schema['references'][reference.key]['definition']
+        )
+
         self.assertDictEqual({
             reference.key: {
                 'dimension': reference.element_key,
+                'definition': '"test"."dt"',
                 'interval': reference.interval,
                 'modifier': reference.modifier,
             }
@@ -801,12 +808,12 @@ class SlicerSchemaReferenceTests(SlicerSchemaTests):
         self._reference_test_with_date(DeltaPercentage(YoY('date')))
 
     def test_reference_missing_dimension(self):
-        # Reference dimension is required in order to use a reference with it
+        # Throws exception when reference key is not a dimension key
         with self.assertRaises(SlicerException):
             self.test_slicer.manager.data_query_schema(
                 metrics=['foo'],
                 dimensions=[],
-                references=[WoW('date')],
+                references=[WoW('blahblah')],
             )
 
     def test_reference_wrong_dimension_type(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 six
 pandas==0.18.1
-pypika==0.1.12
+pypika==0.2.0
 vertica-python>=0.6
 matplotlib
 mock

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     install_requires=[
         'six',
         'pandas==0.18.1',
-        'pypika==0.1.12'
+        'pypika==0.2.0'
     ],
     tests_require=[
         'mock'


### PR DESCRIPTION
Fixes #91 Refactored references to no longer require that the reference dimension is selected.