### PR TITLE
Order of columns in csv using references

### DIFF
--- a/fireant/tests/widgets/test_csv.py
+++ b/fireant/tests/widgets/test_csv.py
@@ -22,6 +22,8 @@ from fireant.tests.widgets.test_pandas import _format_float
 from fireant.utils import alias_selector as f
 
 csv_options = {'quoting': QUOTE_MINIMAL}
+
+
 class CSVWidgetTests(TestCase):
     maxDiff = None
 
@@ -156,6 +158,19 @@ class CSVWidgetTests(TestCase):
         expected = dimx2_date_str_ref_df.copy()[[f('votes'), f('votes_eoe')]]
         expected.index.names = ['Timestamp', 'Party']
         expected.columns = ['Votes', 'Votes EoE']
+        expected = expected.applymap(_format_float)
+
+        self.assertEqual(expected.to_csv(**csv_options), result)
+
+    def test_time_series_multi_ref(self):
+        query_dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
+        query_references = [ElectionOverElection(mock_dataset.fields.timestamp)]
+        result = CSV(mock_dataset.fields.votes, mock_dataset.fields.wins) \
+            .transform(dimx2_date_str_ref_df, mock_dataset, query_dimensions, query_references)
+
+        expected = dimx2_date_str_ref_df.copy()[[f('votes'), f('votes_eoe'), f('wins'), f('wins_eoe')]]
+        expected.index.names = ['Timestamp', 'Party']
+        expected.columns = ['Votes', 'Votes EoE', 'Wins', 'Wins EoE']
         expected = expected.applymap(_format_float)
 
         self.assertEqual(expected.to_csv(**csv_options), result)

--- a/fireant/widgets/pandas.py
+++ b/fireant/widgets/pandas.py
@@ -41,8 +41,8 @@ class Pandas(TransformableWidget):
         result = data_frame.copy()
 
         items = [item if reference is None else ReferenceItem(item, reference)
-                 for reference in [None] + references
-                 for item in self.items]
+                 for item in self.items
+                 for reference in [None] + references]
 
         if isinstance(data_frame.index, pd.MultiIndex):
             index_levels = [alias_selector(dimension.alias)


### PR DESCRIPTION
Fixed the ordering of columns in csv to put the references directly after the metric columns