### PR TITLE
Fixed the metric format function to correctly handle for inf and nan

### DIFF
--- a/fireant/formats.py
+++ b/fireant/formats.py
@@ -111,6 +111,9 @@ def metric_display(value, prefix=None, suffix=None, precision=None):
     :return:
         A formatted string containing the display value for the metric.
     """
+    if pd.isnull(value) or value in {np.inf, -np.inf}:
+        return ''
+
     if isinstance(value, float):
         if precision is not None:
             float_format = '%d' if precision == 0 else '%.{}f'.format(precision)
@@ -128,9 +131,6 @@ def metric_display(value, prefix=None, suffix=None, precision=None):
     if isinstance(value, int):
         float_format = '%d'
         value = locale.format(float_format, value, grouping=True)
-
-    if value is INFINITY:
-        return "∞"
 
     return '{prefix}{value}{suffix}'.format(
           prefix=prefix or '',

--- a/fireant/slicer/dimensions.py
+++ b/fireant/slicer/dimensions.py
@@ -316,11 +316,21 @@ class PatternDimension(PatternFilterableMixin, Dimension):
         :return:
             A copy of the dimension with the interval set.
         """
+        self.groups = groups
+
         cases = Case()
         for group in groups:
             cases = cases.when(self.field.like(group), group)
 
         self.definition = cases.else_(self._DEFAULT)
+
+    def __repr__(self):
+        dimension = super().__repr__()
+
+        if self.groups is not None:
+            return '{}({})'.format(dimension, self.groups)
+
+        return dimension
 
 
 class TotalsDimension(Dimension):

--- a/fireant/tests/slicer/widgets/test_pandas.py
+++ b/fireant/tests/slicer/widgets/test_pandas.py
@@ -1,5 +1,7 @@
+import copy
 from unittest import TestCase
 
+import numpy as np
 import pandas as pd
 import pandas.testing
 
@@ -195,5 +197,65 @@ class DataTablesTransformerTests(TestCase):
                                  for x in expected[fm('votes')] / 3]
         expected.index.names = ['Timestamp']
         expected.columns = ['Votes']
+
+        pandas.testing.assert_frame_equal(result, expected)
+
+    def test_nan_in_metrics(self):
+        cat_dim_df_with_nan = cat_dim_df.copy()
+        cat_dim_df_with_nan['$m$wins'] = cat_dim_df_with_nan['$m$wins'].apply(float)
+        cat_dim_df_with_nan.iloc[2, 1] = np.nan
+
+        result = Pandas(slicer.metrics.wins) \
+            .transform(cat_dim_df_with_nan, slicer, [slicer.dimensions.political_party], [])
+
+        expected = cat_dim_df_with_nan.copy()[[fm('wins')]]
+        expected.index = pd.Index(['Democrat', 'Independent', 'Republican'], name='Party')
+        expected.columns = ['Wins']
+
+        pandas.testing.assert_frame_equal(result, expected)
+
+    def test_inf_in_metrics(self):
+        cat_dim_df_with_nan = cat_dim_df.copy()
+        cat_dim_df_with_nan['$m$wins'] = cat_dim_df_with_nan['$m$wins'].apply(float)
+        cat_dim_df_with_nan.iloc[2, 1] = np.inf
+
+        result = Pandas(slicer.metrics.wins) \
+            .transform(cat_dim_df_with_nan, slicer, [slicer.dimensions.political_party], [])
+
+        expected = cat_dim_df_with_nan.copy()[[fm('wins')]]
+        expected.index = pd.Index(['Democrat', 'Independent', 'Republican'], name='Party')
+        expected.columns = ['Wins']
+
+        pandas.testing.assert_frame_equal(result, expected)
+
+    def test_neginf_in_metrics(self):
+        cat_dim_df_with_nan = cat_dim_df.copy()
+        cat_dim_df_with_nan['$m$wins'] = cat_dim_df_with_nan['$m$wins'].apply(float)
+        cat_dim_df_with_nan.iloc[2, 1] = np.inf
+
+        result = Pandas(slicer.metrics.wins) \
+            .transform(cat_dim_df_with_nan, slicer, [slicer.dimensions.political_party], [])
+
+        expected = cat_dim_df_with_nan.copy()[[fm('wins')]]
+        expected.index = pd.Index(['Democrat', 'Independent', 'Republican'], name='Party')
+        expected.columns = ['Wins']
+
+        pandas.testing.assert_frame_equal(result, expected)
+
+    def test_inf_in_metrics_with_precision_zero(self):
+        cat_dim_df_with_nan = cat_dim_df.copy()
+        cat_dim_df_with_nan['$m$wins'] = cat_dim_df_with_nan['$m$wins'].apply(float)
+        cat_dim_df_with_nan.iloc[2, 1] = np.inf
+
+        slicer_modified = copy.deepcopy(slicer)
+        slicer_modified.metrics.wins.precision = 0
+
+        result = Pandas(slicer_modified.metrics.wins) \
+            .transform(cat_dim_df_with_nan, slicer_modified, [slicer_modified.dimensions.political_party], [])
+
+        expected = cat_dim_df_with_nan.copy()[[fm('wins')]]
+        expected.index = pd.Index(['Democrat', 'Independent', 'Republican'], name='Party')
+        expected['$m$wins'] = ['6', '0', '']
+        expected.columns = ['Wins']
 
         pandas.testing.assert_frame_equal(result, expected)


### PR DESCRIPTION
If a metric was set to use precision 0, then an inf or nan result in the data frame would cause the transformer to raise an unhandled exception