### PR TITLE
Convert dimension values to an Iterable

### DIFF
--- a/fireant/slicer/widgets/helpers.py
+++ b/fireant/slicer/widgets/helpers.py
@@ -70,10 +70,13 @@ def dimensional_metric_label(dimensions, dimension_display_values):
             a tuple of dimension values. Can be zero-length or longer.
         :return:
         """
+        # normalize the dimension values, as we expect them to be an iterable, in
+        # order to calculate the number of used dimension safely
+        dimension_values = utils.wrap_list(dimension_values)
+
         num_used_dimensions = len(dimensions) - len(dimension_values)
         used_dimensions = dimensions[num_used_dimensions:]
 
-        dimension_values = utils.wrap_list(dimension_values)
         dimension_labels = [utils.getdeepattr(dimension_display_values,
                                               (utils.format_dimension_key(dimension.key), dimension_value),
                                               dimension_value)


### PR DESCRIPTION
Make sure that the dimension values are always an Iterable before calculating the number of used dimensions. Fix for #224 