### PR TITLE
Fixed mysql connection

### DIFF
--- a/fireant/database/mysql.py
+++ b/fireant/database/mysql.py
@@ -48,6 +48,8 @@ class MySQLDatabase(Database):
         self.charset = charset
 
     def _get_connection_class(self):
+        # Nesting inside a function so the import does not cause issues if users have not installed the 'mysql' extra
+        # when installing
         import pymysql
 
         class MySQLConnection(pymysql.connections.Connection):

--- a/fireant/tests/database/test_mysql.py
+++ b/fireant/tests/database/test_mysql.py
@@ -29,17 +29,17 @@ class TestMySQLDatabase(TestCase):
         self.assertIsNone(self.mysql.user)
         self.assertIsNone(self.mysql.password)
 
-    def test_connect(self):
+    @patch.object(MySQLDatabase, '_get_connection_class')
+    def test_connect(self, mock_connection_class):
         mock_pymysql = Mock()
         with patch.dict('sys.modules', pymysql=mock_pymysql):
             mock_pymysql.connect.return_value = 'OK'
 
             mysql = MySQLDatabase(database='test_database', host='test_host', port=1234,
                                   user='test_user', password='password')
-            result = mysql.connect()
+            mysql.connect()
 
-        self.assertEqual('OK', result)
-        mock_pymysql.connect.assert_called_once_with(
+        mock_connection_class.return_value.assert_called_once_with(
             host='test_host', port=1234, db='test_database', charset='utf8mb4',
             user='test_user', password='password', cursorclass=ANY
         )


### PR DESCRIPTION
For all drivers aside from pymysql, using a context manager like `with db.connect() as connection` returned a connection object. This was then passed to pandas which retrieved the cursor, executed the query and closed the cursor.

Pymysql's connection object returns a cursor object when used in a context manager. This PR adds a class which overrides the pymysql connection object to ensure that the connection object is returned on __enter__ and closed on __exit__ (which was not happening on the pymysql version). Note: This class could have been nested in the connect method, but that would make it hard to test, so I extracted it into a separate method.