### PR TITLE
Fixed references to align to weekday

### DIFF
--- a/fireant/dataset/intervals.py
+++ b/fireant/dataset/intervals.py
@@ -18,6 +18,9 @@ class NumericInterval(DimensionModifier):
         return hash(repr(self))
 
 
+DATETIME_INTERVALS = ('hour', 'day', 'week', 'month', 'quarter', 'year')
+
+
 class DatetimeInterval(DimensionModifier):
     def __init__(self, dimension, interval_key):
         super().__init__(dimension)
@@ -37,4 +40,4 @@ class DatetimeInterval(DimensionModifier):
 
 
 hour, day, week, month, quarter, year = [partial(DatetimeInterval, interval_key=key)
-                                         for key in ('hour', 'day', 'week', 'month', 'quarter', 'year')]
+                                         for key in DATETIME_INTERVALS]

--- a/fireant/dataset/references.py
+++ b/fireant/dataset/references.py
@@ -39,8 +39,8 @@ class Reference(object):
 
 
 class ReferenceType(object):
-    def __init__(self, key, label, time_unit: str, interval: int):
-        self.alias = key
+    def __init__(self, alias, label, time_unit: str, interval: int):
+        self.alias = alias
         self.label = label
 
         self.time_unit = time_unit

--- a/fireant/queries/builder.py
+++ b/fireant/queries/builder.py
@@ -17,6 +17,7 @@ from fireant.utils import (
 from pypika import Order
 from . import special_cases
 from .execution import fetch_data
+from .field_helper import make_orders_for_dimensions
 from .finders import (
     find_and_group_references_for_dimensions,
     find_and_replace_reference_dimensions,
@@ -27,7 +28,6 @@ from .finders import (
 from .pagination import paginate
 from .sql_transformer import (
     make_latest_query,
-    make_orders_for_dimensions,
     make_slicer_query,
     make_slicer_query_with_totals_and_references,
 )
@@ -178,7 +178,7 @@ class DataSetQueryBuilder(QueryBuilder):
 
     @property
     def reference_groups(self):
-        return list(find_and_group_references_for_dimensions(self._references).values())
+        return list(find_and_group_references_for_dimensions(self._dimensions, self._references).values())
 
     @property
     def sql(self):

--- a/fireant/queries/field_helper.py
+++ b/fireant/queries/field_helper.py
@@ -1,0 +1,48 @@
+from fireant.dataset.intervals import DatetimeInterval
+from fireant.utils import alias_selector
+
+
+def make_term_for_metrics(metric):
+    return metric.definition.as_(alias_selector(metric.alias))
+
+
+def make_term_for_dimension(dimension, window=None):
+    """
+    Makes a list of pypika terms for a given slicer definition.
+
+    :param dimension:
+        A slicer dimension.
+    :param window:
+        A window function to apply to the dimension definition if it is a continuous dimension.
+    :return:
+        a list of terms required to select and group by in a SQL query given a slicer dimension. This list will contain
+        either one or two elements. A second element will be included if the dimension has a definition for its display
+        field.
+    """
+    f_alias = alias_selector(dimension.alias)
+
+    if window and isinstance(dimension, DatetimeInterval):
+        return window(dimension.definition, dimension.interval_key).as_(f_alias)
+
+    return dimension.definition.as_(f_alias)
+
+
+def make_orders_for_dimensions(dimensions):
+    """
+    Creates a list of ordering for a slicer query based on a list of dimensions. The dimensions's display definition is
+    used preferably as the ordering term but the definition is used for dimensions that do not have a display
+    definition.
+
+    :param dimensions:
+    :return:
+        a list of tuple pairs like (term, orientation) for ordering a SQL query where the first element is the term
+        to order by and the second is the orientation of the ordering, ASC or DESC.
+    """
+
+    # Use the same function to make the definition terms to force it to be consistent.
+    # Always take the last element in order to prefer the display definition.
+    definitions = [make_term_for_dimension(dimension)
+                   for dimension in dimensions]
+
+    return [(definition, None)
+            for definition in definitions]

--- a/fireant/queries/totals_helper.py
+++ b/fireant/queries/totals_helper.py
@@ -21,18 +21,16 @@ def adapt_for_totals_query(totals_dimension, dimensions, filters):
 
     # Get an index to split the dimensions before and after the totals dimension
 
-    if is_totals_query:
-        index = [i
-                 for i, dimension in enumerate(dimensions)
-                 if dimension is totals_dimension][0]
-        totals_dims = [Rollup(dimension)
-                       if i >= index
-                       else dimension
-                       for i, dimension in enumerate(raw_dimensions)]
-        totals_filters = find_filters_for_totals(filters)
+    if not is_totals_query:
+        return raw_dimensions, filters
 
-    else:
-        totals_dims = raw_dimensions
-        totals_filters = filters
+    index = [i
+             for i, dimension in enumerate(dimensions)
+             if dimension is totals_dimension][0]
+    totals_dims = [Rollup(dimension)
+                   if i >= index
+                   else dimension
+                   for i, dimension in enumerate(raw_dimensions)]
+    totals_filters = find_filters_for_totals(filters)
 
     return totals_dims, totals_filters

--- a/fireant/queries/totals_helper.py
+++ b/fireant/queries/totals_helper.py
@@ -1,0 +1,38 @@
+from fireant.dataset.totals import Rollup
+from .finders import find_filters_for_totals
+
+
+def adapt_for_totals_query(totals_dimension, dimensions, filters):
+    """
+    Adapt filters for totals query. This function will select filters for total dimensions depending on the
+    apply_filter_to_totals values for the filters. A total dimension with value None indicates the base query for
+    which all filters will be applied by default.
+
+    :param totals_dimension:
+    :param dimensions:
+    :param filters:
+    :return:
+    """
+    is_totals_query = totals_dimension is not None
+    raw_dimensions = [dimension.dimension
+                      if isinstance(dimension, Rollup)
+                      else dimension
+                      for dimension in dimensions]
+
+    # Get an index to split the dimensions before and after the totals dimension
+
+    if is_totals_query:
+        index = [i
+                 for i, dimension in enumerate(dimensions)
+                 if dimension is totals_dimension][0]
+        totals_dims = [Rollup(dimension)
+                       if i >= index
+                       else dimension
+                       for i, dimension in enumerate(raw_dimensions)]
+        totals_filters = find_filters_for_totals(filters)
+
+    else:
+        totals_dims = raw_dimensions
+        totals_filters = filters
+
+    return totals_dims, totals_filters

--- a/fireant/tests/queries/test_build_dimensions.py
+++ b/fireant/tests/queries/test_build_dimensions.py
@@ -305,7 +305,7 @@ class QueryBuilderDimensionTotalsTests(TestCase):
 
         with self.subTest('reference query is shifted'):
             self.assertEqual('SELECT '
-                             'TRUNC(TIMESTAMPADD(\'day\',1,"timestamp"),\'DD\') "$timestamp",'
+                             'TRUNC(TIMESTAMPADD(\'day\',1,TRUNC("timestamp",\'DD\')),\'DD\') "$timestamp",'
                              '"political_party" "$political_party",'
                              'SUM("votes") "$votes_dod" '
                              'FROM "politics"."politician" '
@@ -323,7 +323,7 @@ class QueryBuilderDimensionTotalsTests(TestCase):
 
         with self.subTest('reference total query is shifted without the rollup dimension'):
             self.assertEqual('SELECT '
-                             'TRUNC(TIMESTAMPADD(\'day\',1,"timestamp"),\'DD\') "$timestamp",'
+                             'TRUNC(TIMESTAMPADD(\'day\',1,TRUNC("timestamp",\'DD\')),\'DD\') "$timestamp",'
                              'NULL "$political_party",'
                              'SUM("votes") "$votes_dod" '
                              'FROM "politics"."politician" '
@@ -353,7 +353,7 @@ class QueryBuilderDimensionTotalsTests(TestCase):
 
         with self.subTest('reference query is shifted'):
             self.assertEqual('SELECT '
-                             'TRUNC(TIMESTAMPADD(\'day\',1,"timestamp"),\'DD\') "$timestamp",'
+                             'TRUNC(TIMESTAMPADD(\'day\',1,TRUNC("timestamp",\'DD\')),\'DD\') "$timestamp",'
                              '"political_party" "$political_party",'
                              'SUM("votes") "$votes_dod" '
                              'FROM "politics"."politician" '
@@ -373,7 +373,7 @@ class QueryBuilderDimensionTotalsTests(TestCase):
 
         with self.subTest('reference total query is shifted without the rollup dimension'):
             self.assertEqual('SELECT '
-                             'TRUNC(TIMESTAMPADD(\'day\',1,"timestamp"),\'DD\') "$timestamp",'
+                             'TRUNC(TIMESTAMPADD(\'day\',1,TRUNC("timestamp",\'DD\')),\'DD\') "$timestamp",'
                              'NULL "$political_party",'
                              'SUM("votes") "$votes_dod" '
                              'FROM "politics"."politician" '


### PR DESCRIPTION
Fixed references to align on the weekday when a date dimension is selected and uses an interval that is weekly or smaller. Also removed the special case for YoY references on weekly intervals so the fix for leap years is generalized and so that the YoY reference aligns correctly.