### PR TITLE
Pin urllib3 to 2.4.3 to fix the snowflake connector.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
 -r requirements.txt
--r requirements-db-vertica.txt
--r requirements-db-snowflake.txt
--r requirements-db-mysql.txt
--r requirements-db-redshift.txt
--r requirements-db-postgresql.txt
--r requirements-db-ipython.txt
+-r requirements-extras-vertica.txt
+-r requirements-extras-snowflake.txt
+-r requirements-extras-mysql.txt
+-r requirements-extras-redshift.txt
+-r requirements-extras-postgresql.txt
+-r requirements-extras-ipython.txt
 mock
 bumpversion==0.5.3
 wheel==0.30.0

--- a/requirements-extras-snowflake.txt
+++ b/requirements-extras-snowflake.txt
@@ -1,2 +1,2 @@
+urllib3==1.24.3
 snowflake-connector-python==2.0.3
-cryptography==2.4.2


### PR DESCRIPTION
I had to remove `cryptography==2.4.2` as requirements.txt already contains a pinned version for cryptography.