### PR TITLE
Fixed queries ordered by a metric not selected in a widget

### DIFF
--- a/fireant/slicer/queries/builder.py
+++ b/fireant/slicer/queries/builder.py
@@ -1,13 +1,15 @@
-import pandas as pd
 from typing import (
     Dict,
     Iterable,
 )
 
+import pandas as pd
+
 from fireant.utils import (
     format_dimension_key,
     format_metric_key,
     immutable,
+    repr_field_key,
 )
 from pypika import Order
 from . import special_cases
@@ -240,7 +242,10 @@ class SlicerQueryBuilder(QueryBuilder):
                         + ["filter({})".format(repr(filter))
                            for filter in self._filters]
                         + ["reference({})".format(repr(reference))
-                           for reference in self._references])
+                           for reference in self._references]
+                        + ["orderby({}, {})".format(repr_field_key(definition.alias),
+                                                    orientation)
+                           for (definition, orientation) in self._orders])
 
 
 class DimensionChoicesQueryBuilder(QueryBuilder):

--- a/fireant/slicer/queries/makers.py
+++ b/fireant/slicer/queries/makers.py
@@ -179,8 +179,12 @@ def make_slicer_query(database: Database,
     if terms:
         query = query.select(*terms)
 
+    select_aliases = {el.alias for el in query._selects}
     for (term, orientation) in orders:
         query = query.orderby(term, order=orientation)
+
+        if term.alias not in select_aliases:
+            query = query.select(term)
 
     return query
 
@@ -201,6 +205,7 @@ def make_latest_query(database: Database,
         query = query.select(fn.Max(dimension.definition).as_(f_dimension_key))
 
     return query
+
 
 def make_terms_for_metrics(metrics):
     return [metric.definition.as_(format_metric_key(metric.key))
@@ -256,4 +261,3 @@ def make_orders_for_dimensions(dimensions):
 
     return [(definition, None)
             for definition in definitions]
-

--- a/fireant/tests/slicer/queries/test_build_orderbys.py
+++ b/fireant/tests/slicer/queries/test_build_orderbys.py
@@ -1,8 +1,7 @@
 from unittest import TestCase
 
-from pypika import Order
-
 import fireant as f
+from pypika import Order
 from ..mocks import slicer
 
 
@@ -193,3 +192,20 @@ class QueryBuilderOrderTests(TestCase):
                          'FROM "politics"."politician" '
                          'GROUP BY "$d$timestamp" '
                          'ORDER BY "$d$timestamp" ASC,"$m$votes" DESC', str(queries[0]))
+
+    def test_build_query_order_by_metric_not_in_widget(self):
+        queries = slicer.data \
+            .widget(f.DataTablesJS(slicer.metrics.votes)) \
+            .dimension(slicer.dimensions.timestamp) \
+            .orderby(slicer.metrics.wins) \
+            .queries
+
+        self.assertEqual(len(queries), 1)
+
+        self.assertEqual('SELECT '
+                         'TRUNC("timestamp",\'DD\') "$d$timestamp",'
+                         'SUM("votes") "$m$votes",'
+                         'SUM("is_winner") "$m$wins" '
+                         'FROM "politics"."politician" '
+                         'GROUP BY "$d$timestamp" '
+                         'ORDER BY "$m$wins"', str(queries[0]))

--- a/fireant/utils.py
+++ b/fireant/utils.py
@@ -237,3 +237,10 @@ def format_dimension_key(key):
 
 def format_metric_key(key):
     return format_key(key, 'm')
+
+
+def repr_field_key(key):
+    field_type_symbol = key[1]
+    field_key = key[3:]
+    field_type = {'m': 'metrics', 'd': 'dimensions'}[field_type_symbol]
+    return 'slicer.{}.{}'.format(field_type, field_key)


### PR DESCRIPTION
Added a select statement for metrics included in the order by that are not selected as metrics.