### PR TITLE
Added handle for empty sort array in pandas transformer

### DIFF
--- a/fireant/slicer/widgets/pandas.py
+++ b/fireant/slicer/widgets/pandas.py
@@ -122,7 +122,7 @@ class Pandas(TransformableWidget):
         return self.sort_data_frame(data_frame)
 
     def sort_data_frame(self, data_frame):
-        if self.sort is None:
+        if not self.sort:
             return data_frame
 
         # reset the index so all columns can be sorted together

--- a/fireant/tests/slicer/widgets/test_pandas.py
+++ b/fireant/tests/slicer/widgets/test_pandas.py
@@ -532,3 +532,14 @@ class PandasTransformerSortTests(TestCase):
         expected = expected.set_index(['Timestamp', 'State'])
 
         pandas.testing.assert_frame_equal(expected, result)
+
+    def test_empty_sort_array_is_ignored(self):
+        result = Pandas(slicer.metrics.wins, sort=[]) \
+            .transform(cont_dim_df, slicer, [slicer.dimensions.timestamp], [])
+
+        expected = cont_dim_df.copy()[[fm('wins')]]
+        expected.index.names = ['Timestamp']
+        expected.columns = ['Wins']
+        expected.columns.name = 'Metrics'
+
+        pandas.testing.assert_frame_equal(expected, result)


### PR DESCRIPTION
Fixed a case where an empty sort array passed to the fireant transformers would raise an unhandled exception.