### PR TITLE
Fix zero dimension checks in transformers

### DIFF
--- a/fireant/database/base.py
+++ b/fireant/database/base.py
@@ -9,8 +9,8 @@ from pypika import (
 class Database(object):
     """
     This is a abstract base class used for interfacing with a database platform.
-
     """
+
     # The pypika query class to use for constructing queries
     query_cls = Query
 

--- a/fireant/slicer/dimensions.py
+++ b/fireant/slicer/dimensions.py
@@ -1,11 +1,7 @@
 from typing import Iterable
 
 from fireant.utils import immutable
-from pypika.terms import (
-    Case,
-    NullValue,
-    ValueWrapper,
-)
+from pypika.terms import NullValue
 from .base import SlicerElement
 from .exceptions import QueryException
 from .filters import (

--- a/fireant/slicer/widgets/highcharts.py
+++ b/fireant/slicer/widgets/highcharts.py
@@ -2,12 +2,12 @@ import itertools
 from datetime import datetime
 
 import pandas as pd
+
 from fireant import (
     DatetimeDimension,
     formats,
     utils,
 )
-
 from .base import TransformableWidget
 from .chart_base import (
     ChartWidget,
@@ -160,7 +160,7 @@ class HighCharts(ChartWidget, TransformableWidget):
             }
 
         categories = ["All"] \
-            if isinstance(first_level, pd.RangeIndex) \
+            if not isinstance(data_frame.index, pd.MultiIndex) and data_frame.index.name is None \
             else [utils.getdeepattr(dimension_display_values,
                                     (first_level.name, dimension_value),
                                     dimension_value or 'Totals')

--- a/fireant/slicer/widgets/reacttable.py
+++ b/fireant/slicer/widgets/reacttable.py
@@ -215,7 +215,7 @@ class ReactTable(Pandas):
                          for d in dimensions + [metrics]}
 
         columns = []
-        if isinstance(data_frame.index, pd.RangeIndex):
+        if not isinstance(data_frame.index, pd.MultiIndex) and data_frame.index.name is None:
             return columns
 
         for f_dimension_key in data_frame.index.names:


### PR DESCRIPTION
Since merging data frames results in the RangeIndex being converted, a more accurate check should be made to assert if the data frame was created with zero active dimensions.