### PR TITLE
Fixed sorting data frames with no dimensions

### DIFF
--- a/fireant/slicer/widgets/pandas.py
+++ b/fireant/slicer/widgets/pandas.py
@@ -121,7 +121,7 @@ class Pandas(TransformableWidget):
             .fillna(value='')
 
     def sort_data_frame(self, data_frame):
-        if not self.sort:
+        if not self.sort or len(data_frame) == 1:
             return data_frame
 
         # reset the index so all columns can be sorted together

--- a/fireant/slicer/widgets/pandas.py
+++ b/fireant/slicer/widgets/pandas.py
@@ -122,6 +122,7 @@ class Pandas(TransformableWidget):
 
     def sort_data_frame(self, data_frame):
         if not self.sort or len(data_frame) == 1:
+            # If there are no sort arguments or the data frame is a single row, then no need to sort
             return data_frame
 
         # reset the index so all columns can be sorted together

--- a/fireant/tests/slicer/mocks.py
+++ b/fireant/tests/slicer/mocks.py
@@ -1,23 +1,23 @@
 from collections import (
     OrderedDict,
 )
-from unittest.mock import Mock
-
-import pandas as pd
 from datetime import (
     datetime,
 )
-from pypika import (
-    JoinType,
-    Table,
-    functions as fn,
-)
+from unittest.mock import Mock
+
+import pandas as pd
 
 from fireant import *
 from fireant.slicer.references import ReferenceType
 from fireant.utils import (
     format_dimension_key as fd,
     format_metric_key as fm,
+)
+from pypika import (
+    JoinType,
+    Table,
+    functions as fn,
 )
 
 
@@ -259,6 +259,8 @@ multi_metric_df = pd.DataFrame(mock_politics_database[[fm('votes'), fm('wins')]]
 cont_dim_df = mock_politics_database[[fd('timestamp'), fm('votes'), fm('wins')]] \
     .groupby(fd('timestamp')) \
     .sum()
+
+no_index_df = pd.DataFrame(cont_dim_df.sum()).T
 
 cat_dim_df = mock_politics_database[[fd('political_party'), fm('votes'), fm('wins')]] \
     .groupby(fd('political_party')) \

--- a/fireant/tests/slicer/widgets/test_pandas.py
+++ b/fireant/tests/slicer/widgets/test_pandas.py
@@ -16,6 +16,7 @@ from fireant.tests.slicer.mocks import (
     cont_uni_dim_df,
     cont_uni_dim_ref_df,
     multi_metric_df,
+    no_index_df,
     single_metric_df,
     slicer,
     uni_dim_df,
@@ -544,12 +545,22 @@ class PandasTransformerSortTests(TestCase):
 
         pandas.testing.assert_frame_equal(expected, result)
 
-
     def test_sort_value_greater_than_number_of_columns_is_ignored(self):
         result = Pandas(slicer.metrics.wins, sort=[5]) \
             .transform(cont_dim_df, slicer, [slicer.dimensions.timestamp], [])
 
         expected = cont_dim_df.copy()[[fm('wins')]]
+        expected.index.names = ['Timestamp']
+        expected.columns = ['Wins']
+        expected.columns.name = 'Metrics'
+
+        pandas.testing.assert_frame_equal(expected, result)
+
+    def test_sort_with_no_index(self):
+        result = Pandas(slicer.metrics.wins, sort=[0]) \
+            .transform(no_index_df, slicer, [slicer.dimensions.timestamp], [])
+
+        expected = no_index_df.copy()[[fm('wins')]]
         expected.index.names = ['Timestamp']
         expected.columns = ['Wins']
         expected.columns.name = 'Metrics'


### PR DESCRIPTION
Fixed another issue related to sorting data frames in the pandas transformer when there are no dimensions