### PR TITLE
Added MySQL support to FireAnt

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[report]
+omit = */tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - "3.3"
     - "3.4"
     - "3.5"
+    - "3.6"
 
 install:
     - "python setup.py install"

--- a/README.rst
+++ b/README.rst
@@ -31,20 +31,25 @@ Slicers
 
 Slicers are the core component of |Brand|.  A Slicer is a configuration of two types of elements, metrics and dimensions, which represent what kinds of data exist and how the data can be organized.  A metric is a type of data, a measurement such as clicks and a dimension is a range over which metrics can be extended or grouped by.  Concretely, metrics represent the data *in* a chart or table and dimensions represent the rows and columns, axes, or categories.
 
-To configure a slicer, instantiate a |ClassSlicer| with a list of |ClassMetric| and |ClassDimension|.
+To configure a slicer, instantiate a |ClassSlicer| with either a |ClassVerticaDatabase| or a |ClassMySQLDatabase| and a |ClassTable| or |ClassTables|, with a list of |ClassMetric| and |ClassDimension|.
 
 .. _slicer_example_start:
 
 .. code-block:: python
 
     from fireant.slicer import *
+    from fireant.database import VerticaDatabase
     from pypika import Tables, functions as fn
 
+    vertica_database = VerticaDatabase(user='fakeuser', password='fakepassword')
     analytics, accounts = Tables('analytics', 'accounts')
 
     my_slicer = Slicer(
         # This is the primary database table that our slicer uses
         table=analytics,
+
+        # Define the database connection object
+        database=vertica_database,
 
         joins=[
             # Metrics and dimensions can use columns from joined tables by
@@ -258,7 +263,11 @@ Crafted with ♥ in Berlin.
 .. |ClassSection| replace:: ``fireant.dashboards.Section``
 
 .. |ClassDatabase| replace:: ``fireant.database.Database``
-.. |ClassVertica| replace:: ``fireant.database.Vertica``
+.. |ClassVerticaDatabase| replace:: ``fireant.database.VerticaDatabase``
+.. |ClassMySQLDatabase| replace:: ``fireant.database.MySQLDatabase``
+
+.. |ClassTable| replace:: `pypika.Table`
+.. |ClassTables| replace:: `pypika.Tables`
 
 .. _PyPika: https://github.com/kayak/pypika/
 .. _Pandas: http://pandas.pydata.org/

--- a/docs/1_setup.rst
+++ b/docs/1_setup.rst
@@ -18,6 +18,12 @@ Vertica
 
     pip install fireant[vertica]
 
+MySQL
+
+.. code-block:: bash
+
+    pip install fireant[mysql]
+
 Transformer add-ons
 -------------------
 
@@ -31,22 +37,39 @@ matplotlib
     pip install fireant[matplotlib]
 
 
-Once you have added |Brand| to your project, you must provide some additional settings.  A database connection is required in order to execute queries.  Currently, only Vertica is supported via ``vertica_python``, however future plans include support for various other databases such as MySQL and Oracle.
+Once you have added |Brand| to your project, you must provide some additional settings.  A database connection is required in order to execute queries.  Currently, only Vertica and MySQL are supported via ``vertica_python`` and ``pymysql`` respectively, however future plans include support for various other databases such as MSSQL, PostgreSQL and Oracle.
 
 To configure a database, instantiate a subclass of |ClassDatabase| and set it in ``fireant.settings``.  This must be only set once.
 
+Vertica
 
 .. code-block:: python
 
     import fireant.settings
-    from fireant.database import Vertica
+    from fireant.database import VerticaDatabase
 
-    fireant.settings = Vertica(
+    fireant.settings = VerticaDatabase(
         host='example.com',
         port=5433,
         database='example',
         user='user',
         password='password123',
+    )
+
+MySQL
+
+.. code-block:: python
+
+    import fireant.settings
+    from fireant.database import MySQLDatabase
+
+    fireant.settings = MySQLDatabase(
+        database='testdb',
+        host='mysql.example.com',
+        port=3308,
+        user='user',
+        password='password123',
+        charset='utf8mb4',
     )
 
 
@@ -91,7 +114,9 @@ Instead of using one of the built in database connectors, you can provide your o
         password='password123',
     )
 
-In a custom database connector, the ``connect`` function must be overridden to provide a ``connection`` to the database. The ``trunc_date`` function must also be overridden since there is no common way to trunc dates in SQL databases.
+In a custom database connector, the ``connect`` function must be overridden to provide a ``connection`` to the database.
+The ``trunc_date`` function must also be overridden since there is no common way to trunc dates in SQL databases.
+|ClassDatabase| also implements a default ``interval`` method which can be overridden if necessary.
 
 
 

--- a/docs/1_setup.rst
+++ b/docs/1_setup.rst
@@ -72,6 +72,7 @@ MySQL
         charset='utf8mb4',
     )
 
+To enable full MySQL support, please install the custom database and MySQL date truncate function found in fireant/scripts/mysql_functions.sql. Further information is provided in this script on how to grant permissions on this function to your MySQL users.
 
 Custom Database
 ---------------

--- a/docs/2_slicer.rst
+++ b/docs/2_slicer.rst
@@ -80,12 +80,15 @@ A join requires three parameters, a *key*, a *table*, and a *criterion*.  The *k
 
 
     from fireant.slicer import *
+    from fireant.database.vertica import VerticaDatabase
     from pypika import Tables, functions as fn
 
+    vertica_database = VerticaDatabase(user='fakeuser', password='fakepassword')
     analytics, customers = Tables('analytics', 'customers')
 
     slicer = Slicer(
-        analytics,
+        table=analytics,
+        database=vertica_database,
 
         joins=[
             Join('customers', customers, analytics.customer_id == customers.id),
@@ -345,12 +348,12 @@ For each |FeatureReference|, there are the following variations:
 
 .. code-block:: python
 
-    from fireant.slicer.references import WoW, DeltaMoM, DeltaQoQ
+    from fireant.slicer.references import WoW, MoM, QoQ, Delta, DeltaPercentage
 
     slicer.notebooks.column_index_table(
         metrics=['clicks', 'conversions'],
         dimensions=['date'],
-        references=[WoW('date'), DeltaMoM('date'), DeltaQoQ('date')],
+        references=[WoW('date'), Delta(MoM('date')), DeltaPercentage(QoQ('date'))],
     )
 
 .. note::
@@ -367,6 +370,10 @@ Totals
 """"""
 
 Totals adds ``ROLLUP`` to the SQL query to load the data and aggregated across dimensions.  It requires one or more dimension keys as parameters for the dimensions that should be totaled.  The below example will add an extra line with the total clicks and conversions for each date in addition to the three lines for each device type, desktop, mobile and tablet.
+
+.. note::
+
+    Please note, the ROLLUP functionality is not currently supported for MySQL, as it implements ROLLUP differently to many Database platforms. An exception will be raised if you try and use this.
 
 .. code-block:: python
 

--- a/fireant/database/__init__.py
+++ b/fireant/database/__init__.py
@@ -1,3 +1,6 @@
 # coding: utf-8
 
 from .database import Database
+from .mysql import MySQLDatabase
+from .vertica import (Vertica,
+                      VerticaDatabase)

--- a/fireant/database/database.py
+++ b/fireant/database/database.py
@@ -2,16 +2,21 @@
 
 import pandas as pd
 
+from pypika import Interval, Query
+
 
 class Database(object):
+    # The pypika query class to use for constructing queries
+    query_cls = Query
+
     def connect(self):
         raise NotImplementedError
 
     def trunc_date(self, field, interval):
         raise NotImplementedError
 
-    def interval(self, years=0, months=0, days=0, hours=0, minutes=0, seconds=0, microseconds=0, quarters=0, weeks=0):
-        raise NotImplementedError
+    def interval(self, **kwargs):
+        return Interval(**kwargs)
 
     def fetch(self, query):
         with self.connect() as connection:

--- a/fireant/database/mysql.py
+++ b/fireant/database/mysql.py
@@ -1,0 +1,57 @@
+# coding: utf-8
+import pandas as pd
+from pypika import (MySQLQuery,
+                    terms)
+from pypika.terms import Interval
+
+from fireant.database import Database
+
+
+class Trunc(terms.Function):
+    """
+    Wrapper for a custom MySQL TRUNC function (installed via a custon FireAnt MySQL script
+    """
+
+    def __init__(self, field, date_format, alias=None):
+        super(Trunc, self).__init__('TRUNC', field, date_format, alias=alias)
+
+
+class MySQLDatabase(Database):
+    """
+    MySQL client that uses the PyMySQL module.
+    """
+    # The pypika query class to use for constructing queries
+    query_cls = MySQLQuery
+
+    def __init__(self, database, host='localhost', port=3306,
+                 user=None, password=None, charset='utf8mb4'):
+        self.host = host
+        self.port = port
+        self.database = database
+        self.user = user
+        self.password = password
+        self.charset = charset
+
+    def connect(self):
+        import pymysql
+
+        return pymysql.connect(
+            host=self.host, port=self.port, db=self.database,
+            user=self.user, password=self.password,
+            charset=self.charset,
+            cursorclass=pymysql.cursors.Cursor,
+        )
+
+    def fetch(self, query):
+        with self.connect().cursor() as cursor:
+            cursor.execute(query)
+            return cursor.fetchall()
+
+    def fetch_dataframe(self, query):
+        return pd.read_sql(query, self.connect())
+
+    def trunc_date(self, field, interval):
+        return Trunc(field, interval)
+
+    def interval(self, **kwargs):
+        return Interval(**kwargs)

--- a/fireant/database/mysql.py
+++ b/fireant/database/mysql.py
@@ -13,7 +13,7 @@ class Trunc(terms.Function):
     """
 
     def __init__(self, field, date_format, alias=None):
-        super(Trunc, self).__init__('TRUNC', field, date_format, alias=alias)
+        super(Trunc, self).__init__('dashmore.TRUNC', field, date_format, alias=alias)
 
 
 class MySQLDatabase(Database):
@@ -23,7 +23,7 @@ class MySQLDatabase(Database):
     # The pypika query class to use for constructing queries
     query_cls = MySQLQuery
 
-    def __init__(self, database, host='localhost', port=3306,
+    def __init__(self, database=None, host='localhost', port=3306,
                  user=None, password=None, charset='utf8mb4'):
         self.host = host
         self.port = port

--- a/fireant/slicer/managers.py
+++ b/fireant/slicer/managers.py
@@ -23,6 +23,7 @@ class SlicerManager(QueryManager, OperationManager):
         """
         :param slicer:
         """
+        super(SlicerManager, self).__init__(database=slicer.database)
         self.slicer = slicer
 
     def data(self, metrics=(), dimensions=(),

--- a/fireant/slicer/queries.py
+++ b/fireant/slicer/queries.py
@@ -5,15 +5,25 @@ import time
 from itertools import chain
 
 import pandas as pd
+from pypika import JoinType, MySQLQuery
 
 from fireant import utils
-from fireant.slicer.references import YoY, Delta, DeltaPercentage
-from pypika import Query, JoinType
+from fireant.slicer.references import (YoY,
+                                       Delta,
+                                       DeltaPercentage)
 
 query_logger = logging.getLogger('fireant.query_log$')
 
 
+class QueryNotSupportedError(Exception):
+    pass
+
+
 class QueryManager(object):
+    def __init__(self, database):
+        # Get the correct pypika database query class
+        self.query_cls = database.query_cls
+
     def query_data(self, database, table, joins=None,
                    metrics=None, dimensions=None,
                    mfilters=None, dfilters=None,
@@ -105,6 +115,11 @@ class QueryManager(object):
         :return:
             A pd.DataFrame indexed by the provided dimensions paramaters containing columns for each metrics parameter.
         """
+        if rollup and database.query_cls is MySQLQuery:
+            # MySQL doesn't currently support query rollups in the same way as Vertica, Oracle etc.
+            # We therefore don't support it for now.
+            raise QueryNotSupportedError("MySQL currently doesn't support ROLLUP operations!")
+
         query = self._build_data_query(
             database, table, joins, metrics, dimensions, dfilters, mfilters, references, rollup
         )
@@ -180,8 +195,8 @@ class QueryManager(object):
 
     def _build_reference_query(self, query, database, references, table, joins, metrics, dimensions, dfilters,
                                mfilters, rollup):
-        wrapper_query = Query.from_(query).select(*[query.field(key).as_(key)
-                                                    for key in list(dimensions.keys()) + list(metrics.keys())])
+        wrapper_query = self.query_cls.from_(query).select(*[query.field(key).as_(key)
+                                                             for key in list(dimensions.keys()) + list(metrics.keys())])
 
         for reference_key, schema in references.items():
             dimension_key, interval = schema['dimension'], schema['interval']
@@ -223,7 +238,7 @@ class QueryManager(object):
         return self._add_sorting(wrapper_query, [query.field(dkey) for dkey in dimensions.keys()])
 
     def _build_dimension_query(self, table, joins, dimensions, filters, limit=None):
-        query = Query.from_(table).distinct()
+        query = self.query_cls.from_(table).distinct()
         query = self._add_joins(joins, query)
         query = self._add_filters(query, filters, [])
 
@@ -236,7 +251,7 @@ class QueryManager(object):
         return query
 
     def _build_query_inner(self, table, joins, metrics, dimensions, dfilters, mfilters, rollup):
-        query = Query.from_(table)
+        query = self.query_cls.from_(table)
         query = self._add_joins(joins, query)
         query = self._select_dimensions(query, dimensions, rollup)
         query = self._select_metrics(query, metrics)

--- a/fireant/slicer/queries.py
+++ b/fireant/slicer/queries.py
@@ -113,7 +113,7 @@ class QueryManager(object):
                 moved after the non-ROLLUP dimensions.
 
         :return:
-            A pd.DataFrame indexed by the provided dimensions paramaters containing columns for each metrics parameter.
+            A pd.DataFrame indexed by the provided dimensions parameters containing columns for each metrics parameter.
         """
         if rollup and database.query_cls is MySQLQuery:
             # MySQL doesn't currently support query rollups in the same way as Vertica, Oracle etc.

--- a/fireant/slicer/queries.py
+++ b/fireant/slicer/queries.py
@@ -57,7 +57,7 @@ class QueryManager(object):
             than one value is given, then a pd.DataFrame with a multi-index will be returned.  The key used will match
             the corresponding index level in the returned DataFrame.
 
-            If a dict is used instead of an OrderedDict, then the index levels cannot be guarenteed, so in most cases an
+            If a dict is used instead of an OrderedDict, then the index levels cannot be guaranteed, so in most cases an
             OrderedDict should be used.
 
         :param mfilters:

--- a/fireant/slicer/schemas.py
+++ b/fireant/slicer/schemas.py
@@ -104,12 +104,12 @@ class DatetimeInterval(object):
 
 
 class DatetimeDimension(ContinuousDimension):
-    hour = DatetimeInterval('HH')
-    day = DatetimeInterval('DD')
-    week = DatetimeInterval('IW')
-    month = DatetimeInterval('MM')
-    quarter = DatetimeInterval('Q')
-    year = DatetimeInterval('Y')
+    hour = 'hour'
+    day = 'day'
+    week = 'week'
+    month = 'month'
+    quarter = 'quarter'
+    year = 'year'
 
     def __init__(self, key, label=None, definition=None, default_interval=day, joins=None):
         super(DatetimeDimension, self).__init__(key=key, label=label, definition=definition, joins=joins,
@@ -117,7 +117,7 @@ class DatetimeDimension(ContinuousDimension):
 
     def schemas(self, *args, **kwargs):
         interval = args[0] if args else self.default_interval
-        return [(self.key, kwargs['database'].trunc_date(self.definition, interval.size))]
+        return [(self.key, kwargs['database'].trunc_date(self.definition, interval))]
 
 
 class CategoricalDimension(Dimension):

--- a/fireant/tests/database/mock_database.py
+++ b/fireant/tests/database/mock_database.py
@@ -1,24 +1,9 @@
 # coding: utf-8
-from pypika import terms
-from fireant.database import Database
-from fireant.database.vertica import Interval
+from fireant.database.vertica import VerticaDatabase
 
 
-class Trunc(terms.Function):
-    # Wrapper for Vertica TRUNC function for truncating dates.
-
-    def __init__(self, field, date_format, alias=None):
-        super(Trunc, self).__init__('TRUNC', field, date_format, alias=alias)
-
-
-class TestDatabase(Database):
+class TestDatabase(VerticaDatabase):
     # Vertica client that uses the vertica_python driver.
 
-    def __init__(self, **kwargs):
-        self.kwargs = kwargs
-
-    def trunc_date(self, field, interval):
-        return Trunc(field, interval)
-
-    def interval(self, **kwargs):
-        return Interval(**kwargs)
+    def connect(self):
+        pass

--- a/fireant/tests/database/test_mysql.py
+++ b/fireant/tests/database/test_mysql.py
@@ -36,29 +36,29 @@ class TestMySQLDatabase(TestCase):
     def test_trunc_hour(self):
         result = MySQLDatabase(database='testdb').trunc_date(Field('date'), 'hour')
 
-        self.assertEqual('TRUNC("date",\'hour\')', str(result))
+        self.assertEqual('dashmore.TRUNC("date",\'hour\')', str(result))
 
     def test_trunc_day(self):
         result = MySQLDatabase(database='testdb').trunc_date(Field('date'), 'day')
 
-        self.assertEqual('TRUNC("date",\'day\')', str(result))
+        self.assertEqual('dashmore.TRUNC("date",\'day\')', str(result))
 
     def test_trunc_week(self):
         result = MySQLDatabase(database='testdb').trunc_date(Field('date'), 'week')
 
-        self.assertEqual('TRUNC("date",\'week\')', str(result))
+        self.assertEqual('dashmore.TRUNC("date",\'week\')', str(result))
 
     def test_trunc_month(self):
         result = MySQLDatabase(database='testdb').trunc_date(Field('date'), 'month')
 
-        self.assertEqual('TRUNC("date",\'month\')', str(result))
+        self.assertEqual('dashmore.TRUNC("date",\'month\')', str(result))
 
     def test_trunc_quarter(self):
         result = MySQLDatabase(database='testdb').trunc_date(Field('date'), 'quarter')
 
-        self.assertEqual('TRUNC("date",\'quarter\')', str(result))
+        self.assertEqual('dashmore.TRUNC("date",\'quarter\')', str(result))
 
     def test_trunc_year(self):
         result = MySQLDatabase(database='testdb').trunc_date(Field('date'), 'year')
 
-        self.assertEqual('TRUNC("date",\'year\')', str(result))
+        self.assertEqual('dashmore.TRUNC("date",\'year\')', str(result))

--- a/fireant/tests/database/test_mysql.py
+++ b/fireant/tests/database/test_mysql.py
@@ -1,0 +1,64 @@
+# coding: utf-8
+from unittest import TestCase
+
+from mock import patch, Mock, ANY
+from pypika import Field
+
+from fireant.database import MySQLDatabase
+
+
+class TestMySQLDatabase(TestCase):
+
+    def test_defaults(self):
+        mysql = MySQLDatabase(database='testdb')
+
+        self.assertEqual('localhost', mysql.host)
+        self.assertEqual(3306, mysql.port)
+        self.assertEqual('utf8mb4', mysql.charset)
+        self.assertIsNone(mysql.user)
+        self.assertIsNone(mysql.password)
+
+    def test_connect(self):
+        mock_pymysql = Mock()
+        with patch.dict('sys.modules', pymysql=mock_pymysql):
+            mock_pymysql.connect.return_value = 'OK'
+
+            mysql = MySQLDatabase(database='test_database', host='test_host', port=1234,
+                                  user='test_user', password='password')
+            result = mysql.connect()
+
+        self.assertEqual('OK', result)
+        mock_pymysql.connect.assert_called_once_with(
+            host='test_host', port=1234, db='test_database', charset='utf8mb4',
+            user='test_user', password='password', cursorclass=ANY
+        )
+
+    def test_trunc_hour(self):
+        result = MySQLDatabase(database='testdb').trunc_date(Field('date'), 'hour')
+
+        self.assertEqual('TRUNC("date",\'hour\')', str(result))
+
+    def test_trunc_day(self):
+        result = MySQLDatabase(database='testdb').trunc_date(Field('date'), 'day')
+
+        self.assertEqual('TRUNC("date",\'day\')', str(result))
+
+    def test_trunc_week(self):
+        result = MySQLDatabase(database='testdb').trunc_date(Field('date'), 'week')
+
+        self.assertEqual('TRUNC("date",\'week\')', str(result))
+
+    def test_trunc_month(self):
+        result = MySQLDatabase(database='testdb').trunc_date(Field('date'), 'month')
+
+        self.assertEqual('TRUNC("date",\'month\')', str(result))
+
+    def test_trunc_quarter(self):
+        result = MySQLDatabase(database='testdb').trunc_date(Field('date'), 'quarter')
+
+        self.assertEqual('TRUNC("date",\'quarter\')', str(result))
+
+    def test_trunc_year(self):
+        result = MySQLDatabase(database='testdb').trunc_date(Field('date'), 'year')
+
+        self.assertEqual('TRUNC("date",\'year\')', str(result))

--- a/fireant/tests/database/test_vertica.py
+++ b/fireant/tests/database/test_vertica.py
@@ -3,13 +3,14 @@ from unittest import TestCase
 
 from mock import patch, Mock
 
-from fireant.database.vertica import Vertica
+from fireant.database import VerticaDatabase
 from pypika import Field
 
 
 class TestVertica(TestCase):
+
     def test_defaults(self):
-        vertica = Vertica()
+        vertica = VerticaDatabase()
 
         self.assertEqual('localhost', vertica.host)
         self.assertEqual(5433, vertica.port)
@@ -23,7 +24,7 @@ class TestVertica(TestCase):
         with patch.dict('sys.modules', vertica_python=mock_vertica):
             mock_vertica.connect.return_value = 'OK'
 
-            vertica = Vertica('test_host', 1234, 'test_database',
+            vertica = VerticaDatabase('test_host', 1234, 'test_database',
                               'test_user', 'password')
             result = vertica.connect()
 
@@ -33,7 +34,27 @@ class TestVertica(TestCase):
             user='test_user', password='password', read_timeout=None,
         )
 
-    def test_trunc_date(self):
-        result = Vertica().trunc_date(Field('date'), 'XX')
+    def test_trunc_hour(self):
+        result = VerticaDatabase().trunc_date(Field('date'), 'hour')
 
-        self.assertEqual('TRUNC("date",\'XX\')', str(result))
+        self.assertEqual('TRUNC("date",\'HH\')', str(result))
+
+    def test_trunc_day(self):
+        result = VerticaDatabase().trunc_date(Field('date'), 'day')
+
+        self.assertEqual('TRUNC("date",\'DD\')', str(result))
+
+    def test_trunc_week(self):
+        result = VerticaDatabase().trunc_date(Field('date'), 'week')
+
+        self.assertEqual('TRUNC("date",\'IW\')', str(result))
+
+    def test_trunc_quarter(self):
+        result = VerticaDatabase().trunc_date(Field('date'), 'quarter')
+
+        self.assertEqual('TRUNC("date",\'Q\')', str(result))
+
+    def test_trunc_year(self):
+        result = VerticaDatabase().trunc_date(Field('date'), 'year')
+
+        self.assertEqual('TRUNC("date",\'Y\')', str(result))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 six
 pandas==0.19.2
-pypika==0.3.0
+pypika>=0.4,<=0.4.99
+pymysql==0.7.11
 vertica-python>=0.6
 matplotlib
 mock

--- a/scripts/mysql_functions.sql
+++ b/scripts/mysql_functions.sql
@@ -9,7 +9,7 @@ Valid formats:
   - quarter - To the start of the quarter
   - year - To the start of the year
 
-Called with TRUNC(<date>, <format required>) -> returns a string
+Called with TRUNC(<date>, <format required>) -> returns a timestamp
 
 
 Note: A new database/schema will be created called 'dashmore' which will store the new function. All database users that
@@ -28,30 +28,28 @@ CREATE DATABASE IF NOT EXISTS dashmore DEFAULT CHARACTER SET = 'utf8' DEFAULT CO
 DROP FUNCTION IF EXISTS dashmore.TRUNC$$
 
 CREATE FUNCTION dashmore.TRUNC(DT  DATETIME,
-                      FMT ENUM ('hour', 'day', 'week', 'month', 'quarter', 'year')) RETURNS NVARCHAR(19)
+                      FMT ENUM ('hour', 'day', 'week', 'month', 'quarter', 'year')) RETURNS TIMESTAMP
 
   BEGIN
     DECLARE NEW_DT NVARCHAR(19);
 
     CASE FMT
       WHEN 'hour'
-      THEN SET NEW_DT = DATE_FORMAT(DT, '%Y-%m-%d %H:00:00');
+      THEN SET NEW_DT = TIMESTAMP(DATE_FORMAT(DT, '%Y-%m-%d %H:00:00'));
       WHEN 'day'
-      THEN SET NEW_DT = DATE_FORMAT(DT, '%Y-%m-%d 00:00:00');
+      THEN SET NEW_DT = TIMESTAMP(DATE_FORMAT(DT, '%Y-%m-%d 00:00:00'));
       WHEN 'week'
-      THEN SET NEW_DT = DATE_FORMAT(DATE_SUB(DT, INTERVAL WEEKDAY(DT) DAY), '%Y-%m-%d 00:00:00');
+      THEN SET NEW_DT = TIMESTAMP(DATE_FORMAT(DATE_SUB(DT, INTERVAL WEEKDAY(DT) DAY), '%Y-%m-%d 00:00:00'));
       WHEN 'month'
-      THEN SET NEW_DT = DATE_FORMAT(DT, '%Y-%m-01');
+      THEN SET NEW_DT = TIMESTAMP(DATE_FORMAT(DT, '%Y-%m-01'));
       WHEN 'quarter'
-      THEN SET NEW_DT = MAKEDATE(YEAR(TIMESTAMP(DT)), 1) + INTERVAL QUARTER(TIMESTAMP(DT)) QUARTER - INTERVAL 1 QUARTER;
+      THEN SET NEW_DT = TIMESTAMP(MAKEDATE(YEAR(TIMESTAMP(DT)), 1) + INTERVAL QUARTER(TIMESTAMP(DT)) QUARTER - INTERVAL 1 QUARTER);
       WHEN 'year'
-      THEN SET NEW_DT = DATE_FORMAT(DT, '%Y-01-01');
-    ELSE SET NEW_DT = DT;
+      THEN SET NEW_DT = TIMESTAMP(DATE_FORMAT(DT, '%Y-01-01'));
+    ELSE SET NEW_DT = TIMESTAMP(DT);
     END CASE;
 
     RETURN NEW_DT;
   END$$
 
 DELIMITER ;
-
-

--- a/scripts/mysql_functions.sql
+++ b/scripts/mysql_functions.sql
@@ -1,11 +1,5 @@
-DELIMITER $$
-
-DROP FUNCTION IF EXISTS TRUNC$$
-
 /*
 Implements the Vertica TRUNC function in MySQL
-
-Called with TRUNC(<date>, <format required>) -> returns a string
 
 Valid formats:
   - hour - To the start of the hour
@@ -15,8 +9,25 @@ Valid formats:
   - quarter - To the start of the quarter
   - year - To the start of the year
 
+Called with TRUNC(<date>, <format required>) -> returns a string
+
+
+Note: A new database/schema will be created called 'dashmore' which will store the new function. All database users that
+Dashmore will use to query data with need to have permissions to execute this function.
+
+To give permissions, use the following query for each MySQL user you want to use to query data through Dashmore:
+
+  GRANT EXECUTE ON FUNCTION dashmore.TRUNC to '<user>'@'<host>';
+
 */
-CREATE FUNCTION TRUNC(DT  DATETIME,
+
+DELIMITER $$
+
+CREATE DATABASE IF NOT EXISTS dashmore DEFAULT CHARACTER SET = 'utf8' DEFAULT COLLATE 'utf8_general_ci'$$
+
+DROP FUNCTION IF EXISTS dashmore.TRUNC$$
+
+CREATE FUNCTION dashmore.TRUNC(DT  DATETIME,
                       FMT ENUM ('hour', 'day', 'week', 'month', 'quarter', 'year')) RETURNS NVARCHAR(19)
 
   BEGIN

--- a/scripts/mysql_functions.sql
+++ b/scripts/mysql_functions.sql
@@ -1,0 +1,46 @@
+DELIMITER $$
+
+DROP FUNCTION IF EXISTS TRUNC$$
+
+/*
+Implements the Vertica TRUNC function in MySQL
+
+Called with TRUNC(<date>, <format required>) -> returns a string
+
+Valid formats:
+  - hour - To the start of the hour
+  - day - To the start of the day (00:00:00)
+  - week - To the monday in the week
+  - month - To the start of the month
+  - quarter - To the start of the quarter
+  - year - To the start of the year
+
+*/
+CREATE FUNCTION TRUNC(DT  DATETIME,
+                      FMT ENUM ('hour', 'day', 'week', 'month', 'quarter', 'year')) RETURNS NVARCHAR(19)
+
+  BEGIN
+    DECLARE NEW_DT NVARCHAR(19);
+
+    CASE FMT
+      WHEN 'hour'
+      THEN SET NEW_DT = DATE_FORMAT(DT, '%Y-%m-%d %H:00:00');
+      WHEN 'day'
+      THEN SET NEW_DT = DATE_FORMAT(DT, '%Y-%m-%d 00:00:00');
+      WHEN 'week'
+      THEN SET NEW_DT = DATE_FORMAT(DATE_SUB(DT, INTERVAL WEEKDAY(DT) DAY), '%Y-%m-%d 00:00:00');
+      WHEN 'month'
+      THEN SET NEW_DT = DATE_FORMAT(DT, '%Y-%m-01');
+      WHEN 'quarter'
+      THEN SET NEW_DT = MAKEDATE(YEAR(TIMESTAMP(DT)), 1) + INTERVAL QUARTER(TIMESTAMP(DT)) QUARTER - INTERVAL 1 QUARTER;
+      WHEN 'year'
+      THEN SET NEW_DT = DATE_FORMAT(DT, '%Y-01-01');
+    ELSE SET NEW_DT = DT;
+    END CASE;
+
+    RETURN NEW_DT;
+  END$$
+
+DELIMITER ;
+
+

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,12 @@ setup(
     # License
     license='Apache License Version 2.0',
 
-    packages=['fireant', 'fireant.database', 'fireant.dashboards', 'fireant.slicer', 'fireant.slicer.transformers'],
+    packages=['fireant',
+              'fireant.database',
+              'fireant.dashboards',
+              'fireant.slicer',
+              'fireant.slicer.transformers',
+              'scripts'],
 
     # Include additional files into the package
     include_package_data=True,
@@ -53,14 +58,16 @@ setup(
     install_requires=[
         'six',
         'pandas==0.19.2',
-        'pypika==0.3.0',
-        'vertica-python>=0.6'
+        'pypika>=0.4,<=0.4.99',
+        'vertica-python>=0.6',
+        'pymysql==0.7.11'
     ],
     tests_require=[
         'mock'
     ],
     extras_require={
         'vertica': ['vertica-python>=0.6'],
+        'mysql': ['pymysql==0.7.11'],
         'matplotlib': ['matplotlib'],
     },
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35
+envlist = py27,py33,py34,py35,py36
 [testenv]
 deps = pypika
 commands = setup.py build test


### PR DESCRIPTION

- Added MySQL database class.
- Deprecated the old Vertica class with a warning, and added new VerticaDatabase class to match the new naming standard.
- Fixed a number of errors in the documentation and updated the docs with information about the new MySQLDatabase class.
- Changed PyPika to install the latest patch version.
