### PR TITLE
Fix rounding issue with datetime intervals for dimensions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ To configure a slicer, instantiate a |ClassSlicer| with a list of |ClassMetric| 
         ],
 
         dimensions=[
-            # Datetime Dimensions are continuous and must be rounded to an interval
+            # Datetime Dimensions are continuous and must be truncated to an interval
             # like hour, day, week. Day is the default.
             DatetimeDimension('date', definition=analytics.dt),
 

--- a/docs/1_setup.rst
+++ b/docs/1_setup.rst
@@ -80,8 +80,8 @@ Instead of using one of the built in database connectors, you can provide your o
                 read_timeout=self.read_timeout,
             )
 
-        def round_date(self, field, interval):
-            return Round(field, interval)
+        def trunc_date(self, field, interval):
+            return Trunc(field, interval)
 
     hostage.settings = MyVertica(
         host='example.com',
@@ -91,7 +91,7 @@ Instead of using one of the built in database connectors, you can provide your o
         password='password123',
     )
 
-In a custom database connector, the ``connect`` function must be overridden to provide a ``connection`` to the database. The ``round_date`` function must also be overridden since there is no common way to round dates in SQL databases.
+In a custom database connector, the ``connect`` function must be overridden to provide a ``connection`` to the database. The ``trunc_date`` function must also be overridden since there is no common way to trunc dates in SQL databases.
 
 
 

--- a/fireant/database/database.py
+++ b/fireant/database/database.py
@@ -10,7 +10,7 @@ class Database(object):
     def connect(self):
         raise NotImplementedError
 
-    def round_date(self, field, interval):
+    def trunc_date(self, field, interval):
         raise NotImplementedError
 
     def fetch(self, query):

--- a/fireant/database/vertica.py
+++ b/fireant/database/vertica.py
@@ -3,11 +3,11 @@ from pypika import terms
 from . import Database
 
 
-class Round(terms.Function):
-    # Wrapper for Vertica ROUND function for rounding dates.
+class Trunc(terms.Function):
+    # Wrapper for Vertica TRUNC function for truncating dates.
 
     def __init__(self, field, date_format, alias=None):
-        super(Round, self).__init__('ROUND', field, date_format, alias=alias)
+        super(Trunc, self).__init__('TRUNC', field, date_format, alias=alias)
 
 
 class Vertica(Database):
@@ -32,5 +32,5 @@ class Vertica(Database):
             read_timeout=self.read_timeout,
         )
 
-    def round_date(self, field, interval):
-        return Round(field, interval)
+    def trunc_date(self, field, interval):
+        return Trunc(field, interval)

--- a/fireant/slicer/schemas.py
+++ b/fireant/slicer/schemas.py
@@ -117,7 +117,7 @@ class DatetimeDimension(ContinuousDimension):
 
     def schemas(self, *args, **kwargs):
         interval = args[0] if args else self.default_interval
-        return [(self.key, kwargs['database'].round_date(self.definition, interval.size))]
+        return [(self.key, kwargs['database'].trunc_date(self.definition, interval.size))]
 
 
 class CategoricalDimension(Dimension):

--- a/fireant/slicer/transformers/highcharts.py
+++ b/fireant/slicer/transformers/highcharts.py
@@ -235,15 +235,16 @@ class HighchartsColumnTransformer(HighchartsLineTransformer):
         metric_key = utils.slice_first(idx)
         return {
             'name': self._format_label(idx, dim_ordinal, display_schema, reference),
-            'data': [_format_data_point(x)
-                     for x in item
-                     if not (isinstance(x, (float, int)) and np.isnan(x))],
+            'data': self._format_data(item),
             'tooltip': self._format_tooltip(display_schema['metrics'][metric_key]),
             'yAxis': metrics.index(metric_key),
             'color': color,
         }
 
     def xaxis_options(self, dataframe, dim_ordinal, display_schema):
+        if isinstance(dataframe.index, pd.DatetimeIndex):
+            return {'type': 'datetime'}
+
         result = {'type': 'categorical'}
 
         categories = self._make_categories(dataframe, dim_ordinal, display_schema)
@@ -281,11 +282,6 @@ class HighchartsColumnTransformer(HighchartsLineTransformer):
         if 'display_field' in category_dimension:
             display_field = category_dimension['display_field']
             return dataframe.index.get_level_values(display_field).tolist()
-
-        if isinstance(dataframe.index, pd.DatetimeIndex):
-            if any(value.time() for value in dataframe.index):
-                return [value.isoformat() for value in dataframe.index]
-            return [value.strftime("%y-%m-%d") for value in dataframe.index]
 
         display_options = category_dimension.get('category_dimension', {})
         return [display_options.get(value, value) for value in dataframe.index]

--- a/fireant/tests/database/mock_database.py
+++ b/fireant/tests/database/mock_database.py
@@ -4,11 +4,11 @@ from pypika import terms
 from fireant.database import Database
 
 
-class Round(terms.Function):
-    # Wrapper for Vertica ROUND function for rounding dates.
+class Trunc(terms.Function):
+    # Wrapper for Vertica TRUNC function for truncating dates.
 
     def __init__(self, field, date_format, alias=None):
-        super(Round, self).__init__('ROUND', field, date_format, alias=alias)
+        super(Trunc, self).__init__('TRUNC', field, date_format, alias=alias)
 
 
 class TestDatabase(Database):
@@ -17,5 +17,5 @@ class TestDatabase(Database):
     def __init__(self, **kwargs):
         self.kwargs = kwargs
 
-    def round_date(self, field, interval):
-        return Round(field, interval)
+    def trunc_date(self, field, interval):
+        return Trunc(field, interval)

--- a/fireant/tests/database/test_databases.py
+++ b/fireant/tests/database/test_databases.py
@@ -40,4 +40,4 @@ class DatabaseTests(TestCase):
             db.connect()
 
         with self.assertRaises(NotImplementedError):
-            db.round_date(Field('abc'), 'DAY')
+            db.trunc_date(Field('abc'), 'DAY')

--- a/fireant/tests/database/test_vertica.py
+++ b/fireant/tests/database/test_vertica.py
@@ -33,7 +33,7 @@ class TestVertica(TestCase):
             user='test_user', password='password', read_timeout=None,
         )
 
-    def test_round_date(self):
-        result = Vertica().round_date(Field('date'), 'XX')
+    def test_trunc_date(self):
+        result = Vertica().trunc_date(Field('date'), 'XX')
 
-        self.assertEqual('ROUND("date",\'XX\')', str(result))
+        self.assertEqual('TRUNC("date",\'XX\')', str(result))

--- a/fireant/tests/slicer/test_slicer_api.py
+++ b/fireant/tests/slicer/test_slicer_api.py
@@ -170,7 +170,7 @@ class SlicerSchemaDimensionTests(SlicerSchemaTests):
         self.assertEqual('SUM("test"."foo")', str(query_schema['metrics']['foo']))
 
         self.assertSetEqual({'date'}, set(query_schema['dimensions'].keys()))
-        self.assertEqual('ROUND("test"."dt",\'DD\')', str(query_schema['dimensions']['date']))
+        self.assertEqual('TRUNC("test"."dt",\'DD\')', str(query_schema['dimensions']['date']))
 
     def test_date_dimension_custom_interval(self):
         query_schema = self.test_slicer.manager.data_query_schema(
@@ -186,7 +186,7 @@ class SlicerSchemaDimensionTests(SlicerSchemaTests):
         self.assertEqual('SUM("test"."foo")', str(query_schema['metrics']['foo']))
 
         self.assertSetEqual({'date'}, set(query_schema['dimensions'].keys()))
-        self.assertEqual('ROUND("test"."dt",\'WW\')', str(query_schema['dimensions']['date']))
+        self.assertEqual('TRUNC("test"."dt",\'WW\')', str(query_schema['dimensions']['date']))
 
     def test_numeric_dimension_default_interval(self):
         query_schema = self.test_slicer.manager.data_query_schema(
@@ -755,7 +755,7 @@ class SlicerSchemaReferenceTests(SlicerSchemaTests):
         self.assertSetEqual({'foo'}, set(query_schema['metrics'].keys()))
         self.assertEqual('SUM("test"."foo")', str(query_schema['metrics']['foo']))
         self.assertSetEqual({'date'}, set(query_schema['dimensions'].keys()))
-        self.assertEqual('ROUND("test"."dt",\'DD\')', str(query_schema['dimensions']['date']))
+        self.assertEqual('TRUNC("test"."dt",\'DD\')', str(query_schema['dimensions']['date']))
 
         # Cast definition to string for comparison
         query_schema['references'][reference.key]['definition'] = str(
@@ -841,7 +841,7 @@ class SlicerOperationSchemaTests(SlicerSchemaTests):
         self.assertEqual('SUM("test"."foo")', str(query_schema['metrics']['foo']))
 
         self.assertSetEqual({'date', 'locale', 'account', 'account_display'}, set(query_schema['dimensions'].keys()))
-        self.assertEqual('ROUND("test"."dt",\'DD\')', str(query_schema['dimensions']['date']))
+        self.assertEqual('TRUNC("test"."dt",\'DD\')', str(query_schema['dimensions']['date']))
 
         self.assertListEqual(['locale', 'account', 'account_display'], query_schema['rollup'])
 

--- a/fireant/tests/slicer/transformers/test_highcharts.py
+++ b/fireant/tests/slicer/transformers/test_highcharts.py
@@ -316,7 +316,7 @@ class HighchartsColumnTransformerTests(TestCase):
         result_data = [series['data'] for series in result['series']]
 
         for data, (_, item) in zip(result_data, df.iteritems()):
-            self.assertListEqual(list(item), data)
+            self.assertListEqual(list(item.iteritems()), data)
 
     def test_no_dims_multi_metric(self):
         df = mock_df.no_dims_multi_metric_df


### PR DESCRIPTION
This also makes Bar and Column charts use a datetime type for an axis when the axis data is a DatetimeIndex, therefore looking more consistent with how the Line chart format dates. 