### PR TITLE
Fixes #129 Upgraded to latest pypika and fixed some bugs

### DIFF
--- a/fireant/slicer/managers.py
+++ b/fireant/slicer/managers.py
@@ -2,10 +2,10 @@
 
 import functools
 import itertools
+from collections import OrderedDict
+
 import numpy as np
 import pandas as pd
-
-from collections import OrderedDict
 
 from fireant import utils
 from fireant.slicer.operations import Totals
@@ -56,8 +56,7 @@ class SlicerManager(QueryManager, OperationManager):
         :return:
             A transformed response that is queried based on the slicer and the format.
         """
-        metrics = utils.filter_duplicates(metrics)
-        dimensions = utils.filter_duplicates(dimensions)
+        metrics, dimensions = map(utils.filter_duplicates, (metrics, dimensions))
 
         query_schema = self.data_query_schema(metrics=metrics, dimensions=dimensions,
                                               metric_filters=metric_filters, dimension_filters=dimension_filters,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 six
 pandas==0.19.2
-pypika>=0.2.4
+pypika==0.3.0
 vertica-python>=0.6
 matplotlib
 mock


### PR DESCRIPTION
- Fixed issues with how the pypika query was constructed with roll up
- Changed the default label value for slicer components to be the key (instead of formatting the key value)
- Upgraded to pypika 0.3.0