### PR TITLE
Handle invalid column idx in sort

### DIFF
--- a/fireant/slicer/widgets/pandas.py
+++ b/fireant/slicer/widgets/pandas.py
@@ -135,7 +135,13 @@ class Pandas(TransformableWidget):
             if self.ascending is not None \
             else True
 
-        sort_columns = [column_names[abs(column)] for column in self.sort]
+        sort_columns = [column_names[column]
+                        for column in self.sort
+                        if column < len(column_names)]
+
+        if not sort_columns:
+            return data_frame
+
         return unsorted \
             .sort_values(sort_columns, ascending=ascending) \
             .set_index(index_names)

--- a/fireant/tests/slicer/widgets/test_pandas.py
+++ b/fireant/tests/slicer/widgets/test_pandas.py
@@ -543,3 +543,15 @@ class PandasTransformerSortTests(TestCase):
         expected.columns.name = 'Metrics'
 
         pandas.testing.assert_frame_equal(expected, result)
+
+
+    def test_sort_value_greater_than_number_of_columns_is_ignored(self):
+        result = Pandas(slicer.metrics.wins, sort=[5]) \
+            .transform(cont_dim_df, slicer, [slicer.dimensions.timestamp], [])
+
+        expected = cont_dim_df.copy()[[fm('wins')]]
+        expected.index.names = ['Timestamp']
+        expected.columns = ['Wins']
+        expected.columns.name = 'Metrics'
+
+        pandas.testing.assert_frame_equal(expected, result)


### PR DESCRIPTION
Changed the behavior of the pandas transfomer's sorting to ignore invalid indices 