### PR TITLE
Changed Vertica date trunc intervals for week and year

### DIFF
--- a/fireant/slicer/schemas.py
+++ b/fireant/slicer/schemas.py
@@ -106,10 +106,10 @@ class DatetimeInterval(object):
 class DatetimeDimension(ContinuousDimension):
     hour = DatetimeInterval('HH')
     day = DatetimeInterval('DD')
-    week = DatetimeInterval('WW')
+    week = DatetimeInterval('IW')
     month = DatetimeInterval('MM')
     quarter = DatetimeInterval('Q')
-    year = DatetimeInterval('IY')
+    year = DatetimeInterval('Y')
 
     def __init__(self, key, label=None, definition=None, default_interval=day, joins=None):
         super(DatetimeDimension, self).__init__(key=key, label=label, definition=definition, joins=joins,

--- a/fireant/tests/slicer/test_slicer_api.py
+++ b/fireant/tests/slicer/test_slicer_api.py
@@ -172,7 +172,7 @@ class SlicerSchemaDimensionTests(SlicerSchemaTests):
         self.assertSetEqual({'date'}, set(query_schema['dimensions'].keys()))
         self.assertEqual('TRUNC("test"."dt",\'DD\')', str(query_schema['dimensions']['date']))
 
-    def test_date_dimension_custom_interval(self):
+    def test_date_dimension_custom_week_interval(self):
         query_schema = self.test_slicer.manager.data_query_schema(
             metrics=['foo'],
             # TODO This could be improved by using an object
@@ -186,7 +186,47 @@ class SlicerSchemaDimensionTests(SlicerSchemaTests):
         self.assertEqual('SUM("test"."foo")', str(query_schema['metrics']['foo']))
 
         self.assertSetEqual({'date'}, set(query_schema['dimensions'].keys()))
-        self.assertEqual('TRUNC("test"."dt",\'WW\')', str(query_schema['dimensions']['date']))
+        self.assertEqual('TRUNC("test"."dt",\'IW\')', str(query_schema['dimensions']['date']))
+
+    def test_date_dimension_year_interval_uses_correct_trunc_statement(self):
+        query_schema = self.test_slicer.manager.data_query_schema(
+            metrics=['foo'],
+            dimensions=[('date', DatetimeDimension.year)],
+        )
+        self.assertSetEqual({'date'}, set(query_schema['dimensions'].keys()))
+        self.assertEqual('TRUNC("test"."dt",\'Y\')', str(query_schema['dimensions']['date']))
+
+    def test_date_dimension_quarter_interval_uses_correct_trunc_statement(self):
+        query_schema = self.test_slicer.manager.data_query_schema(
+            metrics=['foo'],
+            dimensions=[('date', DatetimeDimension.quarter)],
+        )
+        self.assertSetEqual({'date'}, set(query_schema['dimensions'].keys()))
+        self.assertEqual('TRUNC("test"."dt",\'Q\')', str(query_schema['dimensions']['date']))
+
+    def test_date_dimension_month_interval_uses_correct_trunc_statement(self):
+        query_schema = self.test_slicer.manager.data_query_schema(
+            metrics=['foo'],
+            dimensions=[('date', DatetimeDimension.month)],
+        )
+        self.assertSetEqual({'date'}, set(query_schema['dimensions'].keys()))
+        self.assertEqual('TRUNC("test"."dt",\'MM\')', str(query_schema['dimensions']['date']))
+
+    def test_date_dimension_day_interval_uses_correct_trunc_statement(self):
+        query_schema = self.test_slicer.manager.data_query_schema(
+            metrics=['foo'],
+            dimensions=[('date', DatetimeDimension.day)],
+        )
+        self.assertSetEqual({'date'}, set(query_schema['dimensions'].keys()))
+        self.assertEqual('TRUNC("test"."dt",\'DD\')', str(query_schema['dimensions']['date']))
+
+    def test_date_dimension_hour_interval_uses_correct_trunc_statement(self):
+        query_schema = self.test_slicer.manager.data_query_schema(
+            metrics=['foo'],
+            dimensions=[('date', DatetimeDimension.hour)],
+        )
+        self.assertSetEqual({'date'}, set(query_schema['dimensions'].keys()))
+        self.assertEqual('TRUNC("test"."dt",\'HH\')', str(query_schema['dimensions']['date']))
 
     def test_numeric_dimension_default_interval(self):
         query_schema = self.test_slicer.manager.data_query_schema(


### PR DESCRIPTION
Now we use IW for week (ISO week - weeks are Monday through to Sunday) and year to use Y (so years start on Jan 1st)

Further information: https://my.vertica.com/docs/7.1.x/HTML/Content/Authoring/SQLReferenceManual/Functions/Date-Time/TRUNCDateTime.htm