### PR TITLE
Introduce concurrency middleware

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -207,50 +207,51 @@ Crafted with ♥ in Berlin.
 
 .. |Brand| replace:: *fireant*
 
-.. |FeatureDataSet| replace:: *Data Set*
+.. |FeatureDataSet| replace:: *DataSet*
 .. |FeatureMetric| replace:: *Metric*
 .. |FeatureDimension| replace:: *Dimension*
 .. |FeatureFilter| replace:: *Filter*
 .. |FeatureReference| replace:: *Reference*
 .. |FeatureOperation| replace:: *Operation*
 
-.. |ClassDataSet| replace:: ``fireant.DataSet``
-.. |ClassDatabase| replace:: ``fireant.database.Database``
-.. |ClassJoin| replace:: ``fireant.dataset.joins.Join``
-.. |ClassMetric| replace:: ``fireant.dataset.fields.Field``
+.. |ClassDataSet| replace:: :class:`fireant.DataSet <fireant.dataset.klass.DataSet>`
+.. |ClassDatabase| replace:: :class:`fireant.database.Database <fireant.database.base.Database>`
+.. |ClassJoin| replace:: :class:`fireant.Join <fireant.dataset.joins.Join>`
+.. |ClassMetric| replace:: :class:`fireant.Field <fireant.dataset.fields.Field>`
+.. |ClassThreadPoolConcurrencyMiddleware| replace:: :class:`fireant.middleware.ThreadPoolConcurrencyMiddleware <fireant.middleware.concurrency.ThreadPoolConcurrencyMiddleware>`
+.. |ClassBaseConcurrencyMiddleware| replace:: :class:`fireant.middleware.BaseConcurrencyMiddleware <fireant.middleware.concurrency.BaseConcurrencyMiddleware>`
 
-.. |ClassDimension| replace:: ``fireant.dataset.fields.Field``
-.. |ClassBooleanDimension| replace:: ``fireant.dataset.dimensions.BooleanDimension``
-.. |ClassContDimension| replace:: ``fireant.dataset.dimensions.ContinuousDimension``
-.. |ClassDateDimension| replace:: ``fireant.dataset.dimensions.DatetimeDimension``
-.. |ClassCatDimension| replace:: ``fireant.dataset.dimensions.CategoricalDimension``
-.. |ClassUniqueDimension| replace:: ``fireant.dataset.dimensions.UniqueDimension``
-.. |ClassDisplayDimension| replace:: ``fireant.dataset.dimensions.DisplayDimension``
+.. |ClassBooleanDimension| replace:: :class:`fireant.dataset.dimensions.BooleanDimension`
+.. |ClassContDimension| replace:: :class:`fireant.dataset.dimensions.ContinuousDimension`
+.. |ClassDateDimension| replace:: :class:`fireant.dataset.dimensions.DatetimeDimension`
+.. |ClassCatDimension| replace:: :class:`fireant.dataset.dimensions.CategoricalDimension`
+.. |ClassUniqueDimension| replace:: :class:`fireant.dataset.dimensions.UniqueDimension`
+.. |ClassDisplayDimension| replace:: :class:`fireant.dataset.dimensions.DisplayDimension`
 
-.. |ClassFilter| replace:: ``fireant.dataset.filters.Filter``
-.. |ClassComparatorFilter| replace:: ``fireant.dataset.filters.ComparatorFilter``
-.. |ClassBooleanFilter| replace:: ``fireant.dataset.filters.BooleanFilter``
-.. |ClassContainsFilter| replace:: ``fireant.dataset.filters.ContainsFilter``
-.. |ClassExcludesFilter| replace:: ``fireant.dataset.filters.ExcludesFilter``
-.. |ClassRangeFilter| replace:: ``fireant.dataset.filters.RangeFilter``
-.. |ClassPatternFilter| replace:: ``fireant.dataset.filters.PatternFilter``
-.. |ClassAntiPatternFilter| replace:: ``fireant.dataset.filters.AntiPatternFilter``
+.. |ClassFilter| replace:: :class:`fireant.dataset.filters.Filter`
+.. |ClassComparatorFilter| replace:: :class:`fireant.dataset.filters.ComparatorFilter`
+.. |ClassBooleanFilter| replace:: :class:`fireant.dataset.filters.BooleanFilter`
+.. |ClassContainsFilter| replace:: :class:`fireant.dataset.filters.ContainsFilter`
+.. |ClassExcludesFilter| replace:: :class:`fireant.dataset.filters.ExcludesFilter`
+.. |ClassRangeFilter| replace:: :class:`fireant.dataset.filters.RangeFilter`
+.. |ClassPatternFilter| replace:: :class:`fireant.dataset.filters.PatternFilter`
+.. |ClassAntiPatternFilter| replace:: :class:`fireant.dataset.filters.AntiPatternFilter`
 
-.. |ClassReference| replace:: ``fireant.dataset.references.Reference``
+.. |ClassReference| replace:: :class:`fireant.dataset.references.Reference`
 
-.. |ClassWidget| replace:: ``fireant.widgets.base.Widget``
-.. |ClassPandasWidget| replace:: ``fireant.widgets.pandas.Pandas``
-.. |ClassHighChartsWidget| replace:: ``fireant.widgets.highcharts.HighCharts``
-.. |ClassHighChartsSeries| replace:: ``fireant.widgets.highcharts.Series``
+.. |ClassWidget| replace:: :class:`fireant.widgets.base.Widget`
+.. |ClassPandasWidget| replace:: :class:`fireant.widgets.pandas.Pandas`
+.. |ClassHighChartsWidget| replace:: :class:`fireant.widgets.highcharts.HighCharts <fireant.widgets.highcharts.HighCharts>`
+.. |ClassHighChartsSeries| replace:: :class:`fireant.widgets.highcharts.Series <fireant.widgets.chart_base.Series>`
 
-.. |ClassOperation| replace:: ``fireant.dataset.operations.Operation``
+.. |ClassOperation| replace:: :class:`fireant.dataset.operations.Operation`
 
-.. |ClassVerticaDatabase| replace:: ``fireant.database.VerticaDatabase``
-.. |ClassMySQLDatabase| replace:: ``fireant.database.MySQLDatabase``
-.. |ClassPostgreSQLDatabase| replace:: ``fireant.database.PostgreSQLDatabase``
-.. |ClassRedshiftDatabase| replace:: ``fireant.database.RedshiftDatabase``
+.. |ClassVerticaDatabase| replace:: :class:`fireant.database.VerticaDatabase`
+.. |ClassMySQLDatabase| replace:: :class:`fireant.database.MySQLDatabase`
+.. |ClassPostgreSQLDatabase| replace:: :class:`fireant.database.PostgreSQLDatabase`
+.. |ClassRedshiftDatabase| replace:: :class:`fireant.database.RedshiftDatabase`
 
-.. |ClassDatetimeInterval| replace:: ``fireant.DatetimeInterval``
+.. |ClassDatetimeInterval| replace:: :class:`fireant.DatetimeInterval <fireant.dataset.intervals.DatetimeInterval>`
 
 .. |ClassTable| replace:: ``pypika.Table``
 .. |ClassTables| replace:: ``pypika.Tables``

--- a/docs/1_setup.rst
+++ b/docs/1_setup.rst
@@ -9,7 +9,7 @@ Installation and Setup
 Database Connector add-ons
 --------------------------
 
-By default, |Brand| does not include any database drivers. You can optionally include one or provide your own. The following extra installations will set up |Brand| with the recommended drivers. |Brand| may work with additional drivrers, but is untested and requires a custom extension of the ``fireant.database.Database`` class (see below).
+By default, |Brand| does not include any database drivers. You can optionally include one or provide your own. The following extra installations will set up |Brand| with the recommended drivers. |Brand| may work with additional drivrers, but is untested and requires a custom extension of the |ClassDatabase| class (see below).
 
 
 .. code-block:: bash

--- a/docs/2_database.rst
+++ b/docs/2_database.rst
@@ -1,9 +1,10 @@
-Connecting to the database
-==========================
+Database Configuration
+======================
+Database Connector
+------------------
+In order for |Brand| to connect to your database, a database connector must be used. This takes the form of an instance of a concrete subclass of |Brand|'s |ClassDatabase| class. Database connectors are shipped with |Brand| for all of the supported databases, but it is also possible to write your own. See below on how to extend |Brand| to support additional databases.
 
-In order for |Brand| to connect to your database, a database connectors must be used. This takes the form of an instance of a concrete subclass of |Brand|'s ``Database`` class. Database connectors are shipped with |Brand| for all of the supported databases, but it is also possible to write your own. See below on how to extend |Brand| to support additional databases.
-
-To configure a database, instantiate a subclass of |ClassDatabase|. You will use this instance to create a |FeatureDataSet|. It is possible to use multiple databases simultaneous, but |FeatureDataSet| can only use a single database, since they inherently model the structure of a table in the database.
+To configure a database, instantiate a subclass of |ClassDatabase|. You will use this instance to create a |FeatureDataSet|. It is possible to use multiple databases simultaneous, but |ClassDataSet| can only use a single database, since they inherently model the structure of a table in the database.
 
 Vertica
 
@@ -131,6 +132,35 @@ Once a Database connector has been set up, it can be used when instantiating |Cl
 
 In a custom database connector, the ``connect`` function must be overridden to provide a ``connection`` to the database.
 The ``trunc_date`` and ``date_add`` functions must also be overridden since are no common ways to truncate/add dates in SQL databases.
+
+
+Middleware
+----------
+
+In order to provide extra functionality as well as flexibility the database connectors allow the setup of middleware.
+Default configurable middleware implementations are provided by fireant but it's also
+possible to extend the middleware classes for custom functionality.
+
+Concurrency Middleware
+""""""""""""""""""""""
+
+When executing queries on the database the operations are tunneled through a concurrency middleware. By default the
+|ClassThreadPoolConcurrencyMiddleware| is used when no custom middleware is configured in the database connector.
+This middleware implementation will parallelize multiple queries using a :class:`ThreadPool`.
+The maximum amount of simultaneously active threads is then defined by the ``max_processes`` parameter of the database
+connector.
+
+A custom middleware can easily be created by implementing |ClassBaseConcurrencyMiddleware|. For example a
+concurrency middleware that would simply execute a group of queries synchronously would look like this:
+
+.. code-block:: python
+
+    from fireant.middleware import BaseConcurrencyMiddleware
+    from fireant.queries import fetch_as_dataframe
+
+    class HueyConcurrencyMiddleware(BaseConcurrencyMiddleware):
+        def fetch_queries_as_dataframe(self, queries, database):
+            return [fetch_as_dataframe(query, database) for query in queries]
 
 
 .. include:: ../README.rst

--- a/docs/4_queries.rst
+++ b/docs/4_queries.rst
@@ -1,7 +1,7 @@
 Querying with a |FeatureDataSet|
 ================================
 
-After configuring an instance of Data Set, you'll have access to its powerful query API. This follows the builder design pattern, allowing for function calls to be chains to build up a context.
+After configuring an instance of |ClassDataSet|, you'll have access to its powerful query API. This follows the builder design pattern, allowing for function calls to be chained to build up a context.
 The result of a query is one or more widgets, which the query defines as well. Furthermore, data rendered in widgets can be grouped by setting dimensions, filtered, compared over time intervals using references, and sorted and limited using pagination.
 
 Widget

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -154,7 +154,6 @@ changes:
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
 	@echo
 	@echo "The overview file is in $(BUILDDIR)/changes."
-
 linkcheck:
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
@@ -175,3 +174,10 @@ pseudoxml:
 	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
 	@echo
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
+
+api_ref:
+	sphinx-apidoc -fM ../fireant -o api
+
+full_doc:
+	$(MAKE) api_ref
+	$(MAKE) html

--- a/docs/README
+++ b/docs/README
@@ -1,3 +1,3 @@
 To generate the sphinx API docs run from this working directory:
 
->> sphinx-apidoc  -o api/ ..
+>> make full_doc

--- a/docs/api/fireant.database.rst
+++ b/docs/api/fireant.database.rst
@@ -1,6 +1,11 @@
 fireant.database package
 ========================
 
+.. automodule:: fireant.database
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Submodules
 ----------
 
@@ -8,55 +13,47 @@ fireant.database.base module
 ----------------------------
 
 .. automodule:: fireant.database.base
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.database.mysql module
 -----------------------------
 
 .. automodule:: fireant.database.mysql
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.database.postgresql module
 ----------------------------------
 
 .. automodule:: fireant.database.postgresql
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.database.redshift module
 --------------------------------
 
 .. automodule:: fireant.database.redshift
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.database.snowflake module
 ---------------------------------
 
 .. automodule:: fireant.database.snowflake
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.database.vertica module
 -------------------------------
 
 .. automodule:: fireant.database.vertica
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-
-Module contents
----------------
-
-.. automodule:: fireant.database
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/api/fireant.dataset.rst
+++ b/docs/api/fireant.dataset.rst
@@ -1,6 +1,11 @@
 fireant.dataset package
 =======================
 
+.. automodule:: fireant.dataset
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Submodules
 ----------
 
@@ -8,79 +13,71 @@ fireant.dataset.fields module
 -----------------------------
 
 .. automodule:: fireant.dataset.fields
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.dataset.filters module
 ------------------------------
 
 .. automodule:: fireant.dataset.filters
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.dataset.intervals module
 --------------------------------
 
 .. automodule:: fireant.dataset.intervals
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.dataset.joins module
 ----------------------------
 
 .. automodule:: fireant.dataset.joins
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.dataset.klass module
 ----------------------------
 
 .. automodule:: fireant.dataset.klass
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.dataset.modifiers module
 --------------------------------
 
 .. automodule:: fireant.dataset.modifiers
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.dataset.operations module
 ---------------------------------
 
 .. automodule:: fireant.dataset.operations
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.dataset.references module
 ---------------------------------
 
 .. automodule:: fireant.dataset.references
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.dataset.totals module
 -----------------------------
 
 .. automodule:: fireant.dataset.totals
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-
-Module contents
----------------
-
-.. automodule:: fireant.dataset
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/api/fireant.middleware.rst
+++ b/docs/api/fireant.middleware.rst
@@ -1,0 +1,19 @@
+fireant.middleware package
+==========================
+
+.. automodule:: fireant.middleware
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+fireant.middleware.concurrency module
+-------------------------------------
+
+.. automodule:: fireant.middleware.concurrency
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/api/fireant.queries.rst
+++ b/docs/api/fireant.queries.rst
@@ -1,6 +1,11 @@
 fireant.queries package
 =======================
 
+.. automodule:: fireant.queries
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Submodules
 ----------
 
@@ -8,87 +13,79 @@ fireant.queries.builder module
 ------------------------------
 
 .. automodule:: fireant.queries.builder
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.queries.execution module
 --------------------------------
 
 .. automodule:: fireant.queries.execution
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.queries.field\_helper module
 ------------------------------------
 
 .. automodule:: fireant.queries.field_helper
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.queries.finders module
 ------------------------------
 
 .. automodule:: fireant.queries.finders
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.queries.pagination module
 ---------------------------------
 
 .. automodule:: fireant.queries.pagination
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.queries.reference\_helper module
 ----------------------------------------
 
 .. automodule:: fireant.queries.reference_helper
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.queries.slow\_query\_logger module
 ------------------------------------------
 
 .. automodule:: fireant.queries.slow_query_logger
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.queries.special\_cases module
 -------------------------------------
 
 .. automodule:: fireant.queries.special_cases
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.queries.sql\_transformer module
 ---------------------------------------
 
 .. automodule:: fireant.queries.sql_transformer
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.queries.totals\_helper module
 -------------------------------------
 
 .. automodule:: fireant.queries.totals_helper
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-
-Module contents
----------------
-
-.. automodule:: fireant.queries
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/api/fireant.rst
+++ b/docs/api/fireant.rst
@@ -1,16 +1,22 @@
 fireant package
 ===============
 
+.. automodule:: fireant
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Subpackages
 -----------
 
 .. toctree::
 
-    fireant.database
-    fireant.dataset
-    fireant.queries
-    fireant.tests
-    fireant.widgets
+   fireant.database
+   fireant.dataset
+   fireant.middleware
+   fireant.queries
+   fireant.tests
+   fireant.widgets
 
 Submodules
 ----------
@@ -19,47 +25,39 @@ fireant.exceptions module
 -------------------------
 
 .. automodule:: fireant.exceptions
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.formats module
 ----------------------
 
 .. automodule:: fireant.formats
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.reference\_helpers module
 ---------------------------------
 
 .. automodule:: fireant.reference_helpers
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.settings module
 -----------------------
 
 .. automodule:: fireant.settings
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.utils module
 --------------------
 
 .. automodule:: fireant.utils
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-
-Module contents
----------------
-
-.. automodule:: fireant
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/api/fireant.tests.database.rst
+++ b/docs/api/fireant.tests.database.rst
@@ -1,6 +1,11 @@
 fireant.tests.database package
 ==============================
 
+.. automodule:: fireant.tests.database
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Submodules
 ----------
 
@@ -8,63 +13,55 @@ fireant.tests.database.mock\_database module
 --------------------------------------------
 
 .. automodule:: fireant.tests.database.mock_database
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.database.test\_base\_database module
 --------------------------------------------------
 
 .. automodule:: fireant.tests.database.test_base_database
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.database.test\_mysql module
 -----------------------------------------
 
 .. automodule:: fireant.tests.database.test_mysql
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.database.test\_postgresql module
 ----------------------------------------------
 
 .. automodule:: fireant.tests.database.test_postgresql
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.database.test\_redshift module
 --------------------------------------------
 
 .. automodule:: fireant.tests.database.test_redshift
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.database.test\_snowflake module
 ---------------------------------------------
 
 .. automodule:: fireant.tests.database.test_snowflake
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.database.test\_vertica module
 -------------------------------------------
 
 .. automodule:: fireant.tests.database.test_vertica
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-
-Module contents
----------------
-
-.. automodule:: fireant.tests.database
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/api/fireant.tests.dataset.operations.rst
+++ b/docs/api/fireant.tests.dataset.operations.rst
@@ -1,6 +1,11 @@
 fireant.tests.dataset.operations package
 ========================================
 
+.. automodule:: fireant.tests.dataset.operations
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Submodules
 ----------
 
@@ -8,39 +13,31 @@ fireant.tests.dataset.operations.test\_builder module
 -----------------------------------------------------
 
 .. automodule:: fireant.tests.dataset.operations.test_builder
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.dataset.operations.test\_cumulative module
 --------------------------------------------------------
 
 .. automodule:: fireant.tests.dataset.operations.test_cumulative
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.dataset.operations.test\_rolling module
 -----------------------------------------------------
 
 .. automodule:: fireant.tests.dataset.operations.test_rolling
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.dataset.operations.test\_share module
 ---------------------------------------------------
 
 .. automodule:: fireant.tests.dataset.operations.test_share
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-
-Module contents
----------------
-
-.. automodule:: fireant.tests.dataset.operations
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/api/fireant.tests.dataset.rst
+++ b/docs/api/fireant.tests.dataset.rst
@@ -1,12 +1,17 @@
 fireant.tests.dataset package
 =============================
 
+.. automodule:: fireant.tests.dataset
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Subpackages
 -----------
 
 .. toctree::
 
-    fireant.tests.dataset.operations
+   fireant.tests.dataset.operations
 
 Submodules
 ----------
@@ -15,55 +20,47 @@ fireant.tests.dataset.matchers module
 -------------------------------------
 
 .. automodule:: fireant.tests.dataset.matchers
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.dataset.mocks module
 ----------------------------------
 
 .. automodule:: fireant.tests.dataset.mocks
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.dataset.test\_dataset module
 ------------------------------------------
 
 .. automodule:: fireant.tests.dataset.test_dataset
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.dataset.test\_execution module
 --------------------------------------------
 
 .. automodule:: fireant.tests.dataset.test_execution
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.dataset.test\_fields module
 -----------------------------------------
 
 .. automodule:: fireant.tests.dataset.test_fields
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.dataset.test\_filter\_totals\_from\_share\_results module
 -----------------------------------------------------------------------
 
 .. automodule:: fireant.tests.dataset.test_filter_totals_from_share_results
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-
-Module contents
----------------
-
-.. automodule:: fireant.tests.dataset
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/api/fireant.tests.queries.rst
+++ b/docs/api/fireant.tests.queries.rst
@@ -1,6 +1,11 @@
 fireant.tests.queries package
 =============================
 
+.. automodule:: fireant.tests.queries
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Submodules
 ----------
 
@@ -8,135 +13,127 @@ fireant.tests.queries.test\_build\_dimensions module
 ----------------------------------------------------
 
 .. automodule:: fireant.tests.queries.test_build_dimensions
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.queries.test\_build\_filters module
 -------------------------------------------------
 
 .. automodule:: fireant.tests.queries.test_build_filters
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.queries.test\_build\_having\_filters module
 ---------------------------------------------------------
 
 .. automodule:: fireant.tests.queries.test_build_having_filters
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.queries.test\_build\_joins module
 -----------------------------------------------
 
 .. automodule:: fireant.tests.queries.test_build_joins
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.queries.test\_build\_metrics module
 -------------------------------------------------
 
 .. automodule:: fireant.tests.queries.test_build_metrics
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.queries.test\_build\_operations module
 ----------------------------------------------------
 
 .. automodule:: fireant.tests.queries.test_build_operations
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.queries.test\_build\_orderbys module
 --------------------------------------------------
 
 .. automodule:: fireant.tests.queries.test_build_orderbys
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-fireant.tests.queries.test\_build\_pagination module
-----------------------------------------------------
-
-.. automodule:: fireant.tests.queries.test_build_pagination
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.queries.test\_build\_references module
 ----------------------------------------------------
 
 .. automodule:: fireant.tests.queries.test_build_references
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.queries.test\_builder module
 ------------------------------------------
 
 .. automodule:: fireant.tests.queries.test_builder
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.queries.test\_database module
 -------------------------------------------
 
 .. automodule:: fireant.tests.queries.test_database
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.queries.test\_dimension\_choices module
 -----------------------------------------------------
 
 .. automodule:: fireant.tests.queries.test_dimension_choices
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.queries.test\_dimension\_latest module
 ----------------------------------------------------
 
 .. automodule:: fireant.tests.queries.test_dimension_latest
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.queries.test\_fetch\_data module
 ----------------------------------------------
 
 .. automodule:: fireant.tests.queries.test_fetch_data
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+fireant.tests.queries.test\_fetch\_operations module
+----------------------------------------------------
+
+.. automodule:: fireant.tests.queries.test_fetch_operations
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.queries.test\_latest\_data module
 -----------------------------------------------
 
 .. automodule:: fireant.tests.queries.test_latest_data
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.queries.test\_pagination module
 ---------------------------------------------
 
 .. automodule:: fireant.tests.queries.test_pagination
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-
-Module contents
----------------
-
-.. automodule:: fireant.tests.queries
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/api/fireant.tests.rst
+++ b/docs/api/fireant.tests.rst
@@ -1,15 +1,20 @@
 fireant.tests package
 =====================
 
+.. automodule:: fireant.tests
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Subpackages
 -----------
 
 .. toctree::
 
-    fireant.tests.database
-    fireant.tests.dataset
-    fireant.tests.queries
-    fireant.tests.widgets
+   fireant.tests.database
+   fireant.tests.dataset
+   fireant.tests.queries
+   fireant.tests.widgets
 
 Submodules
 ----------
@@ -18,31 +23,31 @@ fireant.tests.test\_fireant module
 ----------------------------------
 
 .. automodule:: fireant.tests.test_fireant
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.test\_formats module
 ----------------------------------
 
 .. automodule:: fireant.tests.test_formats
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+fireant.tests.test\_middleware module
+-------------------------------------
+
+.. automodule:: fireant.tests.test_middleware
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.utils module
 --------------------------
 
 .. automodule:: fireant.tests.utils
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-
-Module contents
----------------
-
-.. automodule:: fireant.tests
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/api/fireant.tests.widgets.rst
+++ b/docs/api/fireant.tests.widgets.rst
@@ -1,6 +1,11 @@
 fireant.tests.widgets package
 =============================
 
+.. automodule:: fireant.tests.widgets
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Submodules
 ----------
 
@@ -8,55 +13,47 @@ fireant.tests.widgets.test\_csv module
 --------------------------------------
 
 .. automodule:: fireant.tests.widgets.test_csv
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.widgets.test\_highcharts module
 ---------------------------------------------
 
 .. automodule:: fireant.tests.widgets.test_highcharts
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.widgets.test\_matplotlib module
 ---------------------------------------------
 
 .. automodule:: fireant.tests.widgets.test_matplotlib
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.widgets.test\_pandas module
 -----------------------------------------
 
 .. automodule:: fireant.tests.widgets.test_pandas
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.widgets.test\_reacttable module
 ---------------------------------------------
 
 .. automodule:: fireant.tests.widgets.test_reacttable
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.tests.widgets.test\_widgets module
 ------------------------------------------
 
 .. automodule:: fireant.tests.widgets.test_widgets
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-
-Module contents
----------------
-
-.. automodule:: fireant.tests.widgets
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/api/fireant.widgets.rst
+++ b/docs/api/fireant.widgets.rst
@@ -1,6 +1,11 @@
 fireant.widgets package
 =======================
 
+.. automodule:: fireant.widgets
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Submodules
 ----------
 
@@ -8,63 +13,55 @@ fireant.widgets.base module
 ---------------------------
 
 .. automodule:: fireant.widgets.base
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.widgets.chart\_base module
 ----------------------------------
 
 .. automodule:: fireant.widgets.chart_base
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.widgets.csv module
 --------------------------
 
 .. automodule:: fireant.widgets.csv
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.widgets.highcharts module
 ---------------------------------
 
 .. automodule:: fireant.widgets.highcharts
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.widgets.matplotlib module
 ---------------------------------
 
 .. automodule:: fireant.widgets.matplotlib
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.widgets.pandas module
 -----------------------------
 
 .. automodule:: fireant.widgets.pandas
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 fireant.widgets.reacttable module
 ---------------------------------
 
 .. automodule:: fireant.widgets.reacttable
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-
-Module contents
----------------
-
-.. automodule:: fireant.widgets
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -1,7 +1,7 @@
-fireant
-=======
+API Reference
+=============
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 5
 
    fireant

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'fireant'
-copyright = '2016, KAYAK Germany GmbH'
+copyright = '2019, KAYAK Germany GmbH'
 author = 'Timothy Heys, Mourad Mourafiq, Arturas Tutkus, Remi Koenig, Michael England, Lucas Lira Gomes'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -80,7 +80,7 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = []
+exclude_patterns = ['_build', 'api/fireant.tests*']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/fireant/database/base.py
+++ b/fireant/database/base.py
@@ -5,6 +5,8 @@ from pypika import (
     terms,
 )
 
+from fireant.middleware.concurrency import ThreadPoolConcurrencyMiddleware
+
 
 class Database(object):
     """
@@ -16,14 +18,14 @@ class Database(object):
 
     slow_query_log_min_seconds = 15
 
-    def __init__(self, host=None, port=None, database=None, max_processes=2, max_result_set_size=200000,
-                 cache_middleware=None):
+    def __init__(self, host=None, port=None, database=None, max_processes=1, max_result_set_size=200000,
+                 cache_middleware=None, concurrency_middleware=None):
         self.host = host
         self.port = port
         self.database = database
-        self.max_processes = max_processes
         self.max_result_set_size = max_result_set_size
         self.cache_middleware = cache_middleware
+        self.concurrency_middleware = concurrency_middleware or ThreadPoolConcurrencyMiddleware(max_processes)
 
     def connect(self):
         """

--- a/fireant/database/mysql.py
+++ b/fireant/database/mysql.py
@@ -41,10 +41,8 @@ class MySQLDatabase(Database):
     query_cls = MySQLQuery
 
     def __init__(self, host='localhost', port=3306, database=None,
-                 user=None, password=None, charset='utf8mb4', max_processes=1, cache_middleware=None):
-        super(MySQLDatabase, self).__init__(host, port, database,
-                                            max_processes=max_processes,
-                                            cache_middleware=cache_middleware)
+                 user=None, password=None, charset='utf8mb4', **kwags):
+        super(MySQLDatabase, self).__init__(host, port, database, **kwags)
         self.user = user
         self.password = password
         self.charset = charset

--- a/fireant/database/postgresql.py
+++ b/fireant/database/postgresql.py
@@ -30,10 +30,8 @@ class PostgreSQLDatabase(Database):
     query_cls = PostgreSQLQuery
 
     def __init__(self, host='localhost', port=5432, database=None,
-                 user=None, password=None, max_processes=1, cache_middleware=None):
-        super(PostgreSQLDatabase, self).__init__(host, port, database,
-                                                 max_processes=max_processes,
-                                                 cache_middleware=cache_middleware)
+                 user=None, password=None, **kwags):
+        super(PostgreSQLDatabase, self).__init__(host, port, database, **kwags)
         self.user = user
         self.password = password
 

--- a/fireant/database/redshift.py
+++ b/fireant/database/redshift.py
@@ -12,7 +12,5 @@ class RedshiftDatabase(PostgreSQLDatabase):
     query_cls = RedshiftQuery
 
     def __init__(self, host='localhost', port=5439, database=None,
-                 user=None, password=None, max_processes=1, cache_middleware=None):
-        super(RedshiftDatabase, self).__init__(host, port, database, user, password,
-                                               max_processes=max_processes,
-                                               cache_middleware=cache_middleware)
+                 user=None, password=None, **kwags):
+        super(RedshiftDatabase, self).__init__(host, port, database, user, password, **kwags)

--- a/fireant/database/snowflake.py
+++ b/fireant/database/snowflake.py
@@ -50,11 +50,8 @@ class SnowflakeDatabase(Database):
     def __init__(self, user='snowflake', password=None,
                  account='snowflake', database='snowflake',
                  private_key_data=None, private_key_password=None,
-                 region=None, warehouse=None,
-                 max_processes=1, cache_middleware=None):
-        super(SnowflakeDatabase, self).__init__(database=database,
-                                                max_processes=max_processes,
-                                                cache_middleware=cache_middleware)
+                 region=None, warehouse=None, **kwags):
+        super(SnowflakeDatabase, self).__init__(database=database, **kwags)
         self.user = user
         self.password = password
         self.account = account

--- a/fireant/database/vertica.py
+++ b/fireant/database/vertica.py
@@ -39,10 +39,8 @@ class VerticaDatabase(Database):
     }
 
     def __init__(self, host='localhost', port=5433, database='vertica', user='vertica', password=None,
-                 read_timeout=None, max_processes=1, cache_middleware=None):
-        super(VerticaDatabase, self).__init__(host, port, database,
-                                              max_processes=max_processes,
-                                              cache_middleware=cache_middleware)
+                 read_timeout=None, **kwags):
+        super(VerticaDatabase, self).__init__(host, port, database, **kwags)
         self.user = user
         self.password = password
         self.read_timeout = read_timeout

--- a/fireant/middleware/__init__.py
+++ b/fireant/middleware/__init__.py
@@ -1,0 +1,4 @@
+from .concurrency import (
+    BaseConcurrencyMiddleware,
+    ThreadPoolConcurrencyMiddleware,
+)

--- a/fireant/middleware/concurrency.py
+++ b/fireant/middleware/concurrency.py
@@ -1,0 +1,46 @@
+import abc
+from multiprocessing.pool import ThreadPool
+
+
+class BaseConcurrencyMiddleware(abc.ABC):
+    """
+    The abstract base class that should be inherited from to define a concurrency middleware.
+    """
+    @abc.abstractmethod
+    def fetch_queries_as_dataframe(self, queries, database):
+        """
+        Implementations of this method should execute the given queries on the supplied database and return the results.
+        :return: A list of the results of the executed queries.
+        """
+        pass
+
+    def fetch_query(self, query, database):
+        """
+        Perform a query on the database.
+
+        :param query: The query to execute.
+        :param database: The database to perform the query on.
+        :return: The result of the query.
+        """
+        return database.fetch(query)
+
+
+class ThreadPoolConcurrencyMiddleware(BaseConcurrencyMiddleware):
+    """
+    A concurrency middleware implementation based on threadpools used as a default middleware.
+    """
+    def __init__(self, max_processes=1):
+        self.max_processes = max_processes
+
+    def fetch_queries_as_dataframe(self, queries, database):
+        """
+        Executes the different queries in separate threads.
+        """
+        from fireant.queries.execution import fetch_as_dataframe
+        iterable = [(query, database) for query in queries]
+
+        with ThreadPool(processes=self.max_processes) as pool:
+            results = pool.map(lambda args: fetch_as_dataframe(*args), iterable)
+            pool.close()
+
+        return results

--- a/fireant/queries/__init__.py
+++ b/fireant/queries/__init__.py
@@ -3,3 +3,4 @@ from .builder import (
     DimensionChoicesQueryBuilder,
     DimensionLatestQueryBuilder,
 )
+from .execution import fetch_as_dataframe

--- a/fireant/tests/database/test_base_database.py
+++ b/fireant/tests/database/test_base_database.py
@@ -3,6 +3,8 @@ from unittest import TestCase
 from fireant.database import Database
 from pypika import Field
 
+from fireant.middleware.concurrency import ThreadPoolConcurrencyMiddleware
+
 
 class DatabaseTests(TestCase):
     def test_database_api(self):
@@ -19,3 +21,9 @@ class DatabaseTests(TestCase):
 
         to_char = db.to_char(Field('field'))
         self.assertEqual(str(to_char), 'CAST("field" AS VARCHAR)')
+
+    def test_no_concurrency_middleware_specified_gives_default_threadpool(self):
+        db = Database(max_processes=5)
+
+        self.assertIsInstance(db.concurrency_middleware, ThreadPoolConcurrencyMiddleware)
+        self.assertEquals(db.concurrency_middleware.max_processes, 5)

--- a/fireant/tests/queries/test_database.py
+++ b/fireant/tests/queries/test_database.py
@@ -8,7 +8,7 @@ from unittest.mock import (
 import pandas as pd
 import time
 
-from fireant.queries.execution import _do_fetch_data
+from fireant.queries.execution import fetch_as_dataframe
 from fireant.tests.dataset.mocks import (
     dimx1_str_df,
     dimx2_date_str_df,
@@ -35,7 +35,7 @@ class FetchDataTests(TestCase):
 
     def test_do_fetch_data_calls_database_fetch_data(self, ):
         with patch('fireant.queries.execution.pd.read_sql', return_value=self.mock_data_frame) as mock_read_sql:
-            _do_fetch_data(self.mock_query, self.mock_database)
+            fetch_as_dataframe(self.mock_query, self.mock_database)
 
             mock_read_sql.assert_called_once_with(self.mock_query,
                                                   self.mock_connection,
@@ -63,14 +63,14 @@ class FetchDataLoggingTests(TestCase):
 
     @patch('fireant.queries.execution.query_logger')
     def test_debug_query_log_called_with_query(self, mock_logger, *mocks):
-        _do_fetch_data(self.mock_query, self.mock_database)
+        fetch_as_dataframe(self.mock_query, self.mock_database)
 
         mock_logger.debug.assert_called_once_with('SELECT *')
 
     @patch.object(time, 'time', return_value=1520520255.0)
     @patch('fireant.queries.execution.query_logger')
     def test_info_query_log_called_with_query_and_duration(self, mock_logger, *mocks):
-        _do_fetch_data(self.mock_query, self.mock_database)
+        fetch_as_dataframe(self.mock_query, self.mock_database)
 
         mock_logger.info.assert_called_once_with('[0.0 seconds]: SELECT *')
 
@@ -81,7 +81,7 @@ class FetchDataLoggingTests(TestCase):
                                                                                                mock_time,
                                                                                                *mocks):
         mock_time.side_effect = [1520520255.0, 1520520277.0]
-        _do_fetch_data(self.mock_query, self.mock_database)
+        fetch_as_dataframe(self.mock_query, self.mock_database)
 
         mock_logger.warning.assert_called_once_with('[22.0 seconds]: SELECT *')
 
@@ -92,7 +92,7 @@ class FetchDataLoggingTests(TestCase):
                                                                                                        mock_time,
                                                                                                        *mocks):
         mock_time.side_effect = [1520520763.0, 1520520764.0]
-        _do_fetch_data(self.mock_query, self.mock_database)
+        fetch_as_dataframe(self.mock_query, self.mock_database)
 
         mock_logger.warning.assert_not_called()
 

--- a/fireant/tests/test_middleware.py
+++ b/fireant/tests/test_middleware.py
@@ -1,0 +1,39 @@
+from unittest import TestCase
+from unittest.mock import patch, MagicMock, ANY
+
+from fireant.middleware.concurrency import ThreadPoolConcurrencyMiddleware, BaseConcurrencyMiddleware
+
+
+class TestThreadPoolConcurrencyMiddleware(TestCase):
+
+    @patch('fireant.middleware.concurrency.ThreadPool', autospec=True)
+    def test_fetch_queries_as_dataframe(self, mock_threadpool_manager):
+        queries = ['query_a', 'query_b']
+        database = 'database'
+        pool_mock = MagicMock()
+        pool_mock.map.return_value = ['result_a', 'result_b']
+        mock_threadpool_manager.return_value.__enter__.return_value = pool_mock
+
+        middleware = ThreadPoolConcurrencyMiddleware()
+
+        results = middleware.fetch_queries_as_dataframe(queries, database)
+
+        self.assertEqual(results, ['result_a', 'result_b'])
+        pool_mock.map.assert_called_with(ANY, [('query_a', 'database'), ('query_b', 'database')])
+
+
+class TestBaseConcurrencyMiddleware(TestCase):
+
+    @patch.object(BaseConcurrencyMiddleware, '__abstractmethods__', set())
+    def test_fetch_query(self):
+        query = 'query'
+        mock_database = MagicMock()
+        mock_database.fetch.return_value = 'result'
+
+        concurrency_middleware = BaseConcurrencyMiddleware()
+
+        result = concurrency_middleware.fetch_query(query, mock_database)
+
+        self.assertEqual(result, 'result')
+        mock_database.fetch.assert_called_with(query)
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,5 @@ bumpversion==0.5.3
 wheel==0.30.0
 watchdog==0.8.3
 flake8==3.5.0
+sphinx==2.2.0
+sphinx-rtd-theme==0.4.3

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
       packages=['fireant',
                 'fireant.database',
                 'fireant.dataset',
+                'fireant.middleware',
                 'fireant.queries',
                 'fireant.widgets'],
 


### PR DESCRIPTION
Next to introducing the concept of concurrency middleware I also updated the docs to make references to the api and introduced a section on middleware.

Note: sphinx-apidoc generates 3 spaces instead of 4 now for auto-generated api docs, which causes the clutter in this pull request.