### PR TITLE
Add whitespace as safe char

### DIFF
--- a/fireant/formats.py
+++ b/fireant/formats.py
@@ -82,7 +82,7 @@ def _identity(value):
     return value
 
 
-UNSAFE_CHARS = re.compile(r'[^\w\d\-:()]')
+UNSAFE_CHARS = re.compile(r'[^\w\d\s\-:()]')
 
 
 def json_value(value):

--- a/fireant/tests/test_formats.py
+++ b/fireant/tests/test_formats.py
@@ -61,7 +61,7 @@ class SafeRawValueTests(TestCase):
     def test_string_value_is_returned_with_only_safe_characters_replaced(self):
         tests = [('abcdefghijklmnopqrstuvwxyz', 'abcdefghijklmnopqrstuvwxyz'),
                  ('ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
-                 (' ', '$'),
+                 (' ', ' '),
                  ('-0123456789', '-0123456789'),
                  ('.[]', '$$$'),
                  ('a.1', 'a$1'),


### PR DESCRIPTION
In react table it should be safe to use white spaces in accessors. 

For example `accessor = 'nospace.with space'` will be split up into `['nospace', 'with space']` which is used like normal keys starting from some base object `base_obj['nospace']['with space']`.

Details can be found in https://github.com/tannerlinsley/react-table/blob/master/src/utils.js#L202