### PR TITLE
React-Table transformer

### DIFF
--- a/fireant/formats.py
+++ b/fireant/formats.py
@@ -10,6 +10,8 @@ import pandas as pd
 
 INFINITY = "Infinity"
 NULL_VALUE = 'null'
+TOTALS_VALUE = 'totals'
+RAW_VALUE = 'raw'
 
 NO_TIME = time(0)
 

--- a/fireant/slicer/base.py
+++ b/fireant/slicer/base.py
@@ -19,7 +19,7 @@ class SlicerElement(object):
             used for querying labels.
         """
         self.key = key
-        self.label = label or key
+        self.label = label if label is not None else key
         self.definition = definition
 
         self.display_definition = display_definition

--- a/fireant/slicer/filters.py
+++ b/fireant/slicer/filters.py
@@ -69,7 +69,7 @@ class PatternFilter(DimensionFilter):
         return definition
 
     def __init__(self, dimension_definition, pattern, *patterns):
-        definition = self._apply(dimension_definition, [pattern, *patterns])
+        definition = self._apply(dimension_definition, (pattern,) + patterns)
         super(PatternFilter, self).__init__(definition)
 
 

--- a/fireant/slicer/queries/database.py
+++ b/fireant/slicer/queries/database.py
@@ -1,10 +1,14 @@
 import time
+from functools import partial
 from typing import Iterable
 
 import pandas as pd
 
 from fireant.database.base import Database
-from fireant.formats import NULL_VALUE
+from fireant.formats import (
+    NULL_VALUE,
+    TOTALS_VALUE,
+)
 from fireant.utils import format_dimension_key
 from .logger import (
     query_logger,
@@ -65,7 +69,7 @@ def clean_and_apply_index(data_frame: pd.DataFrame, dimensions: Iterable[Dimensi
             continue
 
         level = format_dimension_key(dimension.key)
-        data_frame[level] = fill_nans_in_level(data_frame, dimension, dimension_keys[:i]) \
+        data_frame[level] = fill_nans_in_level(data_frame, dimensions[:i + 1]) \
             .apply(
               # Handles an annoying case of pandas in which the ENTIRE data frame gets converted from int to float if
               # the are NaNs, even if there are no NaNs in the column :/
@@ -76,7 +80,7 @@ def clean_and_apply_index(data_frame: pd.DataFrame, dimensions: Iterable[Dimensi
     return data_frame.set_index(dimension_keys)
 
 
-def fill_nans_in_level(data_frame, dimension, preceding_dimension_keys):
+def fill_nans_in_level(data_frame, dimensions):
     """
     In case there are NaN values representing both totals (from ROLLUP) and database nulls, we need to replace the real
     nulls with an empty string in order to distinguish between them.  We choose to replace the actual database nulls
@@ -85,33 +89,39 @@ def fill_nans_in_level(data_frame, dimension, preceding_dimension_keys):
 
     :param data_frame:
         The data_frame we are replacing values in.
-    :param dimension:
-        The level of the data frame to replace nulls in. This function should be called once per non-conitnuous
-        dimension, in the order of the dimensions.
-    :param preceding_dimension_keys:
+    :param dimensions:
+        A list of dimensions with the last item in the list being the dimension to fill nans for. This function requires
+        the dimension being processed as well as the preceding dimensions since a roll up in a higher level dimension
+        results in nulls for lower level dimension.
     :return:
         The level in the data_frame with the nulls replaced with empty string
     """
-    level = format_dimension_key(dimension.key)
+    level = format_dimension_key(dimensions[-1].key)
 
-    if dimension.is_rollup:
-        if preceding_dimension_keys:
+    number_rollup_dimensions = sum(dimension.is_rollup for dimension in dimensions)
+    if 0 < number_rollup_dimensions:
+        fill_nan_for_nulls = partial(_fill_nan_for_nulls, offset=number_rollup_dimensions)
+
+        if 1 < len(dimensions):
+            preceding_dimension_keys = [format_dimension_key(d.key)
+                                        for d in dimensions[:-1]]
+
             return (data_frame
                     .groupby(preceding_dimension_keys)[level]
-                    .apply(_fill_nan_for_nulls))
+                    .apply(fill_nan_for_nulls))
 
-        return _fill_nan_for_nulls(data_frame[level])
+        return fill_nan_for_nulls(data_frame[level])
 
     return data_frame[level].fillna(NULL_VALUE)
 
 
-def _fill_nan_for_nulls(df):
+def _fill_nan_for_nulls(df, offset=1):
     """
     Fills the first NaN with a literal string "null" if there are two NaN values, otherwise nothing is filled.
 
     :param df:
     :return:
     """
-    if 1 < pd.isnull(df).sum():
-        return df.fillna(NULL_VALUE, limit=1)
-    return df
+    if offset < pd.isnull(df).sum():
+        return df.fillna(NULL_VALUE, limit=1).fillna(TOTALS_VALUE)
+    return df.fillna(TOTALS_VALUE)

--- a/fireant/slicer/widgets/__init__.py
+++ b/fireant/slicer/widgets/__init__.py
@@ -1,6 +1,7 @@
 from .base import Widget
 from .csv import CSV
 from .datatables import DataTablesJS
+from .reacttable import ReactTable
 from .highcharts import HighCharts
 from .matplotlib import Matplotlib
 from .pandas import Pandas

--- a/fireant/slicer/widgets/base.py
+++ b/fireant/slicer/widgets/base.py
@@ -1,11 +1,15 @@
-from fireant import Metric
+from typing import Union
+
+from fireant import (
+    Metric,
+    Operation,
+)
 from fireant.slicer.exceptions import MetricRequiredException
 from fireant.utils import immutable
-from ..operations import Operation
 
 
 class Widget:
-    def __init__(self, *items: Metric):
+    def __init__(self, *items: Union[Metric, Operation]):
         self.items = list(items)
 
     @immutable

--- a/fireant/slicer/widgets/csv.py
+++ b/fireant/slicer/widgets/csv.py
@@ -4,4 +4,5 @@ from .pandas import Pandas
 class CSV(Pandas):
     def transform(self, data_frame, slicer, dimensions, references):
         result_df = super(CSV, self).transform(data_frame, slicer, dimensions, references)
+        result_df.columns.names = [None]
         return result_df.to_csv()

--- a/fireant/slicer/widgets/helpers.py
+++ b/fireant/slicer/widgets/helpers.py
@@ -67,10 +67,9 @@ def dimensional_metric_label(dimensions, dimension_display_values):
         used_dimensions = dimensions[num_used_dimensions:]
 
         dimension_values = utils.wrap_list(dimension_values)
-        dimension_labels = [utils.deep_get(dimension_display_values,
-                                           [utils.format_dimension_key(dimension.key),
-                                            dimension_value],
-                                           dimension_value)
+        dimension_labels = [utils.getdeepattr(dimension_display_values,
+                                              (utils.format_dimension_key(dimension.key), dimension_value),
+                                              dimension_value)
                             if not pd.isnull(dimension_value)
                             else 'Totals'
                             for dimension, dimension_value in zip(used_dimensions, dimension_values)]

--- a/fireant/slicer/widgets/highcharts.py
+++ b/fireant/slicer/widgets/highcharts.py
@@ -1,4 +1,6 @@
 import itertools
+
+import pandas as pd
 from datetime import (
     datetime,
 )
@@ -6,8 +8,6 @@ from typing import (
     Iterable,
     Union,
 )
-
-import pandas as pd
 
 from fireant import (
     DatetimeDimension,
@@ -261,9 +261,9 @@ class HighCharts(TransformableWidget):
 
         categories = ["All"] \
             if isinstance(first_level, pd.RangeIndex) \
-            else [utils.deep_get(dimension_display_values,
-                                 [first_level.name, dimension_value],
-                                 dimension_value or 'Totals')
+            else [utils.getdeepattr(dimension_display_values,
+                                    (first_level.name, dimension_value),
+                                    dimension_value or 'Totals')
                   for dimension_value in first_level]
 
         return {

--- a/fireant/slicer/widgets/pandas.py
+++ b/fireant/slicer/widgets/pandas.py
@@ -18,9 +18,10 @@ HARD_MAX_COLUMNS = 24
 
 
 class Pandas(TransformableWidget):
-    def __init__(self, metric, *metrics: Metric, pivot=False, max_columns=None):
+    def __init__(self, metric, *metrics: Metric, pivot=(), transpose=False, max_columns=None):
         super(Pandas, self).__init__(metric, *metrics)
         self.pivot = pivot
+        self.transpose = transpose
         self.max_columns = min(max_columns, HARD_MAX_COLUMNS) \
             if max_columns is not None \
             else HARD_MAX_COLUMNS
@@ -71,15 +72,46 @@ class Pandas(TransformableWidget):
             result.index.names = [dimension.label or dimension.key
                                   for dimension in dimensions]
 
-        result.columns = [reference_label(item, reference)
-                          for reference in [None] + references
-                          for item in self.items]
+        result.columns = pd.Index([reference_label(item, reference)
+                                   for item in self.items
+                                   for reference in [None] + references],
+                                  name='Metrics')
 
-        if not self.pivot:
-            return result
+        return self.pivot_data_frame(result, [d.label or d.key for d in self.pivot], self.transpose)
 
-        pivot_levels = result.index.names[1:]
-        return result.unstack(level=pivot_levels)
+    @staticmethod
+    def pivot_data_frame(data_frame, pivot=(), transpose=False):
+        """
+        Pivot and transpose the data frame. Dimensions including in the `pivot` arg will be unshifted to columns. If
+        `transpose` is True the data frame will be transposed. If there is only index level in the data frame (ie. one
+        dimension), and that dimension is pivoted, then the data frame will just be transposed. If there is a single
+        metric in the data frame and at least one dimension pivoted, the metrics column level will be dropped for
+        simplicity.
+
+        :param data_frame:
+        :param pivot:
+        :param transpose:
+        :return:
+        """
+        if not (pivot or transpose):
+            return data_frame
+
+        # NOTE: Don't pivot a single dimension data frame. This turns the data frame into a series and pivots the
+        # metrics anyway. Instead, transpose the data frame.
+        should_transpose_instead_of_pivot = len(pivot) == len(data_frame.index.names)
+
+        if pivot and not should_transpose_instead_of_pivot:
+            data_frame = data_frame.unstack(level=pivot)
+
+        if transpose or should_transpose_instead_of_pivot:
+            data_frame = data_frame.transpose()
+
+        # If there are more than one column levels and the last level is a single metric, drop the level
+        if isinstance(data_frame.columns, pd.MultiIndex) and 1 == len(data_frame.columns.levels[0]):
+            data_frame.name = data_frame.columns.levels[0][0]  # capture the name of the metrics column
+            data_frame.columns = data_frame.columns.droplevel(0)  # drop the metrics level
+
+        return data_frame.fillna('')
 
     def _replace_display_values_in_index(self, dimension, result):
         """
@@ -89,7 +121,9 @@ class Pandas(TransformableWidget):
             df_key = format_dimension_key(dimension.key)
             values = [dimension.display_values.get(x, x)
                       for x in result.index.get_level_values(df_key)]
-            result.index.set_levels(level=df_key, levels=values)
+            result.index.set_levels(level=df_key,
+                                    levels=values,
+                                    inplace=True)
             return result
 
         values = [dimension.display_values.get(x, x)

--- a/fireant/slicer/widgets/pandas.py
+++ b/fireant/slicer/widgets/pandas.py
@@ -89,9 +89,13 @@ class Pandas(TransformableWidget):
         simplicity.
 
         :param data_frame:
+            The result set data frame
         :param pivot:
+            A list of index keys for `data_frame` of levels to shift
         :param transpose:
+            A boolean true or false whether to transpose the data frame.
         :return:
+            The shifted/transposed data frame
         """
         if not (pivot or transpose):
             return data_frame

--- a/fireant/slicer/widgets/reacttable.py
+++ b/fireant/slicer/widgets/reacttable.py
@@ -1,0 +1,324 @@
+from collections import OrderedDict
+
+import pandas as pd
+
+from fireant.formats import (
+    RAW_VALUE,
+    TOTALS_VALUE,
+)
+from fireant.utils import (
+    format_dimension_key,
+    format_metric_key,
+    getdeepattr,
+    setdeepattr,
+)
+from .pandas import Pandas
+from ..dimensions import (
+    DatetimeDimension,
+    Dimension,
+)
+from ..intervals import (
+    annually,
+    daily,
+    hourly,
+    monthly,
+    quarterly,
+    weekly,
+)
+from ..metrics import Metric
+from ..references import (
+    reference_key,
+    reference_label,
+)
+
+DATE_FORMATS = {
+    hourly: '%Y-%m-%d %h',
+    daily: '%Y-%m-%d',
+    weekly: '%Y-%m',
+    monthly: '%Y',
+    quarterly: '%Y-%q',
+    annually: '%Y',
+}
+
+metrics = Dimension('metrics', '')
+metrics_dimension_key = format_dimension_key(metrics.key)
+
+
+def map_index_level(index, level, func):
+    if isinstance(index, pd.MultiIndex):
+        values = index.levels[level]
+        return index.set_levels(values.map(func), level)
+
+    assert level == 0
+
+    return index.map(func)
+
+
+def fillna_index(index, value):
+    if isinstance(index, pd.MultiIndex):
+        return pd.MultiIndex.from_tuples([[value if pd.isnull(x) else x
+                                           for x in row]
+                                          for row in index],
+                                         names=index.names)
+
+    return index.fillna(value)
+
+
+def _get_item_display(item, value):
+    if item is None or all([item.prefix is None, item.suffix is None, item.precision is None]):
+        return
+
+    return '{prefix}{value}{suffix}'.format(
+          prefix=(item.prefix or ""),
+          suffix=(item.suffix or ""),
+          value=value if item.precision is None else '{:.{precision}f}'.format(0.1234567890, precision=2)
+    )
+
+
+def make_column_format(item):
+    if item is None or all([item.prefix is None, item.suffix is None, item.precision is None]):
+        return
+
+    return '{prefix}{format}{suffix}'.format(
+          prefix=(item.prefix or ""),
+          suffix=(item.suffix or "").replace('%', '%%'),
+          format='%s' if item.precision is None else '%.{}f'.format(item.precision)
+    )
+
+
+class ReferenceItem:
+    def __init__(self, item, reference):
+        if reference is None:
+            self.key = item.key
+            self.label = item.label
+        else:
+            self.key = reference_key(item, reference)
+            self.label = reference_label(item, reference)
+
+        self.prefix = item.prefix
+        self.suffix = item.suffix
+        self.precision = item.precision
+
+
+class TotalsItem:
+    key = TOTALS_VALUE
+    label = 'Totals'
+    prefix = suffix = precision = None
+
+
+class ReactTable(Pandas):
+    def __init__(self, metric, *metrics: Metric, pivot=(), transpose=False, max_columns=None):
+        super(ReactTable, self).__init__(metric, *metrics,
+                                         pivot=pivot,
+                                         transpose=transpose,
+                                         max_columns=max_columns)
+
+    def __repr__(self):
+        return '{}({})'.format(self.__class__.__name__,
+                               ','.join(str(m) for m in self.items))
+
+    def map_display_values(self, df, dimensions):
+        """
+        WRITEME
+
+        :param df:
+        :param dimensions:
+        :return:
+        """
+        dimension_display_values = {}
+
+        for dimension in dimensions:
+            f_dimension_key = format_dimension_key(dimension.key)
+
+            if dimension.has_display_field:
+                f_display_key = format_dimension_key(dimension.display_key)
+
+                dimension_display_values[f_dimension_key] = \
+                    df[f_display_key].groupby(f_dimension_key).first().fillna('null').to_dict()
+
+                del df[f_display_key]
+
+            if hasattr(dimension, 'display_values'):
+                dimension_display_values[f_dimension_key] = dimension.display_values
+
+        return dimension_display_values
+
+    @staticmethod
+    def format_data_frame(df, dimensions):
+        """
+        This function prepares the raw data frame for transformation by formatting dates in the index and removing any
+        remaining NaN/NaT values. It also names the column as metrics so that it can be treated like a dimension level.
+
+        :param df:
+        :param dimensions:
+        :return:
+        """
+        for i, dimension in enumerate(dimensions):
+            if isinstance(dimension, DatetimeDimension):
+                date_format = DATE_FORMATS.get(dimension.interval, DATE_FORMATS[daily])
+                df.index = map_index_level(df.index, i, lambda dt: dt.strftime(date_format))
+
+        df.index = fillna_index(df.index, TOTALS_VALUE)
+        df.columns.name = metrics_dimension_key
+
+    @staticmethod
+    def transform_dimension_column_headers(data_frame, dimensions):
+        """
+        Convert the unpivoted dimensions into ReactTable column header definitions.
+
+        :param data_frame:
+        :param dimensions:
+        :return:
+        """
+        dimension_map = {format_dimension_key(d.key): d
+                         for d in dimensions + [metrics]}
+
+        columns = []
+        if isinstance(data_frame.index, pd.RangeIndex):
+            return columns
+
+        for f_dimension_key in data_frame.index.names:
+            dimension = dimension_map[f_dimension_key]
+
+            columns.append({
+                'Header': getattr(dimension, 'label', dimension.key),
+                'accessor': f_dimension_key,
+            })
+
+        return columns
+
+    @staticmethod
+    def transform_metric_column_headers(data_frame, item_map, dimension_display_values):
+        """
+        Convert the metrics into ReactTable column header definitions. This includes any pivoted dimensions, which will
+        result in multiple rows of headers.
+
+        :param data_frame:
+        :param item_map:
+        :param dimension_display_values:
+        :return:
+        """
+
+        def get_header(column_value, f_dimension_key, is_totals):
+            if f_dimension_key == metrics_dimension_key or is_totals:
+                item = item_map[column_value]
+                return getattr(item, 'label', item.key)
+
+            else:
+                return getdeepattr(dimension_display_values, (f_dimension_key, column_value), column_value)
+
+        def _make_columns(df, previous_levels=()):
+            f_dimension_key = df.index.names[0]
+            groups = df.groupby(level=0) \
+                if isinstance(df.index, pd.MultiIndex) else \
+                [(level, None) for level in df.index]
+
+            columns = []
+            for column_value, group in groups:
+                is_totals = TOTALS_VALUE == column_value
+
+                column = {'Header': get_header(column_value, f_dimension_key, is_totals)}
+
+                levels = previous_levels + (column_value,)
+                if group is not None:
+                    next_level_df = group.reset_index(level=0, drop=True)
+                    column['columns'] = _make_columns(next_level_df, levels)
+
+                else:
+                    if hasattr(data_frame, 'name'):
+                        levels += (data_frame.name,)
+                    column['accessor'] = '.'.join(levels)
+
+                if is_totals:
+                    column['className'] = 'fireant-totals'
+
+                columns.append(column)
+
+            return columns
+
+        column_frame = data_frame.columns.to_frame()
+        return _make_columns(column_frame)
+
+    @staticmethod
+    def transform_data(data_frame, item_map, dimension_display_values):
+        """
+        WRITEME
+
+        :param data_frame:
+        :param item_map:
+        :param dimension_display_values:
+        :return:
+        """
+        result = []
+
+        for index, series in data_frame.iterrows():
+            if not isinstance(index, tuple):
+                index = (index,)
+
+            index = [x
+                     if x not in item_map
+                     else getattr(item_map[x], 'label', item_map[x].key)
+                     for x in index]
+
+            row = {}
+            for key, value in zip(data_frame.index.names, index):
+                if key is None:
+                    continue
+
+                data = {RAW_VALUE: value}
+                display = getdeepattr(dimension_display_values, (key, value))
+                if display is not None:
+                    data['display'] = display
+
+                row[key] = data
+
+            for key, value in series.iteritems():
+                data = {RAW_VALUE: value}
+                item = item_map.get(key[0] if isinstance(key, tuple) else key)
+                display = _get_item_display(item, value)
+                if display is not None:
+                    data['display'] = display
+
+                setdeepattr(row, key, data)
+
+            result.append(row)
+
+        return result
+
+    def transform(self, data_frame, slicer, dimensions, references):
+        """
+        WRITEME
+
+        :param data_frame:
+        :param slicer:
+        :param dimensions:
+        :param references:
+        :return:
+        """
+        df_dimension_columns = [format_dimension_key(d.display_key)
+                                for d in dimensions
+                                if d.has_display_field]
+        item_map = OrderedDict([(format_metric_key(reference_key(i, reference)), ReferenceItem(i, reference))
+                                for i in self.items
+                                for reference in [None] + references])
+        df_metric_columns = list(item_map.keys())
+
+        # Add an extra item to map the totals key to it's label
+        item_map[TOTALS_VALUE] = TotalsItem
+
+        df = data_frame[df_dimension_columns + df_metric_columns].copy()
+
+        dimension_display_values = self.map_display_values(df, dimensions)
+        self.format_data_frame(df, dimensions)
+
+        dimension_keys = [format_dimension_key(dimension.key) for dimension in self.pivot]
+        df = self.pivot_data_frame(df, dimension_keys, self.transpose)
+
+        dimension_columns = self.transform_dimension_column_headers(df, dimensions)
+        metric_columns = self.transform_metric_column_headers(df, item_map, dimension_display_values)
+        data = self.transform_data(df, item_map, dimension_display_values)
+
+        return {
+            'columns': dimension_columns + metric_columns,
+            'data': data,
+        }

--- a/fireant/slicer/widgets/reacttable.py
+++ b/fireant/slicer/widgets/reacttable.py
@@ -45,6 +45,10 @@ metrics_dimension_key = format_dimension_key(metrics.key)
 
 
 def map_index_level(index, level, func):
+    # If the index is empty, do not do anything
+    if 0 == index.size:
+        return index
+
     if isinstance(index, pd.MultiIndex):
         values = index.levels[level]
         return index.set_levels(values.map(func), level)

--- a/fireant/slicer/widgets/reacttable.py
+++ b/fireant/slicer/widgets/reacttable.py
@@ -107,6 +107,35 @@ class TotalsItem:
 
 
 class ReactTable(Pandas):
+    """
+    This component does not work with react-table out of the box, some customization is needed in order to work with
+    the transformed data.
+
+    ```
+    // A Custom TdComponent implementation is required by Fireant in order to render display values
+    const TdComponent = ({
+                           toggleSort,
+                           className,
+                           children,
+                           ...rest
+                         }) =>
+        <div className={classNames('rt-td', className)} role="gridcell" {...rest}>
+            {_.get(children, 'display', children.raw) || <span>&nbsp;</span>}
+        </div>;
+
+    const FireantReactTable = ({
+                            config, // The payload from fireant
+                          }) =>
+        <ReactTable columns={config.columns}
+                    data={config.data}
+                    minRows={0}
+
+                    TdComponent={ DashmoreTdComponent}
+                    defaultSortMethod={(a, b, desc) => ReactTableDefaults.defaultSortMethod(a.raw, b.raw, desc)}>
+        </ReactTable>;
+    ```
+    """
+
     def __init__(self, metric, *metrics: Metric, pivot=(), transpose=False, max_columns=None):
         super(ReactTable, self).__init__(metric, *metrics,
                                          pivot=pivot,

--- a/fireant/tests/slicer/mocks.py
+++ b/fireant/tests/slicer/mocks.py
@@ -1,12 +1,12 @@
 from collections import (
     OrderedDict,
 )
-from datetime import (
-    datetime,
-)
 from unittest.mock import Mock
 
 import pandas as pd
+from datetime import (
+    datetime,
+)
 from pypika import (
     JoinType,
     Table,
@@ -108,7 +108,9 @@ slicer = Slicer(
                  definition=fn.Count(voters_table.id)),
           Metric('turnout',
                  label='Turnout',
-                 definition=fn.Sum(politicians_table.votes) / fn.Count(voters_table.id)),
+                 definition=fn.Sum(politicians_table.votes) / fn.Count(voters_table.id),
+                 suffix='%',
+                 precision=2),
       ),
 )
 
@@ -282,6 +284,10 @@ operation_key = fm('cumsum(votes)')
 cont_dim_operation_df[operation_key] = cont_dim_df[fm('votes')].cumsum()
 
 
+def split(list, i):
+    return list[:i], list[i:]
+
+
 def ref(data_frame, columns):
     ref_cols = {column: '%s_eoe' % column
                 for column in columns}
@@ -291,9 +297,9 @@ def ref(data_frame, columns):
         .rename(columns=ref_cols)[list(ref_cols.values())]
 
     return (cont_uni_dim_df
-            .copy()
-            .join(ref_df)
-            .iloc[2:])
+                .copy()
+                .join(ref_df)
+                .iloc[2:])
 
 
 def ref_delta(ref_data_frame, columns):

--- a/fireant/tests/slicer/queries/test_database.py
+++ b/fireant/tests/slicer/queries/test_database.py
@@ -141,11 +141,11 @@ class FetchDataCleanIndexTests(TestCase):
 
         self.assertListEqual(result.index.tolist(), ['d', 'i', 'r', 'null'])
 
-    def test_convert_cat_totals_converted_to_none(self):
+    def test_convert_cat_totals_converted_to_totals(self):
         result = clean_and_apply_index(cat_dim_nans_df.reset_index(),
                                        [slicer.dimensions.political_party.rollup()])
 
-        self.assertListEqual(result.index.tolist(), ['d', 'i', 'r', None])
+        self.assertListEqual(result.index.tolist(), ['d', 'i', 'r', 'totals'])
 
     def test_convert_numeric_values_to_string(self):
         result = clean_and_apply_index(uni_dim_df.reset_index(), [slicer.dimensions.candidate])
@@ -167,13 +167,13 @@ class FetchDataCleanIndexTests(TestCase):
         result = clean_and_apply_index(uni_dim_nans_df.reset_index(),
                                        [slicer.dimensions.candidate.rollup()])
 
-        self.assertListEqual(result.index.tolist(), [str(x + 1) for x in range(11)] + [None])
+        self.assertListEqual(result.index.tolist(), [str(x + 1) for x in range(11)] + ['totals'])
 
     def test_set_index_for_multiindex_with_nans_and_totals(self):
         result = clean_and_apply_index(cont_uni_dim_nans_totals_df.reset_index(),
                                        [slicer.dimensions.timestamp, slicer.dimensions.state.rollup()])
 
-        self.assertListEqual(result.index.get_level_values(1).unique().tolist(), ['2', '1', 'null', np.nan])
+        self.assertListEqual(result.index.get_level_values(1).unique().tolist(), ['2', '1', 'null', 'totals'])
 
 
 class FetchDimensionOptionsTests(TestCase):

--- a/fireant/tests/slicer/widgets/test_csv.py
+++ b/fireant/tests/slicer/widgets/test_csv.py
@@ -33,7 +33,7 @@ class CSVWidgetTests(TestCase):
         expected = single_metric_df.copy()[[fm('votes')]]
         expected.columns = ['Votes']
 
-        self.assertEqual(result, expected.to_csv())
+        self.assertEqual(expected.to_csv(), result)
 
     def test_multiple_metrics(self):
         result = CSV(slicer.metrics.votes, slicer.metrics.wins) \
@@ -42,7 +42,7 @@ class CSVWidgetTests(TestCase):
         expected = multi_metric_df.copy()[[fm('votes'), fm('wins')]]
         expected.columns = ['Votes', 'Wins']
 
-        self.assertEqual(result, expected.to_csv())
+        self.assertEqual(expected.to_csv(), result)
 
     def test_multiple_metrics_reversed(self):
         result = CSV(slicer.metrics.wins, slicer.metrics.votes) \
@@ -51,7 +51,7 @@ class CSVWidgetTests(TestCase):
         expected = multi_metric_df.copy()[[fm('wins'), fm('votes')]]
         expected.columns = ['Wins', 'Votes']
 
-        self.assertEqual(result, expected.to_csv())
+        self.assertEqual(expected.to_csv(), result)
 
     def test_time_series_dim(self):
         result = CSV(slicer.metrics.wins) \
@@ -61,7 +61,7 @@ class CSVWidgetTests(TestCase):
         expected.index.names = ['Timestamp']
         expected.columns = ['Wins']
 
-        self.assertEqual(result, expected.to_csv())
+        self.assertEqual(expected.to_csv(), result)
 
     def test_time_series_dim_with_operation(self):
         result = CSV(CumSum(slicer.metrics.votes)) \
@@ -71,7 +71,7 @@ class CSVWidgetTests(TestCase):
         expected.index.names = ['Timestamp']
         expected.columns = ['CumSum(Votes)']
 
-        self.assertEqual(result, expected.to_csv())
+        self.assertEqual(expected.to_csv(), result)
 
     def test_cat_dim(self):
         result = CSV(slicer.metrics.wins) \
@@ -81,7 +81,7 @@ class CSVWidgetTests(TestCase):
         expected.index = pd.Index(['Democrat', 'Independent', 'Republican'], name='Party')
         expected.columns = ['Wins']
 
-        self.assertEqual(result, expected.to_csv())
+        self.assertEqual(expected.to_csv(), result)
 
     def test_uni_dim(self):
         result = CSV(slicer.metrics.wins) \
@@ -93,7 +93,7 @@ class CSVWidgetTests(TestCase):
         expected.index.names = ['Candidate']
         expected.columns = ['Wins']
 
-        self.assertEqual(result, expected.to_csv())
+        self.assertEqual(expected.to_csv(), result)
 
     def test_uni_dim_no_display_definition(self):
         import copy
@@ -111,7 +111,7 @@ class CSVWidgetTests(TestCase):
         expected.index.names = ['Candidate']
         expected.columns = ['Wins']
 
-        self.assertEqual(result, expected.to_csv())
+        self.assertEqual(expected.to_csv(), result)
 
     def test_multi_dims_time_series_and_uni(self):
         result = CSV(slicer.metrics.wins) \
@@ -123,41 +123,43 @@ class CSVWidgetTests(TestCase):
         expected.index.names = ['Timestamp', 'State']
         expected.columns = ['Wins']
 
-        self.assertEqual(result, expected.to_csv())
+        self.assertEqual(expected.to_csv(), result)
 
-    def test_pivoted_single_dimension_no_effect(self):
-        result = CSV(slicer.metrics.wins, pivot=True) \
+    def test_pivoted_single_dimension_transposes_data_frame(self):
+        result = CSV(slicer.metrics.wins, pivot=[slicer.dimensions.political_party]) \
             .transform(cat_dim_df, slicer, [slicer.dimensions.political_party], [])
 
         expected = cat_dim_df.copy()[[fm('wins')]]
         expected.index = pd.Index(['Democrat', 'Independent', 'Republican'], name='Party')
         expected.columns = ['Wins']
+        expected.columns.names = ['Metrics']
+        expected = expected.transpose()
 
-        self.assertEqual(result, expected.to_csv())
+        self.assertEqual(expected.to_csv(), result)
 
     def test_pivoted_multi_dims_time_series_and_cat(self):
-        result = CSV(slicer.metrics.wins, pivot=True) \
+        result = CSV(slicer.metrics.wins, pivot=[slicer.dimensions.political_party]) \
             .transform(cont_cat_dim_df, slicer, [slicer.dimensions.timestamp, slicer.dimensions.political_party], [])
 
         expected = cont_cat_dim_df.copy()[[fm('wins')]]
-        expected.index.names = ['Timestamp', 'Party']
-        expected.columns = ['Wins']
         expected = expected.unstack(level=[1])
+        expected.index.names = ['Timestamp']
+        expected.columns = ['Democrat', 'Independent', 'Republican']
 
-        self.assertEqual(result, expected.to_csv())
+        self.assertEqual(expected.to_csv(), result)
 
     def test_pivoted_multi_dims_time_series_and_uni(self):
-        result = CSV(slicer.metrics.votes, pivot=True) \
+        result = CSV(slicer.metrics.votes, pivot=[slicer.dimensions.state]) \
             .transform(cont_uni_dim_df, slicer, [slicer.dimensions.timestamp, slicer.dimensions.state], [])
 
         expected = cont_uni_dim_df.copy() \
             .set_index(fd('state_display'), append=True) \
             .reset_index(fd('state'), drop=True)[[fm('votes')]]
-        expected.index.names = ['Timestamp', 'State']
-        expected.columns = ['Votes']
         expected = expected.unstack(level=[1])
+        expected.index.names = ['Timestamp']
+        expected.columns = ['California', 'Texas']
 
-        self.assertEqual(result, expected.to_csv())
+        self.assertEqual(expected.to_csv(), result)
 
     def test_time_series_ref(self):
         result = CSV(slicer.metrics.votes) \
@@ -176,4 +178,4 @@ class CSVWidgetTests(TestCase):
         expected.index.names = ['Timestamp', 'State']
         expected.columns = ['Votes', 'Votes (EoE)']
 
-        self.assertEqual(result, expected.to_csv())
+        self.assertEqual(expected.to_csv(), result)

--- a/fireant/tests/slicer/widgets/test_reacttable.py
+++ b/fireant/tests/slicer/widgets/test_reacttable.py
@@ -1,0 +1,1145 @@
+from unittest import TestCase
+
+from fireant.slicer.widgets.reacttable import ReactTable
+from fireant.tests.slicer.mocks import (
+    CumSum,
+    ElectionOverElection,
+    cat_dim_df,
+    cont_dim_df,
+    cont_dim_operation_df,
+    cont_uni_dim_all_totals_df,
+    cont_uni_dim_df,
+    cont_uni_dim_ref_df,
+    cont_uni_dim_totals_df,
+    multi_metric_df,
+    single_metric_df,
+    slicer,
+    uni_dim_df,
+)
+from fireant.utils import format_dimension_key as fd
+
+
+class ReactTableTransformerTests(TestCase):
+    maxDiff = None
+
+    def test_single_metric(self):
+        result = ReactTable(slicer.metrics.votes) \
+            .transform(single_metric_df, slicer, [], [])
+
+        self.assertEqual({
+            'columns': [{'Header': 'Votes', 'accessor': '$m$votes'}],
+            'data': [{'$m$votes': {'raw': 111674336}}]
+        }, result)
+
+    def test_multiple_metrics(self):
+        result = ReactTable(slicer.metrics.votes, slicer.metrics.wins) \
+            .transform(multi_metric_df, slicer, [], [])
+
+        self.assertEqual({
+            'columns': [{'Header': 'Votes', 'accessor': '$m$votes'},
+                        {'Header': 'Wins', 'accessor': '$m$wins'}],
+            'data': [{'$m$votes': {'raw': 111674336}, '$m$wins': {'raw': 12}}]
+        }, result)
+
+    def test_multiple_metrics_reversed(self):
+        result = ReactTable(slicer.metrics.wins, slicer.metrics.votes) \
+            .transform(multi_metric_df, slicer, [], [])
+
+        self.assertEqual({
+            'columns': [{'Header': 'Wins', 'accessor': '$m$wins'},
+                        {'Header': 'Votes', 'accessor': '$m$votes'}],
+            'data': [{'$m$votes': {'raw': 111674336}, '$m$wins': {'raw': 12}}]
+        }, result)
+
+    def test_time_series_dim(self):
+        result = ReactTable(slicer.metrics.wins) \
+            .transform(cont_dim_df, slicer, [slicer.dimensions.timestamp], [])
+
+        self.assertEqual({
+            'columns': [{'Header': 'Timestamp', 'accessor': '$d$timestamp'},
+                        {'Header': 'Wins', 'accessor': '$m$wins'}],
+            'data': [{'$d$timestamp': {'raw': '1996-01-01'}, '$m$wins': {'raw': 2}},
+                     {'$d$timestamp': {'raw': '2000-01-01'}, '$m$wins': {'raw': 2}},
+                     {'$d$timestamp': {'raw': '2004-01-01'}, '$m$wins': {'raw': 2}},
+                     {'$d$timestamp': {'raw': '2008-01-01'}, '$m$wins': {'raw': 2}},
+                     {'$d$timestamp': {'raw': '2012-01-01'}, '$m$wins': {'raw': 2}},
+                     {'$d$timestamp': {'raw': '2016-01-01'}, '$m$wins': {'raw': 2}}]
+        }, result)
+
+    def test_time_series_dim_with_operation(self):
+        result = ReactTable(CumSum(slicer.metrics.votes)) \
+            .transform(cont_dim_operation_df, slicer, [slicer.dimensions.timestamp], [])
+
+        self.assertEqual({
+            'columns': [{'Header': 'Timestamp', 'accessor': '$d$timestamp'},
+                        {'Header': 'CumSum(Votes)', 'accessor': '$m$cumsum(votes)'}],
+            'data': [{
+                '$d$timestamp': {'raw': '1996-01-01'},
+                '$m$cumsum(votes)': {'raw': 15220449}
+            }, {
+                '$d$timestamp': {'raw': '2000-01-01'},
+                '$m$cumsum(votes)': {'raw': 31882466}
+            }, {
+                '$d$timestamp': {'raw': '2004-01-01'},
+                '$m$cumsum(votes)': {'raw': 51497398}
+            }, {
+                '$d$timestamp': {'raw': '2008-01-01'},
+                '$m$cumsum(votes)': {'raw': 72791613}
+            }, {
+                '$d$timestamp': {'raw': '2012-01-01'},
+                '$m$cumsum(votes)': {'raw': 93363823}
+            }, {
+                '$d$timestamp': {'raw': '2016-01-01'},
+                '$m$cumsum(votes)': {'raw': 111674336}
+            }]
+        }, result)
+
+    def test_cat_dim(self):
+        result = ReactTable(slicer.metrics.wins) \
+            .transform(cat_dim_df, slicer, [slicer.dimensions.political_party], [])
+
+        self.assertEqual({
+            'columns': [{'Header': 'Party', 'accessor': '$d$political_party'},
+                        {'Header': 'Wins', 'accessor': '$m$wins'}],
+            'data': [{
+                '$d$political_party': {'display': 'Democrat', 'raw': 'd'},
+                '$m$wins': {'raw': 6}
+            }, {
+                '$d$political_party': {'display': 'Independent', 'raw': 'i'},
+                '$m$wins': {'raw': 0}
+            }, {
+                '$d$political_party': {'display': 'Republican', 'raw': 'r'},
+                '$m$wins': {'raw': 6}
+            }]
+        }, result)
+
+    def test_uni_dim(self):
+        result = ReactTable(slicer.metrics.wins) \
+            .transform(uni_dim_df, slicer, [slicer.dimensions.candidate], [])
+
+        self.assertEqual({
+            'columns': [{'Header': 'Candidate', 'accessor': '$d$candidate'},
+                        {'Header': 'Wins', 'accessor': '$m$wins'}],
+            'data': [{
+                '$d$candidate': {'display': 'Bill Clinton', 'raw': '1'},
+                '$m$wins': {'raw': 2}
+            }, {
+                '$d$candidate': {'display': 'Bob Dole', 'raw': '2'},
+                '$m$wins': {'raw': 0}
+            }, {
+                '$d$candidate': {'display': 'Ross Perot', 'raw': '3'},
+                '$m$wins': {'raw': 0}
+            }, {
+                '$d$candidate': {'display': 'George Bush', 'raw': '4'},
+                '$m$wins': {'raw': 4}
+            }, {
+                '$d$candidate': {'display': 'Al Gore', 'raw': '5'},
+                '$m$wins': {'raw': 0}
+            }, {
+                '$d$candidate': {'display': 'John Kerry', 'raw': '6'},
+                '$m$wins': {'raw': 0}
+            }, {
+                '$d$candidate': {'display': 'Barrack Obama', 'raw': '7'},
+                '$m$wins': {'raw': 4}
+            }, {
+                '$d$candidate': {'display': 'John McCain', 'raw': '8'},
+                '$m$wins': {'raw': 0}
+            }, {
+                '$d$candidate': {'display': 'Mitt Romney', 'raw': '9'},
+                '$m$wins': {'raw': 0}
+            }, {
+                '$d$candidate': {'display': 'Donald Trump', 'raw': '10'},
+                '$m$wins': {'raw': 2}
+            }, {
+                '$d$candidate': {'display': 'Hillary Clinton', 'raw': '11'},
+                '$m$wins': {'raw': 0}
+            }]
+        }, result)
+
+    def test_uni_dim_no_display_definition(self):
+        import copy
+        candidate = copy.copy(slicer.dimensions.candidate)
+        candidate.display_key = None
+        candidate.display_definition = None
+
+        uni_dim_df_copy = uni_dim_df.copy()
+        del uni_dim_df_copy[fd(slicer.dimensions.candidate.display_key)]
+
+        result = ReactTable(slicer.metrics.wins) \
+            .transform(uni_dim_df_copy, slicer, [candidate], [])
+
+        self.assertEqual({
+            'columns': [{'Header': 'Candidate', 'accessor': '$d$candidate'},
+                        {'Header': 'Wins', 'accessor': '$m$wins'}],
+            'data': [{'$d$candidate': {'raw': '1'}, '$m$wins': {'raw': 2}},
+                     {'$d$candidate': {'raw': '2'}, '$m$wins': {'raw': 0}},
+                     {'$d$candidate': {'raw': '3'}, '$m$wins': {'raw': 0}},
+                     {'$d$candidate': {'raw': '4'}, '$m$wins': {'raw': 4}},
+                     {'$d$candidate': {'raw': '5'}, '$m$wins': {'raw': 0}},
+                     {'$d$candidate': {'raw': '6'}, '$m$wins': {'raw': 0}},
+                     {'$d$candidate': {'raw': '7'}, '$m$wins': {'raw': 4}},
+                     {'$d$candidate': {'raw': '8'}, '$m$wins': {'raw': 0}},
+                     {'$d$candidate': {'raw': '9'}, '$m$wins': {'raw': 0}},
+                     {'$d$candidate': {'raw': '10'}, '$m$wins': {'raw': 2}},
+                     {'$d$candidate': {'raw': '11'}, '$m$wins': {'raw': 0}}]
+        }, result)
+
+    def test_multi_dims_time_series_and_uni(self):
+        result = ReactTable(slicer.metrics.wins) \
+            .transform(cont_uni_dim_df, slicer, [slicer.dimensions.timestamp, slicer.dimensions.state], [])
+
+        self.assertEqual({
+            'columns': [{'Header': 'Timestamp', 'accessor': '$d$timestamp'},
+                        {'Header': 'State', 'accessor': '$d$state'},
+                        {'Header': 'Wins', 'accessor': '$m$wins'}],
+            'data': [{
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '1996-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '1996-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2000-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2000-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2004-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2004-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2008-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2008-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2012-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2012-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2016-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2016-01-01'},
+                '$m$wins': {'raw': 1}
+            }]
+        }, result)
+
+    def test_multi_dims_with_one_level_totals(self):
+        result = ReactTable(slicer.metrics.wins) \
+            .transform(cont_uni_dim_totals_df, slicer, [slicer.dimensions.timestamp, slicer.dimensions.state.rollup()],
+                       [])
+
+        self.assertEqual({
+            'columns': [{'Header': 'Timestamp', 'accessor': '$d$timestamp'},
+                        {'Header': 'State', 'accessor': '$d$state'},
+                        {'Header': 'Wins', 'accessor': '$m$wins'}],
+            'data': [{
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '1996-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '1996-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'raw': 'Totals'},
+                '$d$timestamp': {'raw': '1996-01-01'},
+                '$m$wins': {'raw': 2}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2000-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2000-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'raw': 'Totals'},
+                '$d$timestamp': {'raw': '2000-01-01'},
+                '$m$wins': {'raw': 2}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2004-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2004-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'raw': 'Totals'},
+                '$d$timestamp': {'raw': '2004-01-01'},
+                '$m$wins': {'raw': 2}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2008-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2008-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'raw': 'Totals'},
+                '$d$timestamp': {'raw': '2008-01-01'},
+                '$m$wins': {'raw': 2}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2012-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2012-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'raw': 'Totals'},
+                '$d$timestamp': {'raw': '2012-01-01'},
+                '$m$wins': {'raw': 2}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2016-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2016-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'raw': 'Totals'},
+                '$d$timestamp': {'raw': '2016-01-01'},
+                '$m$wins': {'raw': 2}
+            }]
+        }, result)
+
+    def test_multi_dims_with_all_levels_totals(self):
+        result = ReactTable(slicer.metrics.wins) \
+            .transform(cont_uni_dim_all_totals_df, slicer, [slicer.dimensions.timestamp.rollup(),
+                                                            slicer.dimensions.state.rollup()], [])
+
+        self.assertEqual({
+            'columns': [{'Header': 'Timestamp', 'accessor': '$d$timestamp'},
+                        {'Header': 'State', 'accessor': '$d$state'},
+                        {'Header': 'Wins', 'accessor': '$m$wins'}],
+            'data': [{
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '1996-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '1996-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'raw': 'Totals'},
+                '$d$timestamp': {'raw': '1996-01-01'},
+                '$m$wins': {'raw': 2}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2000-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2000-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'raw': 'Totals'},
+                '$d$timestamp': {'raw': '2000-01-01'},
+                '$m$wins': {'raw': 2}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2004-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2004-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'raw': 'Totals'},
+                '$d$timestamp': {'raw': '2004-01-01'},
+                '$m$wins': {'raw': 2}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2008-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2008-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'raw': 'Totals'},
+                '$d$timestamp': {'raw': '2008-01-01'},
+                '$m$wins': {'raw': 2}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2012-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2012-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'raw': 'Totals'},
+                '$d$timestamp': {'raw': '2012-01-01'},
+                '$m$wins': {'raw': 2}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2016-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2016-01-01'},
+                '$m$wins': {'raw': 1}
+            }, {
+                '$d$state': {'raw': 'Totals'},
+                '$d$timestamp': {'raw': '2016-01-01'},
+                '$m$wins': {'raw': 2}
+            }, {
+                '$d$state': {'raw': 'Totals'},
+                '$d$timestamp': {'raw': 'Totals'},
+                '$m$wins': {'raw': 12}
+            }]
+        }, result)
+
+    def test_time_series_ref(self):
+        result = ReactTable(slicer.metrics.votes) \
+            .transform(cont_uni_dim_ref_df,
+                       slicer,
+                       [
+                           slicer.dimensions.timestamp,
+                           slicer.dimensions.state
+                       ], [
+                           ElectionOverElection(slicer.dimensions.timestamp)
+                       ])
+
+        self.assertEqual({
+            'columns': [{'Header': 'Timestamp', 'accessor': '$d$timestamp'},
+                        {'Header': 'State', 'accessor': '$d$state'},
+                        {'Header': 'Votes', 'accessor': '$m$votes'},
+                        {'Header': 'Votes (EoE)', 'accessor': '$m$votes_eoe'}],
+            'data': [{
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2000-01-01'},
+                '$m$votes': {'raw': 6233385.0},
+                '$m$votes_eoe': {'raw': 5574387.0}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2000-01-01'},
+                '$m$votes': {'raw': 10428632.0},
+                '$m$votes_eoe': {'raw': 9646062.0}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2004-01-01'},
+                '$m$votes': {'raw': 7359621.0},
+                '$m$votes_eoe': {'raw': 6233385.0}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2004-01-01'},
+                '$m$votes': {'raw': 12255311.0},
+                '$m$votes_eoe': {'raw': 10428632.0}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2008-01-01'},
+                '$m$votes': {'raw': 8007961.0},
+                '$m$votes_eoe': {'raw': 7359621.0}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2008-01-01'},
+                '$m$votes': {'raw': 13286254.0},
+                '$m$votes_eoe': {'raw': 12255311.0}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2012-01-01'},
+                '$m$votes': {'raw': 7877967.0},
+                '$m$votes_eoe': {'raw': 8007961.0}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2012-01-01'},
+                '$m$votes': {'raw': 12694243.0},
+                '$m$votes_eoe': {'raw': 13286254.0}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2016-01-01'},
+                '$m$votes': {'raw': 5072915.0},
+                '$m$votes_eoe': {'raw': 7877967.0}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2016-01-01'},
+                '$m$votes': {'raw': 13237598.0},
+                '$m$votes_eoe': {'raw': 12694243.0}
+            }]
+        }, result)
+
+    def test_time_series_ref_multiple_metrics(self):
+        result = ReactTable(slicer.metrics.votes, slicer.metrics.wins) \
+            .transform(cont_uni_dim_ref_df,
+                       slicer,
+                       [
+                           slicer.dimensions.timestamp,
+                           slicer.dimensions.state
+                       ], [
+                           ElectionOverElection(slicer.dimensions.timestamp)
+                       ])
+
+        self.assertEqual({
+            'columns': [{'Header': 'Timestamp', 'accessor': '$d$timestamp'},
+                        {'Header': 'State', 'accessor': '$d$state'},
+                        {'Header': 'Votes', 'accessor': '$m$votes'},
+                        {'Header': 'Votes (EoE)', 'accessor': '$m$votes_eoe'},
+                        {'Header': 'Wins', 'accessor': '$m$wins'},
+                        {'Header': 'Wins (EoE)', 'accessor': '$m$wins_eoe'}],
+            'data': [{
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2000-01-01'},
+                '$m$votes': {'raw': 6233385.0},
+                '$m$votes_eoe': {'raw': 5574387.0},
+                '$m$wins': {'raw': 1.0},
+                '$m$wins_eoe': {'raw': 1.0}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2000-01-01'},
+                '$m$votes': {'raw': 10428632.0},
+                '$m$votes_eoe': {'raw': 9646062.0},
+                '$m$wins': {'raw': 1.0},
+                '$m$wins_eoe': {'raw': 1.0}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2004-01-01'},
+                '$m$votes': {'raw': 7359621.0},
+                '$m$votes_eoe': {'raw': 6233385.0},
+                '$m$wins': {'raw': 1.0},
+                '$m$wins_eoe': {'raw': 1.0}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2004-01-01'},
+                '$m$votes': {'raw': 12255311.0},
+                '$m$votes_eoe': {'raw': 10428632.0},
+                '$m$wins': {'raw': 1.0},
+                '$m$wins_eoe': {'raw': 1.0}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2008-01-01'},
+                '$m$votes': {'raw': 8007961.0},
+                '$m$votes_eoe': {'raw': 7359621.0},
+                '$m$wins': {'raw': 1.0},
+                '$m$wins_eoe': {'raw': 1.0}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2008-01-01'},
+                '$m$votes': {'raw': 13286254.0},
+                '$m$votes_eoe': {'raw': 12255311.0},
+                '$m$wins': {'raw': 1.0},
+                '$m$wins_eoe': {'raw': 1.0}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2012-01-01'},
+                '$m$votes': {'raw': 7877967.0},
+                '$m$votes_eoe': {'raw': 8007961.0},
+                '$m$wins': {'raw': 1.0},
+                '$m$wins_eoe': {'raw': 1.0}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2012-01-01'},
+                '$m$votes': {'raw': 12694243.0},
+                '$m$votes_eoe': {'raw': 13286254.0},
+                '$m$wins': {'raw': 1.0},
+                '$m$wins_eoe': {'raw': 1.0}
+            }, {
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '$d$timestamp': {'raw': '2016-01-01'},
+                '$m$votes': {'raw': 5072915.0},
+                '$m$votes_eoe': {'raw': 7877967.0},
+                '$m$wins': {'raw': 1.0},
+                '$m$wins_eoe': {'raw': 1.0}
+            }, {
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '$d$timestamp': {'raw': '2016-01-01'},
+                '$m$votes': {'raw': 13237598.0},
+                '$m$votes_eoe': {'raw': 12694243.0},
+                '$m$wins': {'raw': 1.0},
+                '$m$wins_eoe': {'raw': 1.0}
+            }]
+        }, result)
+
+    def test_transpose(self):
+        result = ReactTable(slicer.metrics.wins, transpose=True) \
+            .transform(cat_dim_df, slicer, [slicer.dimensions.political_party], [])
+
+        self.assertEqual({
+            'columns': [{'Header': '', 'accessor': '$d$metrics'},
+                        {'Header': 'Democrat', 'accessor': 'd'},
+                        {'Header': 'Independent', 'accessor': 'i'},
+                        {'Header': 'Republican', 'accessor': 'r'}],
+            'data': [{
+                '$d$metrics': {'raw': 'Wins'},
+                'd': {'raw': 6},
+                'i': {'raw': 0},
+                'r': {'raw': 6}
+            }]
+        }, result)
+
+    def test_pivot_second_dimension_with_one_metric(self):
+        result = ReactTable(slicer.metrics.wins, pivot=[slicer.dimensions.state]) \
+            .transform(cont_uni_dim_df, slicer, [slicer.dimensions.timestamp, slicer.dimensions.state], [])
+
+        self.assertEqual({
+            'columns': [{'Header': 'Timestamp', 'accessor': '$d$timestamp'},
+                        {'Header': 'Texas', 'accessor': '1'},
+                        {'Header': 'California', 'accessor': '2'}],
+            'data': [{
+                '$d$timestamp': {'raw': '1996-01-01'},
+                '1': {'raw': 1},
+                '2': {'raw': 1}
+            }, {
+                '$d$timestamp': {'raw': '2000-01-01'},
+                '1': {'raw': 1},
+                '2': {'raw': 1}
+            }, {
+                '$d$timestamp': {'raw': '2004-01-01'},
+                '1': {'raw': 1},
+                '2': {'raw': 1}
+            }, {
+                '$d$timestamp': {'raw': '2008-01-01'},
+                '1': {'raw': 1},
+                '2': {'raw': 1}
+            }, {
+                '$d$timestamp': {'raw': '2012-01-01'},
+                '1': {'raw': 1},
+                '2': {'raw': 1}
+            }, {
+                '$d$timestamp': {'raw': '2016-01-01'},
+                '1': {'raw': 1},
+                '2': {'raw': 1}
+            }]
+        }, result)
+
+    def test_pivot_second_dimension_with_multiple_metrics(self):
+        result = ReactTable(slicer.metrics.wins, slicer.metrics.votes, pivot=[slicer.dimensions.state]) \
+            .transform(cont_uni_dim_df, slicer, [slicer.dimensions.timestamp, slicer.dimensions.state], [])
+
+        self.assertEqual({
+            'columns': [{'Header': 'Timestamp', 'accessor': '$d$timestamp'},
+                        {
+                            'Header': 'Votes',
+                            'columns': [{'Header': 'Texas', 'accessor': '$m$votes.1'},
+                                        {'Header': 'California', 'accessor': '$m$votes.2'}]
+                        }, {
+                            'Header': 'Wins',
+                            'columns': [{'Header': 'Texas', 'accessor': '$m$wins.1'},
+                                        {'Header': 'California', 'accessor': '$m$wins.2'}]
+                        }],
+            'data': [{
+                '$d$timestamp': {'raw': '1996-01-01'},
+                '$m$votes': {'1': {'raw': 5574387}, '2': {'raw': 9646062}},
+                '$m$wins': {'1': {'raw': 1}, '2': {'raw': 1}}
+            }, {
+                '$d$timestamp': {'raw': '2000-01-01'},
+                '$m$votes': {'1': {'raw': 6233385}, '2': {'raw': 10428632}},
+                '$m$wins': {'1': {'raw': 1}, '2': {'raw': 1}}
+            }, {
+                '$d$timestamp': {'raw': '2004-01-01'},
+                '$m$votes': {'1': {'raw': 7359621}, '2': {'raw': 12255311}},
+                '$m$wins': {'1': {'raw': 1}, '2': {'raw': 1}}
+            }, {
+                '$d$timestamp': {'raw': '2008-01-01'},
+                '$m$votes': {'1': {'raw': 8007961}, '2': {'raw': 13286254}},
+                '$m$wins': {'1': {'raw': 1}, '2': {'raw': 1}}
+            }, {
+                '$d$timestamp': {'raw': '2012-01-01'},
+                '$m$votes': {'1': {'raw': 7877967}, '2': {'raw': 12694243}},
+                '$m$wins': {'1': {'raw': 1}, '2': {'raw': 1}}
+            }, {
+                '$d$timestamp': {'raw': '2016-01-01'},
+                '$m$votes': {'1': {'raw': 5072915}, '2': {'raw': 13237598}},
+                '$m$wins': {'1': {'raw': 1}, '2': {'raw': 1}}
+            }]
+        }, result)
+
+    def test_pivot_second_dimension_with_multiple_metrics_and_references(self):
+        result = ReactTable(slicer.metrics.votes, slicer.metrics.wins, pivot=[slicer.dimensions.state]) \
+            .transform(cont_uni_dim_ref_df,
+                       slicer, [
+                           slicer.dimensions.timestamp, slicer.dimensions.state
+                       ], [
+                           ElectionOverElection(slicer.dimensions.timestamp)
+                       ])
+
+        self.assertEqual({
+            'columns': [{'Header': 'Timestamp', 'accessor': '$d$timestamp'},
+                        {
+                            'Header': 'Votes',
+                            'columns': [{'Header': 'Texas', 'accessor': '$m$votes.1'},
+                                        {'Header': 'California', 'accessor': '$m$votes.2'}]
+                        }, {
+                            'Header': 'Votes (EoE)',
+                            'columns': [{'Header': 'Texas', 'accessor': '$m$votes_eoe.1'},
+                                        {
+                                            'Header': 'California',
+                                            'accessor': '$m$votes_eoe.2'
+                                        }]
+                        }, {
+                            'Header': 'Wins',
+                            'columns': [{'Header': 'Texas', 'accessor': '$m$wins.1'},
+                                        {'Header': 'California', 'accessor': '$m$wins.2'}]
+                        }, {
+                            'Header': 'Wins (EoE)',
+                            'columns': [{'Header': 'Texas', 'accessor': '$m$wins_eoe.1'},
+                                        {
+                                            'Header': 'California',
+                                            'accessor': '$m$wins_eoe.2'
+                                        }]
+                        }],
+            'data': [{
+                '$d$timestamp': {'raw': '2000-01-01'},
+                '$m$votes': {'1': {'raw': 6233385.0}, '2': {'raw': 10428632.0}},
+                '$m$votes_eoe': {'1': {'raw': 5574387.0}, '2': {'raw': 9646062.0}},
+                '$m$wins': {'1': {'raw': 1.0}, '2': {'raw': 1.0}},
+                '$m$wins_eoe': {'1': {'raw': 1.0}, '2': {'raw': 1.0}}
+            }, {
+                '$d$timestamp': {'raw': '2004-01-01'},
+                '$m$votes': {'1': {'raw': 7359621.0}, '2': {'raw': 12255311.0}},
+                '$m$votes_eoe': {'1': {'raw': 6233385.0}, '2': {'raw': 10428632.0}},
+                '$m$wins': {'1': {'raw': 1.0}, '2': {'raw': 1.0}},
+                '$m$wins_eoe': {'1': {'raw': 1.0}, '2': {'raw': 1.0}}
+            }, {
+                '$d$timestamp': {'raw': '2008-01-01'},
+                '$m$votes': {'1': {'raw': 8007961.0}, '2': {'raw': 13286254.0}},
+                '$m$votes_eoe': {'1': {'raw': 7359621.0}, '2': {'raw': 12255311.0}},
+                '$m$wins': {'1': {'raw': 1.0}, '2': {'raw': 1.0}},
+                '$m$wins_eoe': {'1': {'raw': 1.0}, '2': {'raw': 1.0}}
+            }, {
+                '$d$timestamp': {'raw': '2012-01-01'},
+                '$m$votes': {'1': {'raw': 7877967.0}, '2': {'raw': 12694243.0}},
+                '$m$votes_eoe': {'1': {'raw': 8007961.0}, '2': {'raw': 13286254.0}},
+                '$m$wins': {'1': {'raw': 1.0}, '2': {'raw': 1.0}},
+                '$m$wins_eoe': {'1': {'raw': 1.0}, '2': {'raw': 1.0}}
+            }, {
+                '$d$timestamp': {'raw': '2016-01-01'},
+                '$m$votes': {'1': {'raw': 5072915.0}, '2': {'raw': 13237598.0}},
+                '$m$votes_eoe': {'1': {'raw': 7877967.0}, '2': {'raw': 12694243.0}},
+                '$m$wins': {'1': {'raw': 1.0}, '2': {'raw': 1.0}},
+                '$m$wins_eoe': {'1': {'raw': 1.0}, '2': {'raw': 1.0}}
+            }]
+        }, result)
+
+    def test_pivot_single_dimension_as_rows_single_metric_metrics_automatically_pivoted(self):
+        result = ReactTable(slicer.metrics.wins, pivot=[slicer.dimensions.candidate]) \
+            .transform(uni_dim_df, slicer, [slicer.dimensions.candidate], [])
+
+        self.assertEqual({
+            'columns': [{'Header': '', 'accessor': '$d$metrics'},
+                        {'Header': 'Bill Clinton', 'accessor': '1'},
+                        {'Header': 'Bob Dole', 'accessor': '2'},
+                        {'Header': 'Ross Perot', 'accessor': '3'},
+                        {'Header': 'George Bush', 'accessor': '4'},
+                        {'Header': 'Al Gore', 'accessor': '5'},
+                        {'Header': 'John Kerry', 'accessor': '6'},
+                        {'Header': 'Barrack Obama', 'accessor': '7'},
+                        {'Header': 'John McCain', 'accessor': '8'},
+                        {'Header': 'Mitt Romney', 'accessor': '9'},
+                        {'Header': 'Donald Trump', 'accessor': '10'},
+                        {'Header': 'Hillary Clinton', 'accessor': '11'}],
+            'data': [{
+                '$d$metrics': {'raw': 'Wins'},
+                '1': {'raw': 2},
+                '10': {'raw': 2},
+                '11': {'raw': 0},
+                '2': {'raw': 0},
+                '3': {'raw': 0},
+                '4': {'raw': 4},
+                '5': {'raw': 0},
+                '6': {'raw': 0},
+                '7': {'raw': 4},
+                '8': {'raw': 0},
+                '9': {'raw': 0}
+            }]
+        }, result)
+
+    def test_pivot_single_dimension_as_rows_single_metric_and_transpose_set_to_true(self):
+        result = ReactTable(slicer.metrics.wins, pivot=[slicer.dimensions.candidate], transpose=True) \
+            .transform(uni_dim_df, slicer, [slicer.dimensions.candidate], [])
+
+        self.assertEqual({
+            'columns': [{'Header': '', 'accessor': '$d$metrics'},
+                        {'Header': 'Bill Clinton', 'accessor': '1'},
+                        {'Header': 'Bob Dole', 'accessor': '2'},
+                        {'Header': 'Ross Perot', 'accessor': '3'},
+                        {'Header': 'George Bush', 'accessor': '4'},
+                        {'Header': 'Al Gore', 'accessor': '5'},
+                        {'Header': 'John Kerry', 'accessor': '6'},
+                        {'Header': 'Barrack Obama', 'accessor': '7'},
+                        {'Header': 'John McCain', 'accessor': '8'},
+                        {'Header': 'Mitt Romney', 'accessor': '9'},
+                        {'Header': 'Donald Trump', 'accessor': '10'},
+                        {'Header': 'Hillary Clinton', 'accessor': '11'}],
+            'data': [{
+                '$d$metrics': {'raw': 'Wins'},
+                '1': {'raw': 2},
+                '10': {'raw': 2},
+                '11': {'raw': 0},
+                '2': {'raw': 0},
+                '3': {'raw': 0},
+                '4': {'raw': 4},
+                '5': {'raw': 0},
+                '6': {'raw': 0},
+                '7': {'raw': 4},
+                '8': {'raw': 0},
+                '9': {'raw': 0}
+            }]
+        }, result)
+
+    def test_pivot_single_dimension_as_rows_multiple_metrics(self):
+        result = ReactTable(slicer.metrics.wins, slicer.metrics.votes,
+                            pivot=[slicer.dimensions.candidate]) \
+            .transform(uni_dim_df, slicer, [slicer.dimensions.candidate], [])
+
+        self.assertEqual({
+            'columns': [{'Header': '', 'accessor': '$d$metrics'},
+                        {'Header': 'Bill Clinton', 'accessor': '1'},
+                        {'Header': 'Bob Dole', 'accessor': '2'},
+                        {'Header': 'Ross Perot', 'accessor': '3'},
+                        {'Header': 'George Bush', 'accessor': '4'},
+                        {'Header': 'Al Gore', 'accessor': '5'},
+                        {'Header': 'John Kerry', 'accessor': '6'},
+                        {'Header': 'Barrack Obama', 'accessor': '7'},
+                        {'Header': 'John McCain', 'accessor': '8'},
+                        {'Header': 'Mitt Romney', 'accessor': '9'},
+                        {'Header': 'Donald Trump', 'accessor': '10'},
+                        {'Header': 'Hillary Clinton', 'accessor': '11'}],
+            'data': [{
+                '$d$metrics': {'raw': 'Wins'},
+                '1': {'raw': 2},
+                '10': {'raw': 2},
+                '11': {'raw': 0},
+                '2': {'raw': 0},
+                '3': {'raw': 0},
+                '4': {'raw': 4},
+                '5': {'raw': 0},
+                '6': {'raw': 0},
+                '7': {'raw': 4},
+                '8': {'raw': 0},
+                '9': {'raw': 0}
+            }, {
+                '$d$metrics': {'raw': 'Votes'},
+                '1': {'raw': 7579518},
+                '10': {'raw': 13438835},
+                '11': {'raw': 4871678},
+                '2': {'raw': 6564547},
+                '3': {'raw': 1076384},
+                '4': {'raw': 18403811},
+                '5': {'raw': 8294949},
+                '6': {'raw': 9578189},
+                '7': {'raw': 24227234},
+                '8': {'raw': 9491109},
+                '9': {'raw': 8148082}
+            }]
+        }, result)
+
+    def test_pivot_single_metric_time_series_dim(self):
+        result = ReactTable(slicer.metrics.wins) \
+            .transform(cont_dim_df, slicer, [slicer.dimensions.timestamp], [])
+
+        self.assertEqual({
+            'columns': [{'Header': 'Timestamp', 'accessor': '$d$timestamp'},
+                        {'Header': 'Wins', 'accessor': '$m$wins'}],
+            'data': [{'$d$timestamp': {'raw': '1996-01-01'}, '$m$wins': {'raw': 2}},
+                     {'$d$timestamp': {'raw': '2000-01-01'}, '$m$wins': {'raw': 2}},
+                     {'$d$timestamp': {'raw': '2004-01-01'}, '$m$wins': {'raw': 2}},
+                     {'$d$timestamp': {'raw': '2008-01-01'}, '$m$wins': {'raw': 2}},
+                     {'$d$timestamp': {'raw': '2012-01-01'}, '$m$wins': {'raw': 2}},
+                     {'$d$timestamp': {'raw': '2016-01-01'}, '$m$wins': {'raw': 2}}]
+        }, result)
+
+    def test_pivot_multi_dims_with_all_levels_totals(self):
+        state = slicer.dimensions.state.rollup()
+        result = ReactTable(slicer.metrics.wins, slicer.metrics.votes, pivot=[state]) \
+            .transform(cont_uni_dim_all_totals_df, slicer, [slicer.dimensions.timestamp.rollup(),
+                                                            state], [])
+
+        self.assertEqual({
+            'columns': [{'Header': 'Timestamp', 'accessor': '$d$timestamp'},
+                        {
+                            'Header': 'Votes',
+                            'columns': [{'Header': 'Texas', 'accessor': '$m$votes.1'},
+                                        {'Header': 'California', 'accessor': '$m$votes.2'},
+                                        {
+                                            'Header': 'Totals',
+                                            'accessor': '$m$votes.totals',
+                                            'className': 'fireant-totals'
+                                        }]
+                        }, {
+                            'Header': 'Wins',
+                            'columns': [{'Header': 'Texas', 'accessor': '$m$wins.1'},
+                                        {'Header': 'California', 'accessor': '$m$wins.2'},
+                                        {
+                                            'Header': 'Totals',
+                                            'accessor': '$m$wins.totals',
+                                            'className': 'fireant-totals'
+                                        }]
+                        }],
+            'data': [{
+                '$d$timestamp': {'raw': '1996-01-01'},
+                '$m$votes': {
+                    '1': {'raw': 5574387.0},
+                    '2': {'raw': 9646062.0},
+                    'totals': {'raw': 15220449.0}
+                },
+                '$m$wins': {
+                    '1': {'raw': 1.0},
+                    '2': {'raw': 1.0},
+                    'totals': {'raw': 2.0}
+                }
+            }, {
+                '$d$timestamp': {'raw': '2000-01-01'},
+                '$m$votes': {
+                    '1': {'raw': 6233385.0},
+                    '2': {'raw': 10428632.0},
+                    'totals': {'raw': 16662017.0}
+                },
+                '$m$wins': {
+                    '1': {'raw': 1.0},
+                    '2': {'raw': 1.0},
+                    'totals': {'raw': 2.0}
+                }
+            }, {
+                '$d$timestamp': {'raw': '2004-01-01'},
+                '$m$votes': {
+                    '1': {'raw': 7359621.0},
+                    '2': {'raw': 12255311.0},
+                    'totals': {'raw': 19614932.0}
+                },
+                '$m$wins': {
+                    '1': {'raw': 1.0},
+                    '2': {'raw': 1.0},
+                    'totals': {'raw': 2.0}
+                }
+            }, {
+                '$d$timestamp': {'raw': '2008-01-01'},
+                '$m$votes': {
+                    '1': {'raw': 8007961.0},
+                    '2': {'raw': 13286254.0},
+                    'totals': {'raw': 21294215.0}
+                },
+                '$m$wins': {
+                    '1': {'raw': 1.0},
+                    '2': {'raw': 1.0},
+                    'totals': {'raw': 2.0}
+                }
+            }, {
+                '$d$timestamp': {'raw': '2012-01-01'},
+                '$m$votes': {
+                    '1': {'raw': 7877967.0},
+                    '2': {'raw': 12694243.0},
+                    'totals': {'raw': 20572210.0}
+                },
+                '$m$wins': {
+                    '1': {'raw': 1.0},
+                    '2': {'raw': 1.0},
+                    'totals': {'raw': 2.0}
+                }
+            }, {
+                '$d$timestamp': {'raw': '2016-01-01'},
+                '$m$votes': {
+                    '1': {'raw': 5072915.0},
+                    '2': {'raw': 13237598.0},
+                    'totals': {'raw': 18310513.0}
+                },
+                '$m$wins': {
+                    '1': {'raw': 1.0},
+                    '2': {'raw': 1.0},
+                    'totals': {'raw': 2.0}
+                }
+            }, {
+                '$d$timestamp': {'raw': 'Totals'},
+                '$m$votes': {
+                    '1': {'raw': ''},
+                    '2': {'raw': ''},
+                    'totals': {'raw': 111674336.0}
+                },
+                '$m$wins': {
+                    '1': {'raw': ''},
+                    '2': {'raw': ''},
+                    'totals': {'raw': 12.0}
+                }
+            }]
+        }, result)
+
+    def test_pivot_first_dimension_and_transpose_with_all_levels_totals(self):
+        state = slicer.dimensions.state.rollup()
+        result = ReactTable(slicer.metrics.wins, slicer.metrics.votes, pivot=[state], transpose=True) \
+            .transform(cont_uni_dim_all_totals_df, slicer, [slicer.dimensions.timestamp.rollup(),
+                                                            state], [])
+
+        self.assertEqual({
+            'columns': [{'Header': '', 'accessor': '$d$metrics'},
+                        {'Header': 'State', 'accessor': '$d$state'},
+                        {'Header': '1996-01-01', 'accessor': '1996-01-01'},
+                        {'Header': '2000-01-01', 'accessor': '2000-01-01'},
+                        {'Header': '2004-01-01', 'accessor': '2004-01-01'},
+                        {'Header': '2008-01-01', 'accessor': '2008-01-01'},
+                        {'Header': '2012-01-01', 'accessor': '2012-01-01'},
+                        {'Header': '2016-01-01', 'accessor': '2016-01-01'},
+                        {
+                            'Header': 'Totals',
+                            'accessor': 'totals',
+                            'className': 'fireant-totals'
+                        }],
+            'data': [{
+                '$d$metrics': {'raw': 'Wins'},
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '1996-01-01': {'raw': 1.0},
+                '2000-01-01': {'raw': 1.0},
+                '2004-01-01': {'raw': 1.0},
+                '2008-01-01': {'raw': 1.0},
+                '2012-01-01': {'raw': 1.0},
+                '2016-01-01': {'raw': 1.0},
+                'totals': {'raw': ''}
+            }, {
+                '$d$metrics': {'raw': 'Wins'},
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '1996-01-01': {'raw': 1.0},
+                '2000-01-01': {'raw': 1.0},
+                '2004-01-01': {'raw': 1.0},
+                '2008-01-01': {'raw': 1.0},
+                '2012-01-01': {'raw': 1.0},
+                '2016-01-01': {'raw': 1.0},
+                'totals': {'raw': ''}
+            }, {
+                '$d$metrics': {'raw': 'Wins'},
+                '$d$state': {'raw': 'Totals'},
+                '1996-01-01': {'raw': 2.0},
+                '2000-01-01': {'raw': 2.0},
+                '2004-01-01': {'raw': 2.0},
+                '2008-01-01': {'raw': 2.0},
+                '2012-01-01': {'raw': 2.0},
+                '2016-01-01': {'raw': 2.0},
+                'totals': {'raw': 12.0}
+            }, {
+                '$d$metrics': {'raw': 'Votes'},
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '1996-01-01': {'raw': 5574387.0},
+                '2000-01-01': {'raw': 6233385.0},
+                '2004-01-01': {'raw': 7359621.0},
+                '2008-01-01': {'raw': 8007961.0},
+                '2012-01-01': {'raw': 7877967.0},
+                '2016-01-01': {'raw': 5072915.0},
+                'totals': {'raw': ''}
+            }, {
+                '$d$metrics': {'raw': 'Votes'},
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '1996-01-01': {'raw': 9646062.0},
+                '2000-01-01': {'raw': 10428632.0},
+                '2004-01-01': {'raw': 12255311.0},
+                '2008-01-01': {'raw': 13286254.0},
+                '2012-01-01': {'raw': 12694243.0},
+                '2016-01-01': {'raw': 13237598.0},
+                'totals': {'raw': ''}
+            }, {
+                '$d$metrics': {'raw': 'Votes'},
+                '$d$state': {'raw': 'Totals'},
+                '1996-01-01': {'raw': 15220449.0},
+                '2000-01-01': {'raw': 16662017.0},
+                '2004-01-01': {'raw': 19614932.0},
+                '2008-01-01': {'raw': 21294215.0},
+                '2012-01-01': {'raw': 20572210.0},
+                '2016-01-01': {'raw': 18310513.0},
+                'totals': {'raw': 111674336.0}
+            }]
+        }, result)
+
+    def test_pivot_second_dimension_and_transpose_with_all_levels_totals(self):
+        state = slicer.dimensions.state.rollup()
+        result = ReactTable(slicer.metrics.wins, slicer.metrics.votes, pivot=[state], transpose=True) \
+            .transform(cont_uni_dim_all_totals_df, slicer, [slicer.dimensions.timestamp.rollup(),
+                                                            state], [])
+
+        self.assertEqual({
+            'columns': [{'Header': '', 'accessor': '$d$metrics'},
+                        {'Header': 'State', 'accessor': '$d$state'},
+                        {'Header': '1996-01-01', 'accessor': '1996-01-01'},
+                        {'Header': '2000-01-01', 'accessor': '2000-01-01'},
+                        {'Header': '2004-01-01', 'accessor': '2004-01-01'},
+                        {'Header': '2008-01-01', 'accessor': '2008-01-01'},
+                        {'Header': '2012-01-01', 'accessor': '2012-01-01'},
+                        {'Header': '2016-01-01', 'accessor': '2016-01-01'},
+                        {
+                            'Header': 'Totals',
+                            'accessor': 'totals',
+                            'className': 'fireant-totals'
+                        }],
+            'data': [{
+                '$d$metrics': {'raw': 'Wins'},
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '1996-01-01': {'raw': 1.0},
+                '2000-01-01': {'raw': 1.0},
+                '2004-01-01': {'raw': 1.0},
+                '2008-01-01': {'raw': 1.0},
+                '2012-01-01': {'raw': 1.0},
+                '2016-01-01': {'raw': 1.0},
+                'totals': {'raw': ''}
+            }, {
+                '$d$metrics': {'raw': 'Wins'},
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '1996-01-01': {'raw': 1.0},
+                '2000-01-01': {'raw': 1.0},
+                '2004-01-01': {'raw': 1.0},
+                '2008-01-01': {'raw': 1.0},
+                '2012-01-01': {'raw': 1.0},
+                '2016-01-01': {'raw': 1.0},
+                'totals': {'raw': ''}
+            }, {
+                '$d$metrics': {'raw': 'Wins'},
+                '$d$state': {'raw': 'Totals'},
+                '1996-01-01': {'raw': 2.0},
+                '2000-01-01': {'raw': 2.0},
+                '2004-01-01': {'raw': 2.0},
+                '2008-01-01': {'raw': 2.0},
+                '2012-01-01': {'raw': 2.0},
+                '2016-01-01': {'raw': 2.0},
+                'totals': {'raw': 12.0}
+            }, {
+                '$d$metrics': {'raw': 'Votes'},
+                '$d$state': {'display': 'Texas', 'raw': '1'},
+                '1996-01-01': {'raw': 5574387.0},
+                '2000-01-01': {'raw': 6233385.0},
+                '2004-01-01': {'raw': 7359621.0},
+                '2008-01-01': {'raw': 8007961.0},
+                '2012-01-01': {'raw': 7877967.0},
+                '2016-01-01': {'raw': 5072915.0},
+                'totals': {'raw': ''}
+            }, {
+                '$d$metrics': {'raw': 'Votes'},
+                '$d$state': {'display': 'California', 'raw': '2'},
+                '1996-01-01': {'raw': 9646062.0},
+                '2000-01-01': {'raw': 10428632.0},
+                '2004-01-01': {'raw': 12255311.0},
+                '2008-01-01': {'raw': 13286254.0},
+                '2012-01-01': {'raw': 12694243.0},
+                '2016-01-01': {'raw': 13237598.0},
+                'totals': {'raw': ''}
+            }, {
+                '$d$metrics': {'raw': 'Votes'},
+                '$d$state': {'raw': 'Totals'},
+                '1996-01-01': {'raw': 15220449.0},
+                '2000-01-01': {'raw': 16662017.0},
+                '2004-01-01': {'raw': 19614932.0},
+                '2008-01-01': {'raw': 21294215.0},
+                '2012-01-01': {'raw': 20572210.0},
+                '2016-01-01': {'raw': 18310513.0},
+                'totals': {'raw': 111674336.0}
+            }]
+        }, result)

--- a/fireant/utils.py
+++ b/fireant/utils.py
@@ -5,20 +5,49 @@ def wrap_list(value):
     return value if isinstance(value, (tuple, list)) else [value]
 
 
-def deep_get(d, keys, default=None):
-    d_level = d
-    for key in keys:
-        if key not in d_level:
-            return default
-        d_level = d_level[key]
-    return d_level
+def setdeepattr(d, keys, value):
+    """
+    Similar to the built-in `setattr`, this function accepts a list/tuple of keys to set a value deep in a `dict`
 
+    Given the following dict structure
+    ```
+    d = {
+      'A': {
+        '0': {
+          'a': 1,
+          'b': 2,
+        }
+      },
+    }
+    ```
 
-def setdeepattr(d, key, value):
-    if not isinstance(key, (list, tuple)):
-        key = (key,)
+    Calling `setdeepattr` with a key path to a value deep in the structure will set that value. If the value or any
+    of the objects in the key path do not exist, then a dict will be created.
 
-    top, *rest = key
+    ```
+    # Overwrites the value in `d` at A.0.a, which was 1, to 3
+    setdeepattr(d, ('A', '0', 'a'), 3)
+
+    # Adds an entry in `d` to A.0 with the key 'c' and the value 3
+    setdeepattr(d, ('A', '0', 'c'), 3)
+
+    # Adds an entry in `d` with the key 'X' and the value a new dict
+    # Adds an entry in `d` to `X` with the key '0' and the value a new dict
+    # Adds an entry in `d` to `X.0` with the key 'a' and the value 0
+    setdeepattr(d, ('X', '0', 'a'), 0)
+    ```
+
+    :param d:
+        A dict value with nested dict attributes.
+    :param keys:
+        A list/tuple path of keys in `d` to the desired value
+    :param value:
+        The value to set at the given path `keys`.
+    """
+    if not isinstance(keys, (list, tuple)):
+        keys = (keys,)
+
+    top, *rest = keys
 
     if rest:
         if top not in d:
@@ -31,6 +60,40 @@ def setdeepattr(d, key, value):
 
 
 def getdeepattr(d, keys, default_value=None):
+    """
+    Similar to the built-in `getattr`, this function accepts a list/tuple of keys to get a value deep in a `dict`
+
+    Given the following dict structure
+    ```
+    d = {
+      'A': {
+        '0': {
+          'a': 1,
+          'b': 2,
+        }
+      },
+    }
+    ```
+
+    Calling `getdeepattr` with a key path to a value deep in the structure will return that value. If the value or any
+    of the objects in the key path do not exist, then the default value is returned.
+
+    ```
+    assert 1 == getdeepattr(d, ('A', '0', 'a'))
+    assert 2 == getdeepattr(d, ('A', '0', 'b'))
+    assert 0 == getdeepattr(d, ('A', '0', 'c'), default_value=0)
+    assert 0 == getdeepattr(d, ('X', '0', 'a'), default_value=0)
+    ```
+
+    :param d:
+        A dict value with nested dict attributes.
+    :param keys:
+        A list/tuple path of keys in `d` to the desired value
+    :param default_value:
+        A default value that will be returned if the path `keys` does not yield a value.
+    :return:
+        The value following the path `keys` or `default_value`
+    """
     d_level = d
 
     for key in keys:
@@ -49,12 +112,6 @@ def slice_first(item):
     if isinstance(item, (tuple, list)):
         return item[0]
     return item
-
-
-a = 'a' \
-    if True \
-    else 'b' if True \
-    else 'c'
 
 
 def filter_duplicates(iterable):

--- a/fireant/utils.py
+++ b/fireant/utils.py
@@ -13,6 +13,34 @@ def deep_get(d, keys, default=None):
         d_level = d_level[key]
     return d_level
 
+
+def setdeepattr(d, key, value):
+    if not isinstance(key, (list, tuple)):
+        key = (key,)
+
+    top, *rest = key
+
+    if rest:
+        if top not in d:
+            d[top] = {}
+
+        setdeepattr(d[top], rest, value)
+
+    else:
+        d[top] = value
+
+
+def getdeepattr(d, keys, default_value=None):
+    d_level = d
+
+    for key in keys:
+        if key not in d_level:
+            return default_value
+
+        d_level = d_level[key]
+
+    return d_level
+
 def flatten(items):
     return [item for level in items for item in wrap_list(level)]
 
@@ -21,6 +49,12 @@ def slice_first(item):
     if isinstance(item, (tuple, list)):
         return item[0]
     return item
+
+
+a = 'a' \
+    if True \
+    else 'b' if True \
+    else 'c'
 
 
 def filter_duplicates(iterable):


### PR DESCRIPTION
Added a react-table transformer and changed pivot behavior of the Pandas and CSV transformers to pivot any dimension and to transpose the data frame.

These transformers accept two arguments: `pivot: List<Dimension>` and `transpose: bool` 

With pivoted dimensions, the tables will render dimension values across columns instead of rows. When transpose is true, the columns and rows will be swapped.