### PR TITLE
Fix col index tables

### DIFF
--- a/fireant/slicer/widgets/datatables.py
+++ b/fireant/slicer/widgets/datatables.py
@@ -1,5 +1,3 @@
-import itertools
-
 import pandas as pd
 
 from fireant import (
@@ -68,8 +66,8 @@ def _render_dimensional_metric_cell(row_data: pd.Series, metric: Metric):
 
     # Group by the last dimension, drop it, and fill the dict with either the raw metric values or the next level of
     # dicts.
-    for key, next_row in row_data.groupby(level=-1):
-        next_row.reset_index(level=-1, drop=True, inplace=True)
+    for key, next_row in row_data.groupby(level=1):
+        next_row.reset_index(level=1, drop=True, inplace=True)
 
         df_key = format_key(metric.key)
         level[key] = _render_dimensional_metric_cell(next_row, metric) \
@@ -214,14 +212,15 @@ class DataTablesJS(TransformableWidget):
         :return:
         """
         columns = []
+        single_metric = 1 == len(self.items)
         for metric in self.items:
-            dimension_value_sets = [list(level)
-                                    for level in df_columns.levels[1:]]
+            dimension_value_sets = [row[1:]
+                                    for row in list(df_columns)]
 
-            for dimension_values in itertools.product(*dimension_value_sets):
+            for dimension_values in dimension_value_sets:
                 for reference in [None] + references:
                     key = reference_key(metric, reference)
-                    title = render_column_label(dimension_values, metric, reference)
+                    title = render_column_label(dimension_values, None if single_metric else metric, reference)
                     data = '.'.join([key] + [str(x) for x in dimension_values])
 
                     columns.append(dict(title=title,

--- a/fireant/slicer/widgets/helpers.py
+++ b/fireant/slicer/widgets/helpers.py
@@ -61,7 +61,9 @@ def dimensional_metric_label(dimensions, dimension_display_values):
             a tuple of dimension values. Can be zero-length or longer.
         :return:
         """
-        used_dimensions = dimensions if metric is None else dimensions[1:]
+        num_used_dimensions = len(dimensions) - len(dimension_values)
+        used_dimensions = dimensions[num_used_dimensions:]
+
         dimension_values = utils.wrap_list(dimension_values)
         dimension_labels = [utils.deep_get(dimension_display_values,
                                            [utils.format_key(dimension.key), dimension_value],
@@ -70,12 +72,16 @@ def dimensional_metric_label(dimensions, dimension_display_values):
                             else 'Totals'
                             for dimension, dimension_value in zip(used_dimensions, dimension_values)]
 
+        label = ", ".join(dimension_labels)
+
         if metric is None:
-            return ", ".join(dimension_labels)
+            if reference is not None:
+                return '{} ({})'.format(label, reference.label)
+            return label
 
         if dimension_labels:
             return '{} ({})'.format(reference_label(metric, reference),
-                                    ', '.join(dimension_labels))
+                                    label)
 
         return reference_label(metric, reference)
 

--- a/fireant/tests/slicer/widgets/test_datatables.py
+++ b/fireant/tests/slicer/widgets/test_datatables.py
@@ -587,15 +587,15 @@ class DataTablesTransformerTests(TestCase):
                 'render': {'_': 'value'},
             }, {
                 'data': 'wins.d',
-                'title': 'Wins (Democrat)',
+                'title': 'Democrat',
                 'render': {'_': 'value', 'display': 'display'},
             }, {
                 'data': 'wins.i',
-                'title': 'Wins (Independent)',
+                'title': 'Independent',
                 'render': {'_': 'value', 'display': 'display'},
             }, {
                 'data': 'wins.r',
-                'title': 'Wins (Republican)',
+                'title': 'Republican',
                 'render': {'_': 'value', 'display': 'display'},
             }],
             'data': [{
@@ -654,11 +654,11 @@ class DataTablesTransformerTests(TestCase):
                 'render': {'_': 'value'},
             }, {
                 'data': 'votes.1',
-                'title': 'Votes (Texas)',
+                'title': 'Texas',
                 'render': {'_': 'value', 'display': 'display'},
             }, {
                 'data': 'votes.2',
-                'title': 'Votes (California)',
+                'title': 'California',
                 'render': {'_': 'value', 'display': 'display'},
             }],
             'data': [{


### PR DESCRIPTION
Data tables would break any time a third dimension was added for two bugs
- The order of the dimensions did not match in the column definition and the data 
- A column definition was created for every combination of dimension values instead of just the ones in the data frame.