### PR TITLE
Improvement on how totals for dimensions are marked in pandas index

### DIFF
--- a/fireant/formats.py
+++ b/fireant/formats.py
@@ -1,11 +1,16 @@
+import numpy as np
+import pandas as pd
 from datetime import (
     date,
     datetime,
     time,
 )
 
-import numpy as np
-import pandas as pd
+from fireant.utils import (
+    MAX_NUMBER,
+    MAX_STRING,
+    MAX_TIMESTAMP,
+)
 
 INF_VALUE = "Inf"
 NULL_VALUE = 'null'
@@ -60,8 +65,11 @@ def dimension_value(value):
         When True, dates and datetimes will be converted to ISO strings. The time is omitted for dates. When False, the
         datetime will be converted to a POSIX timestamp (millis-since-epoch).
     """
-    if pd.isnull(value):
+    if value in {MAX_STRING, MAX_NUMBER, MAX_TIMESTAMP}:
         return 'Totals'
+
+    if pd.isnull(value):
+        return NAN_VALUE
 
     if isinstance(value, date):
         if not hasattr(value, 'time') or value.time() == NO_TIME:

--- a/fireant/slicer/queries/builder.py
+++ b/fireant/slicer/queries/builder.py
@@ -224,7 +224,8 @@ class SlicerQueryBuilder(QueryBuilder):
         data_frame = paginate(data_frame,
                               self._widgets,
                               orders=self._orders,
-                              limit=self._limit, offset=self._offset)
+                              limit=self._limit,
+                              offset=self._offset)
 
         # Apply transformations
         return [widget.transform(data_frame, self.slicer, self._dimensions, self._references)

--- a/fireant/slicer/queries/database.py
+++ b/fireant/slicer/queries/database.py
@@ -1,24 +1,23 @@
 import time
 from functools import (
-    partial,
     reduce,
     wraps,
 )
 from multiprocessing.pool import ThreadPool
-
-import pandas as pd
 from typing import (
     Iterable,
     Sized,
     Union,
 )
 
+import numpy as np
+import pandas as pd
+
 from fireant.database import Database
-from fireant.formats import (
-    NULL_VALUE,
-    TOTALS_VALUE,
-)
 from fireant.utils import (
+    MAX_NUMBER,
+    MAX_STRING,
+    MAX_TIMESTAMP,
     chunks,
     format_dimension_key,
 )
@@ -26,22 +25,19 @@ from .logger import (
     query_logger,
     slow_query_logger,
 )
-from ..dimensions import (
-    ContinuousDimension,
-    Dimension,
-)
+from ..dimensions import Dimension
 
 
 def fetch_data(database: Database, queries: Union[Sized, Iterable], dimensions: Iterable[Dimension],
                reference_groups=()):
-    iterable = [(str(query.limit(int(database.max_result_set_size))), database, dimensions)
+    iterable = [(str(query.limit(int(database.max_result_set_size))), database)
                 for query in queries]
 
     with ThreadPool(processes=database.max_processes) as pool:
         results = pool.map(_exec, iterable)
         pool.close()
 
-    return _reduce_result_set(results, reference_groups)
+    return _reduce_result_set(results, reference_groups, dimensions)
 
 
 def _exec(args):
@@ -81,7 +77,7 @@ def log(func):
 
 @db_cache
 @log
-def _do_fetch_data(query: str, database: Database, dimensions: Iterable[Dimension]):
+def _do_fetch_data(query: str, database: Database):
     """
     Executes a query to fetch data from database middleware and builds/cleans the data as a data frame. The query
     execution is logged with its duration.
@@ -89,28 +85,37 @@ def _do_fetch_data(query: str, database: Database, dimensions: Iterable[Dimensio
     :param database:
         instance of `fireant.Database`, database middleware
     :param query: Query string
-    :param dimensions: A list of dimensions, used for setting the index on the result data frame.
 
     :return: `pd.DataFrame` constructed from the result of the query
     """
     with database.connect() as connection:
-        data_frame = pd.read_sql(query, connection, coerce_float=True, parse_dates=True)
-        return _clean_and_apply_index(data_frame, dimensions)
+        return pd.read_sql(query, connection, coerce_float=True, parse_dates=True)
 
 
-def _reduce_result_set(results: Iterable[pd.DataFrame], reference_groups=()):
+def _reduce_result_set(results: Iterable[pd.DataFrame], reference_groups, dimensions: Iterable[Dimension]):
     """
     Reduces the result sets from individual queries into a single data frame. This effectively joins sets of references
     and concats the sets of totals.
 
     :param results: A list of data frame
     :param reference_groups: A list of groups of references (grouped by interval such as WoW, etc)
+    :param dimensions: A list of dimensions, used for setting the index on the result data frame.
     :return:
     """
+
+    # One result group for each rolled up dimension. Groups contain one member plus one for each reference type used.
     result_groups = chunks(results, 1 + len(reference_groups))
 
-    groups = []
-    for result_group in result_groups:
+    dimension_keys = [format_dimension_key(d.key)
+                      for d in dimensions]
+    rollup_dimension_keys = [format_dimension_key(d.key)
+                             for d in dimensions
+                             if d.is_rollup]
+    rollup_dimension_dtypes = result_groups[0][0][rollup_dimension_keys].dtypes
+
+    # Reduce each group to one data frame per rolled up dimension
+    group_data_frames = []
+    for i, result_group in enumerate(result_groups):
         base_df = result_group[0]
         reference_dfs = [_make_reference_data_frame(base_df, result, reference)
                          for result, reference_group in zip(result_group[1:], reference_groups)
@@ -118,9 +123,27 @@ def _reduce_result_set(results: Iterable[pd.DataFrame], reference_groups=()):
 
         reduced = reduce(lambda left, right: pd.merge(left, right, how='outer', left_index=True, right_index=True),
                          [base_df] + reference_dfs)
-        groups.append(reduced)
 
-    return pd.concat(groups, sort=False)
+        if rollup_dimension_keys[:i]:
+            reduced = _replace_nans_for_rollup_values(reduced, rollup_dimension_dtypes[-i:])
+
+        reduced = reduced.set_index(dimension_keys)
+        group_data_frames.append(reduced)
+
+    return pd.concat(group_data_frames, sort=False) \
+        .sort_index(na_position='first')
+
+
+def _replace_nans_for_rollup_values(data_frame, dtypes):
+    replace = {
+        np.dtype('<M8[ns]'): MAX_TIMESTAMP,
+        np.dtype('int64'): MAX_NUMBER,
+    }
+
+    for dimension_key, dtype in dtypes.items():
+        data_frame[dimension_key] = replace.get(dtype, MAX_STRING)
+
+    return data_frame
 
 
 def _make_reference_data_frame(base_df, ref_df, reference):
@@ -156,93 +179,3 @@ def _make_reference_data_frame(base_df, ref_df, reference):
     if reference.delta_percent:
         return 100. * ref_delta_df / ref_df
     return ref_delta_df
-
-
-def _clean_and_apply_index(data_frame: pd.DataFrame, dimensions: Iterable[Dimension]):
-    """
-    Sets the index on a data frame. This will also replace any nulls from the database with an empty string for
-    non-continuous dimensions. Totals will be indexed with Nones.
-
-    :param data_frame:
-    :param dimensions:
-    :return:
-    """
-    if not dimensions:
-        return data_frame
-
-    dimension_keys = [format_dimension_key(d.key)
-                      for d in dimensions]
-
-    for i, dimension in enumerate(dimensions):
-        if isinstance(dimension, ContinuousDimension):
-            # Continuous dimensions are can never contain null values since they are selected as windows of values
-            # With that in mind, we leave the NaNs in them to represent Totals.
-            continue
-
-        level = format_dimension_key(dimension.key)
-        data_frame[level] = _fill_nans_in_level(data_frame, dimensions[:i + 1]) \
-            .apply(
-              # Handles an annoying case of pandas in which the ENTIRE data frame gets converted from int to float if
-              # the are NaNs, even if there are no NaNs in the column :/
-              lambda x: int(x) if isinstance(x, float) and float.is_integer(x) else x) \
-            .apply(lambda x: str(x) if not pd.isnull(x) else None)
-
-    # Set index on dimension columns
-    return data_frame.set_index(dimension_keys)
-
-
-def _fill_nans_in_level(data_frame, dimensions):
-    """
-    In case there are NaN values representing both totals (from ROLLUP) and database nulls, we need to replace the real
-    nulls with an empty string in order to distinguish between them.  We choose to replace the actual database nulls
-    with an empty string in order to let NaNs represent Totals because mixing string values in the pandas index types
-    used by continuous dimensions does work.
-
-    :param data_frame:
-        The data_frame we are replacing values in.
-    :param dimensions:
-        A list of dimensions with the last item in the list being the dimension to fill nans for. This function requires
-        the dimension being processed as well as the preceding dimensions since a roll up in a higher level dimension
-        results in nulls for lower level dimension.
-    :return:
-        The level in the data_frame with the nulls replaced with empty string
-    """
-    level = format_dimension_key(dimensions[-1].key)
-
-    number_rollup_dimensions = sum(dimension.is_rollup for dimension in dimensions)
-    if 0 < number_rollup_dimensions:
-        fill_nan_for_nulls = partial(_fill_nan_for_nulls, n_rolled_up_dimensions=number_rollup_dimensions)
-
-        if 1 < len(dimensions):
-            preceding_dimension_keys = [format_dimension_key(d.key)
-                                        for d in dimensions[:-1]]
-
-            return (data_frame
-                    .groupby(preceding_dimension_keys)[level]
-                    .apply(fill_nan_for_nulls))
-
-        return fill_nan_for_nulls(data_frame[level])
-
-    return data_frame[level].fillna(NULL_VALUE)
-
-
-def _fill_nan_for_nulls(df, n_rolled_up_dimensions=1):
-    """
-    Fills the first NaN with a literal string "null" if there are two NaN values, otherwise nothing is filled.
-
-    :param df:
-    :param n_rolled_up_dimensions:
-        The number of rolled up dimensions preceding and including the dimension
-    :return:
-    """
-
-    # If there are rolled up dimensions, then fill only the first instance of NULL with a literal string "null" and
-    # the rest of the nulls are totals. This check compares the number of nulls to the number of rolled up dimensions,
-    # or expected nulls which are totals rows. If there are more nulls, there should be exactly
-    # `n_rolled_up_dimensions+1` nulls which means one is a true `null` value.
-    number_of_nulls_for_dimension = pd.isnull(df).sum()
-    if n_rolled_up_dimensions < number_of_nulls_for_dimension:
-        assert n_rolled_up_dimensions + 1 == number_of_nulls_for_dimension
-        return df.fillna(NULL_VALUE, limit=1).fillna(TOTALS_VALUE)
-
-    return df.fillna(TOTALS_VALUE)

--- a/fireant/slicer/queries/makers.py
+++ b/fireant/slicer/queries/makers.py
@@ -80,7 +80,7 @@ def make_slicer_query_with_rollup_and_references(database,
     ```
     """
     rollup_dimensions = find_rolled_up_dimensions(dimensions)
-    rollup_dimensions_and_none = [None] + rollup_dimensions
+    rollup_dimensions_and_none = [None] + rollup_dimensions[::-1]
 
     reference_groups = find_and_group_references_for_dimensions(references)
     reference_groups_and_none = [(None, None)] + list(reference_groups.items())

--- a/fireant/slicer/widgets/datatables.py
+++ b/fireant/slicer/widgets/datatables.py
@@ -7,7 +7,11 @@ from fireant import (
     formats,
     utils,
 )
+from fireant.formats import NAN_VALUE
 from fireant.utils import (
+    MAX_NUMBER,
+    MAX_STRING,
+    MAX_TIMESTAMP,
     format_dimension_key,
     format_metric_key,
 )
@@ -40,8 +44,10 @@ def _render_dimension_cell(dimension_value: str, display_values: dict):
     dimension_cell = {'value': formats.dimension_value(dimension_value)}
 
     if display_values is not None:
-        if pd.isnull(dimension_value):
+        if dimension_value in {MAX_STRING, MAX_NUMBER, MAX_TIMESTAMP}:
             dimension_cell['display'] = 'Totals'
+        elif pd.isnull(dimension_value):
+            dimension_cell['display'] = NAN_VALUE
         else:
             display_value = display_values.get(dimension_value, dimension_value)
             dimension_cell['display'] = formats.dimension_value(display_value)

--- a/fireant/slicer/widgets/helpers.py
+++ b/fireant/slicer/widgets/helpers.py
@@ -1,12 +1,22 @@
 import numpy as np
-import pandas as pd
 
 from fireant import utils
 from fireant.formats import (
     INF_VALUE,
     NAN_VALUE,
 )
+from fireant.utils import (
+    MAX_NUMBER,
+    MAX_STRING,
+    MAX_TIMESTAMP,
+)
 from ..references import reference_label
+
+TOTALS_MARKERS = {
+    MAX_NUMBER,
+    MAX_STRING,
+    MAX_TIMESTAMP,
+}
 
 
 def extract_display_values(dimensions, data_frame):
@@ -77,7 +87,7 @@ def dimensional_metric_label(dimensions, dimension_display_values):
         dimension_labels = [utils.getdeepattr(dimension_display_values,
                                               (utils.format_dimension_key(dimension.key), dimension_value),
                                               dimension_value)
-                            if not pd.isnull(dimension_value)
+                            if dimension_value not in TOTALS_MARKERS
                             else 'Totals'
                             for dimension, dimension_value in zip(used_dimensions, dimension_values)]
 

--- a/fireant/tests/slicer/queries/test_build_dimensions.py
+++ b/fireant/tests/slicer/queries/test_build_dimensions.py
@@ -1,5 +1,6 @@
-from datetime import date
 from unittest import TestCase
+
+from datetime import date
 
 import fireant as f
 from ..mocks import slicer
@@ -305,17 +306,6 @@ class QueryBuilderDimensionTotalsTests(TestCase):
                              'GROUP BY "$d$timestamp","$d$candidate","$d$candidate_display","$d$political_party" '
                              'ORDER BY "$d$timestamp","$d$candidate_display","$d$political_party"', str(queries[0]))
 
-        with self.subTest('all totals dimension are replaced with null'):
-            self.assertEqual('SELECT '
-                             'TRUNC("timestamp",\'DD\') "$d$timestamp",'
-                             'NULL "$d$candidate",'
-                             'NULL "$d$candidate_display",'
-                             'NULL "$d$political_party",'
-                             'SUM("votes") "$m$votes" '
-                             'FROM "politics"."politician" '
-                             'GROUP BY "$d$timestamp" '
-                             'ORDER BY "$d$timestamp","$d$candidate_display","$d$political_party"', str(queries[1]))
-
         with self.subTest('first totals dimension is replaced with null'):
             self.assertEqual('SELECT '
                              'TRUNC("timestamp",\'DD\') "$d$timestamp",'
@@ -325,6 +315,17 @@ class QueryBuilderDimensionTotalsTests(TestCase):
                              'SUM("votes") "$m$votes" '
                              'FROM "politics"."politician" '
                              'GROUP BY "$d$timestamp","$d$candidate","$d$candidate_display" '
+                             'ORDER BY "$d$timestamp","$d$candidate_display","$d$political_party"', str(queries[1]))
+
+        with self.subTest('all totals dimension are replaced with null'):
+            self.assertEqual('SELECT '
+                             'TRUNC("timestamp",\'DD\') "$d$timestamp",'
+                             'NULL "$d$candidate",'
+                             'NULL "$d$candidate_display",'
+                             'NULL "$d$political_party",'
+                             'SUM("votes") "$m$votes" '
+                             'FROM "politics"."politician" '
+                             'GROUP BY "$d$timestamp" '
                              'ORDER BY "$d$timestamp","$d$candidate_display","$d$political_party"', str(queries[2]))
 
     def test_build_query_with_totals_cat_dimension_with_references(self):

--- a/fireant/tests/slicer/queries/test_database.py
+++ b/fireant/tests/slicer/queries/test_database.py
@@ -1,3 +1,4 @@
+import time
 from unittest import TestCase
 from unittest.mock import (
     MagicMock,
@@ -5,20 +6,12 @@ from unittest.mock import (
     patch,
 )
 
-import numpy as np
 import pandas as pd
-import time
 
-from fireant.slicer.queries.database import (
-    _clean_and_apply_index,
-    _do_fetch_data,
-)
+from fireant.slicer.queries.database import _do_fetch_data
 from fireant.tests.slicer.mocks import (
     cat_dim_df,
-    cont_dim_df,
     cont_uni_dim_df,
-    single_metric_df,
-    slicer,
     uni_dim_df,
 )
 from fireant.utils import format_dimension_key as fd
@@ -43,19 +36,12 @@ class FetchDataTests(TestCase):
 
     def test_do_fetch_data_calls_database_fetch_data(self, ):
         with patch('fireant.slicer.queries.database.pd.read_sql', return_value=self.mock_data_frame) as mock_read_sql:
-            _do_fetch_data(self.mock_query, self.mock_database, self.mock_dimensions)
+            _do_fetch_data(self.mock_query, self.mock_database)
 
             mock_read_sql.assert_called_once_with(self.mock_query,
                                                   self.mock_connection,
                                                   coerce_float=True,
                                                   parse_dates=True)
-
-    def test_index_set_on_data_frame_result(self):
-        with patch('fireant.slicer.queries.database.pd.read_sql', return_value=self.mock_data_frame):
-            _do_fetch_data(self.mock_query, self.mock_database, self.mock_dimensions)
-
-            self.mock_data_frame.set_index.assert_called_once_with([fd(d.key)
-                                                                    for d in self.mock_dimensions])
 
 
 @patch('fireant.slicer.queries.database.pd.read_sql')
@@ -78,14 +64,14 @@ class FetchDataLoggingTests(TestCase):
 
     @patch('fireant.slicer.queries.database.query_logger')
     def test_debug_query_log_called_with_query(self, mock_logger, *mocks):
-        _do_fetch_data(self.mock_query, self.mock_database, self.mock_dimensions)
+        _do_fetch_data(self.mock_query, self.mock_database)
 
         mock_logger.debug.assert_called_once_with('SELECT *')
 
     @patch.object(time, 'time', return_value=1520520255.0)
     @patch('fireant.slicer.queries.database.query_logger')
     def test_info_query_log_called_with_query_and_duration(self, mock_logger, *mocks):
-        _do_fetch_data(self.mock_query, self.mock_database, self.mock_dimensions)
+        _do_fetch_data(self.mock_query, self.mock_database)
 
         mock_logger.info.assert_called_once_with('[0.0 seconds]: SELECT *')
 
@@ -96,7 +82,7 @@ class FetchDataLoggingTests(TestCase):
                                                                                                mock_time,
                                                                                                *mocks):
         mock_time.side_effect = [1520520255.0, 1520520277.0]
-        _do_fetch_data(self.mock_query, self.mock_database, self.mock_dimensions)
+        _do_fetch_data(self.mock_query, self.mock_database)
 
         mock_logger.warning.assert_called_once_with('[22.0 seconds]: SELECT *')
 
@@ -107,7 +93,7 @@ class FetchDataLoggingTests(TestCase):
                                                                                                        mock_time,
                                                                                                        *mocks):
         mock_time.side_effect = [1520520763.0, 1520520764.0]
-        _do_fetch_data(self.mock_query, self.mock_database, self.mock_dimensions)
+        _do_fetch_data(self.mock_query, self.mock_database)
 
         mock_logger.warning.assert_not_called()
 
@@ -145,67 +131,6 @@ cont_uni_dim_nans_totals_df = cont_uni_dim_nans_df \
     .append(cont_uni_dim_nans_df.groupby(level=fd('timestamp')).apply(totals)) \
     .sort_index() \
     .sort_index(level=[0, 1], ascending=False)  # This sorts the DF so that the first instance of NaN is the totals
-
-
-class FetchDataCleanIndexTests(TestCase):
-    maxDiff = None
-
-    def test_do_nothing_when_no_dimensions(self):
-        result = _clean_and_apply_index(single_metric_df, [])
-
-        pd.testing.assert_frame_equal(result, single_metric_df)
-
-    def test_set_time_series_index_level(self):
-        result = _clean_and_apply_index(cont_dim_df.reset_index(),
-                                        [slicer.dimensions.timestamp])
-
-        self.assertListEqual(result.index.names, cont_dim_df.index.names)
-
-    def test_set_cat_dim_index(self):
-        result = _clean_and_apply_index(cat_dim_df.reset_index(),
-                                        [slicer.dimensions.political_party])
-
-        self.assertListEqual(result.index.tolist(), ['d', 'i', 'r'])
-
-    def test_set_cat_dim_index_with_nan_converted_to_empty_str(self):
-        result = _clean_and_apply_index(cat_dim_nans_df.reset_index(),
-                                        [slicer.dimensions.political_party])
-
-        self.assertListEqual(result.index.tolist(), ['d', 'i', 'r', 'null'])
-
-    def test_convert_cat_totals_converted_to_totals(self):
-        result = _clean_and_apply_index(cat_dim_nans_df.reset_index(),
-                                        [slicer.dimensions.political_party.rollup()])
-
-        self.assertListEqual(result.index.tolist(), ['d', 'i', 'r', 'totals'])
-
-    def test_convert_numeric_values_to_string(self):
-        result = _clean_and_apply_index(uni_dim_df.reset_index(), [slicer.dimensions.candidate])
-        self.assertEqual(result.index.dtype.type, np.object_)
-
-    def test_set_uni_dim_index(self):
-        result = _clean_and_apply_index(uni_dim_df.reset_index(),
-                                        [slicer.dimensions.candidate])
-
-        self.assertListEqual(result.index.tolist(), [str(x + 1) for x in range(11)])
-
-    def test_set_uni_dim_index_with_nan_converted_to_empty_str(self):
-        result = _clean_and_apply_index(uni_dim_nans_df.reset_index(),
-                                        [slicer.dimensions.candidate])
-
-        self.assertListEqual(result.index.tolist(), [str(x + 1) for x in range(11)] + ['null'])
-
-    def test_convert_uni_totals(self):
-        result = _clean_and_apply_index(uni_dim_nans_df.reset_index(),
-                                        [slicer.dimensions.candidate.rollup()])
-
-        self.assertListEqual(result.index.tolist(), [str(x + 1) for x in range(11)] + ['totals'])
-
-    def test_set_index_for_multiindex_with_nans_and_totals(self):
-        result = _clean_and_apply_index(cont_uni_dim_nans_totals_df.reset_index(),
-                                        [slicer.dimensions.timestamp, slicer.dimensions.state.rollup()])
-
-        self.assertListEqual(result.index.get_level_values(1).unique().tolist(), ['2', '1', 'null', 'totals'])
 
 
 class FetchDimensionOptionsTests(TestCase):

--- a/fireant/tests/slicer/widgets/test_highcharts.py
+++ b/fireant/tests/slicer/widgets/test_highcharts.py
@@ -533,7 +533,7 @@ class HighChartsLineChartTransformerTests(TestCase):
             "yAxis": [{
                 "id": "1",
                 "title": {"text": None},
-                "labels": {"style": {"color": "#DF5353"}},
+                "labels": {"style": {"color": "#7798BF"}},
                 "visible": True,
             }, {
                 "id": "0",
@@ -544,6 +544,7 @@ class HighChartsLineChartTransformerTests(TestCase):
             "tooltip": {"shared": True, "useHTML": True, "enabled": True},
             "legend": {"useHTML": True},
             "series": [{
+                'name': 'Votes (Texas)',
                 'color': '#DDDF0D',
                 'dashStyle': 'Solid',
                 'data': [(820454400000, 5574387),
@@ -558,11 +559,11 @@ class HighChartsLineChartTransformerTests(TestCase):
                     'valueDecimals': None,
                 },
                 'marker': {'fillColor': '#DDDF0D', 'symbol': 'circle'},
-                'name': 'Votes (Texas)',
                 'stacking': self.stacking,
                 'type': self.chart_type,
                 'yAxis': '0'
             }, {
+                'name': 'Votes (California)',
                 'color': '#55BF3B',
                 'dashStyle': 'Solid',
                 'data': [(820454400000, 9646062),
@@ -577,30 +578,30 @@ class HighChartsLineChartTransformerTests(TestCase):
                     'valueDecimals': None,
                 },
                 'marker': {'fillColor': '#DDDF0D', 'symbol': 'square'},
-                'name': 'Votes (California)',
                 'stacking': self.stacking,
                 'type': self.chart_type,
                 'yAxis': '0'
             }, {
+                'name': 'Votes (Totals)',
                 'color': '#DF5353',
                 'dashStyle': 'Solid',
-                'data': [(820454400000, 1),
-                         (946684800000, 1),
-                         (1072915200000, 1),
-                         (1199145600000, 1),
-                         (1325376000000, 1),
-                         (1451606400000, 1)],
+                'data': [(820454400000, 15220449),
+                         (946684800000, 16662017),
+                         (1072915200000, 19614932),
+                         (1199145600000, 21294215),
+                         (1325376000000, 20572210),
+                         (1451606400000, 18310513)],
+                'marker': {'fillColor': '#DDDF0D', 'symbol': 'diamond'},
                 'tooltip': {
-                    'valuePrefix': None,
-                    'valueSuffix': None,
                     'valueDecimals': None,
+                    'valuePrefix': None,
+                    'valueSuffix': None
                 },
-                'marker': {'fillColor': '#DF5353', 'symbol': 'circle'},
-                'name': 'Wins (Texas)',
                 'stacking': self.stacking,
                 'type': self.chart_type,
-                'yAxis': '1'
+                'yAxis': '0'
             }, {
+                'name': 'Wins (Texas)',
                 'color': '#7798BF',
                 'dashStyle': 'Solid',
                 'data': [(820454400000, 1),
@@ -614,8 +615,45 @@ class HighChartsLineChartTransformerTests(TestCase):
                     'valueSuffix': None,
                     'valueDecimals': None,
                 },
-                'marker': {'fillColor': '#DF5353', 'symbol': 'square'},
+                'marker': {'fillColor': '#7798BF', 'symbol': 'circle'},
+                'stacking': self.stacking,
+                'type': self.chart_type,
+                'yAxis': '1'
+            }, {
                 'name': 'Wins (California)',
+                'color': '#AAEEEE',
+                'dashStyle': 'Solid',
+                'data': [(820454400000, 1),
+                         (946684800000, 1),
+                         (1072915200000, 1),
+                         (1199145600000, 1),
+                         (1325376000000, 1),
+                         (1451606400000, 1)],
+                'tooltip': {
+                    'valuePrefix': None,
+                    'valueSuffix': None,
+                    'valueDecimals': None,
+                },
+                'marker': {'fillColor': '#7798BF', 'symbol': 'square'},
+                'stacking': self.stacking,
+                'type': self.chart_type,
+                'yAxis': '1'
+            }, {
+                'name': 'Wins (Totals)',
+                'color': '#FF0066',
+                'dashStyle': 'Solid',
+                'data': [(820454400000, 2),
+                         (946684800000, 2),
+                         (1072915200000, 2),
+                         (1199145600000, 2),
+                         (1325376000000, 2),
+                         (1451606400000, 2)],
+                'marker': {'fillColor': '#7798BF', 'symbol': 'diamond'},
+                'tooltip': {
+                    'valueDecimals': None,
+                    'valuePrefix': None,
+                    'valueSuffix': None
+                },
                 'stacking': self.stacking,
                 'type': self.chart_type,
                 'yAxis': '1'
@@ -639,7 +677,7 @@ class HighChartsLineChartTransformerTests(TestCase):
             "yAxis": [{
                 "id": "1",
                 "title": {"text": None},
-                "labels": {"style": {"color": "#DF5353"}},
+                "labels": {"style": {"color": "#7798BF"}},
                 "visible": True,
             }, {
                 "id": "0",
@@ -650,6 +688,7 @@ class HighChartsLineChartTransformerTests(TestCase):
             "tooltip": {"shared": True, "useHTML": True, "enabled": True},
             "legend": {"useHTML": True},
             "series": [{
+                'name': 'Votes (Texas)',
                 'color': '#DDDF0D',
                 'dashStyle': 'Solid',
                 'data': [(820454400000, 5574387),
@@ -664,11 +703,11 @@ class HighChartsLineChartTransformerTests(TestCase):
                     'valueDecimals': None,
                 },
                 'marker': {'fillColor': '#DDDF0D', 'symbol': 'circle'},
-                'name': 'Votes (Texas)',
                 'stacking': self.stacking,
                 'type': self.chart_type,
                 'yAxis': '0'
             }, {
+                'name': 'Votes (California)',
                 'color': '#55BF3B',
                 'dashStyle': 'Solid',
                 'data': [(820454400000, 9646062),
@@ -683,30 +722,30 @@ class HighChartsLineChartTransformerTests(TestCase):
                     'valueDecimals': None,
                 },
                 'marker': {'fillColor': '#DDDF0D', 'symbol': 'square'},
-                'name': 'Votes (California)',
                 'stacking': self.stacking,
                 'type': self.chart_type,
                 'yAxis': '0'
             }, {
+                'name': 'Votes (Totals)',
                 'color': '#DF5353',
                 'dashStyle': 'Solid',
-                'data': [(820454400000, 1),
-                         (946684800000, 1),
-                         (1072915200000, 1),
-                         (1199145600000, 1),
-                         (1325376000000, 1),
-                         (1451606400000, 1)],
+                'data': [(820454400000, 15220449),
+                         (946684800000, 16662017),
+                         (1072915200000, 19614932),
+                         (1199145600000, 21294215),
+                         (1325376000000, 20572210),
+                         (1451606400000, 18310513)],
+                'marker': {'fillColor': '#DDDF0D', 'symbol': 'diamond'},
                 'tooltip': {
-                    'valuePrefix': None,
-                    'valueSuffix': None,
                     'valueDecimals': None,
+                    'valuePrefix': None,
+                    'valueSuffix': None
                 },
-                'marker': {'fillColor': '#DF5353', 'symbol': 'circle'},
-                'name': 'Wins (Texas)',
                 'stacking': self.stacking,
                 'type': self.chart_type,
-                'yAxis': '1'
+                'yAxis': '0'
             }, {
+                'name': 'Wins (Texas)',
                 'color': '#7798BF',
                 'dashStyle': 'Solid',
                 'data': [(820454400000, 1),
@@ -720,8 +759,45 @@ class HighChartsLineChartTransformerTests(TestCase):
                     'valueSuffix': None,
                     'valueDecimals': None,
                 },
-                'marker': {'fillColor': '#DF5353', 'symbol': 'square'},
+                'marker': {'fillColor': '#7798BF', 'symbol': 'circle'},
+                'stacking': self.stacking,
+                'type': self.chart_type,
+                'yAxis': '1'
+            }, {
                 'name': 'Wins (California)',
+                'color': '#AAEEEE',
+                'dashStyle': 'Solid',
+                'data': [(820454400000, 1),
+                         (946684800000, 1),
+                         (1072915200000, 1),
+                         (1199145600000, 1),
+                         (1325376000000, 1),
+                         (1451606400000, 1)],
+                'tooltip': {
+                    'valuePrefix': None,
+                    'valueSuffix': None,
+                    'valueDecimals': None,
+                },
+                'marker': {'fillColor': '#7798BF', 'symbol': 'square'},
+                'stacking': self.stacking,
+                'type': self.chart_type,
+                'yAxis': '1'
+            }, {
+                'name': 'Wins (Totals)',
+                'color': '#FF0066',
+                'dashStyle': 'Solid',
+                'data': [(820454400000, 2),
+                         (946684800000, 2),
+                         (1072915200000, 2),
+                         (1199145600000, 2),
+                         (1325376000000, 2),
+                         (1451606400000, 2)],
+                'marker': {'fillColor': '#7798BF', 'symbol': 'diamond'},
+                'tooltip': {
+                    'valueDecimals': None,
+                    'valuePrefix': None,
+                    'valueSuffix': None
+                },
                 'stacking': self.stacking,
                 'type': self.chart_type,
                 'yAxis': '1'

--- a/fireant/tests/slicer/widgets/test_reacttable.py
+++ b/fireant/tests/slicer/widgets/test_reacttable.py
@@ -18,7 +18,10 @@ from fireant.tests.slicer.mocks import (
     slicer,
     uni_dim_df,
 )
-from fireant.utils import format_dimension_key as fd
+from fireant.utils import (
+    MAX_STRING,
+    format_dimension_key as fd,
+)
 
 
 class ReactTableTransformerTests(TestCase):
@@ -685,7 +688,7 @@ class ReactTableTransformerTests(TestCase):
                                         {'Header': 'California', 'accessor': '$m$votes.2'},
                                         {
                                             'Header': 'Totals',
-                                            'accessor': '$m$votes.totals',
+                                            'accessor': f'$m$votes.{MAX_STRING}',
                                             'className': 'fireant-totals'
                                         }]
                         }, {
@@ -694,7 +697,7 @@ class ReactTableTransformerTests(TestCase):
                                         {'Header': 'California', 'accessor': '$m$wins.2'},
                                         {
                                             'Header': 'Totals',
-                                            'accessor': '$m$wins.totals',
+                                            'accessor': f'$m$wins.{MAX_STRING}',
                                             'className': 'fireant-totals'
                                         }]
                         }],
@@ -703,31 +706,31 @@ class ReactTableTransformerTests(TestCase):
                 '$m$votes': {
                     '1': {'display': '5,574,387', 'raw': 5574387},
                     '2': {'display': '9,646,062', 'raw': 9646062},
-                    'totals': {'display': '15,220,449', 'raw': 15220449}
+                    MAX_STRING: {'display': '15,220,449', 'raw': 15220449}
                 },
                 '$m$wins': {
                     '1': {'display': '1', 'raw': 1},
                     '2': {'display': '1', 'raw': 1},
-                    'totals': {'display': '2', 'raw': 2}
+                    MAX_STRING: {'display': '2', 'raw': 2}
                 }
             }, {
                 '$d$timestamp': {'raw': '2000-01-01'},
                 '$m$votes': {
                     '1': {'display': '6,233,385', 'raw': 6233385},
                     '2': {'display': '10,428,632', 'raw': 10428632},
-                    'totals': {'display': '16,662,017', 'raw': 16662017}
+                    MAX_STRING: {'display': '16,662,017', 'raw': 16662017}
                 },
                 '$m$wins': {
                     '1': {'display': '1', 'raw': 1},
                     '2': {'display': '1', 'raw': 1},
-                    'totals': {'display': '2', 'raw': 2}
+                    MAX_STRING: {'display': '2', 'raw': 2}
                 }
             }, {
                 '$d$timestamp': {'raw': 'Totals'},
                 '$m$votes': {
                     '1': {'display': '', 'raw': ''},
                     '2': {'display': '', 'raw': ''},
-                    'totals': {
+                    MAX_STRING: {
                         'display': '111,674,336',
                         'raw': 111674336
                     }
@@ -735,7 +738,7 @@ class ReactTableTransformerTests(TestCase):
                 '$m$wins': {
                     '1': {'display': '', 'raw': ''},
                     '2': {'display': '', 'raw': ''},
-                    'totals': {'display': '12', 'raw': 12}
+                    MAX_STRING: {'display': '12', 'raw': 12}
                 }
             }]
         }, result)
@@ -760,7 +763,7 @@ class ReactTableTransformerTests(TestCase):
                         {'Header': '2016-01-01', 'accessor': '2016-01-01'},
                         {
                             'Header': 'Totals',
-                            'accessor': 'totals',
+                            'accessor': 'Totals',
                             'className': 'fireant-totals'
                         }],
             'data': [{
@@ -772,7 +775,7 @@ class ReactTableTransformerTests(TestCase):
                 '2008-01-01': {'display': '1', 'raw': 1},
                 '2012-01-01': {'display': '1', 'raw': 1},
                 '2016-01-01': {'display': '1', 'raw': 1},
-                'totals': {'display': '', 'raw': ''}
+                'Totals': {'display': '', 'raw': ''}
             }, {
                 '$d$metrics': {'raw': 'Votes'},
                 '$d$state': {'display': 'Texas', 'raw': '1'},
@@ -782,7 +785,7 @@ class ReactTableTransformerTests(TestCase):
                 '2008-01-01': {'display': '8,007,961', 'raw': 8007961},
                 '2012-01-01': {'display': '7,877,967', 'raw': 7877967},
                 '2016-01-01': {'display': '5,072,915', 'raw': 5072915},
-                'totals': {'display': '', 'raw': ''}
+                'Totals': {'display': '', 'raw': ''}
             }]
         }, result)
 
@@ -806,7 +809,7 @@ class ReactTableTransformerTests(TestCase):
                         {'Header': '2016-01-01', 'accessor': '2016-01-01'},
                         {
                             'Header': 'Totals',
-                            'accessor': 'totals',
+                            'accessor': 'Totals',
                             'className': 'fireant-totals'
                         }],
             'data': [{
@@ -818,7 +821,7 @@ class ReactTableTransformerTests(TestCase):
                 '2008-01-01': {'display': '1', 'raw': 1},
                 '2012-01-01': {'display': '1', 'raw': 1},
                 '2016-01-01': {'display': '1', 'raw': 1},
-                'totals': {'display': '', 'raw': ''}
+                'Totals': {'display': '', 'raw': ''}
             }, {
                 '$d$metrics': {'raw': 'Wins'},
                 '$d$state': {'display': 'California', 'raw': '2'},
@@ -828,7 +831,7 @@ class ReactTableTransformerTests(TestCase):
                 '2008-01-01': {'display': '1', 'raw': 1},
                 '2012-01-01': {'display': '1', 'raw': 1},
                 '2016-01-01': {'display': '1', 'raw': 1},
-                'totals': {'display': '', 'raw': ''}
+                'Totals': {'display': '', 'raw': ''}
             }]
         }, result)
 

--- a/fireant/utils.py
+++ b/fireant/utils.py
@@ -1,4 +1,11 @@
+import sys
 from collections import OrderedDict
+
+import pandas as pd
+
+MAX_TIMESTAMP = pd.Timestamp.max
+MAX_NUMBER = sys.maxsize
+MAX_STRING = '~~totals'
 
 
 def wrap_list(value):


### PR DESCRIPTION
Changed the handling of totals in the pandas dataframes used to store the query result sets to use marker values instead of trying to fill the values. This is because dimension values can be null, so the NaN and NaT types are reserved for that, and putting different data types in a pandas index changes the dtype to O, which prevents us from keying off of the dtype for transformers.