### PR TITLE
Add option to reuse database connections

### DIFF
--- a/fireant/database/base.py
+++ b/fireant/database/base.py
@@ -41,9 +41,14 @@ class Database(object):
         """
         raise NotImplementedError
 
-    def get_column_definitions(self, schema, table):
+    def get_column_definitions(self, schema, table, connection=None):
         """
-        This function must return the columns of a given schema and table.
+        Return a list of column name, column data type pairs.
+
+        :param schema: The name of the table schema.
+        :param table: The name of the table to get columns from.
+        :param connection: (Optional) The connection to execute this query with.
+        :return: A list of columns.
         """
         raise NotImplementedError
 

--- a/fireant/database/base.py
+++ b/fireant/database/base.py
@@ -34,7 +34,6 @@ class Database(object):
         self.max_result_set_size = max_result_set_size
         self.cache_middleware = cache_middleware
         self.concurrency_middleware = concurrency_middleware or ThreadPoolConcurrencyMiddleware(max_processes)
-        self.connection = None
 
     def connect(self):
         """

--- a/fireant/database/base.py
+++ b/fireant/database/base.py
@@ -42,13 +42,6 @@ class Database(object):
         """
         raise NotImplementedError
 
-    def begin_session(self):
-        self.connection = self.connect()
-
-    def end_session(self):
-        self.connection.close()
-        self.connection = None
-
     def get_column_definitions(self, schema, table):
         """
         This function must return the columns of a given schema and table.

--- a/fireant/database/mysql.py
+++ b/fireant/database/mysql.py
@@ -113,10 +113,7 @@ class MySQLDatabase(Database):
         interval_term = terms.Interval(**{'{}s'.format(str(date_part)): interval, 'dialect': Dialects.MYSQL})
         return DateAdd(field, interval_term)
 
-    def get_column_definitions(self, schema, table):
-        """
-        Return a list of column name, column data type pairs.
-        """
+    def get_column_definitions(self, schema, table, connection=None):
         columns = Table('columns', schema='INFORMATION_SCHEMA')
 
         columns_query = MySQLQuery \
@@ -127,48 +124,51 @@ class MySQLDatabase(Database):
             .distinct() \
             .orderby(columns.column_name)
 
-        return self.fetch(str(columns_query))
+        return self.fetch(str(columns_query), connection=connection)
 
-    def import_csv(self, table, file_path):
+    def import_csv(self, table, file_path, connection=None):
         """
         Execute a query to import a file into a table using the provided connection.
 
         :param table: The name of a table to import data into.
         :param file_path: The path of the file to be imported.
+        :param connection: (Optional) The connection to execute this query with.
         """
         import_query = MySQLQuery \
             .load(file_path) \
             .into(table)
 
-        self.execute(str(import_query))
+        self.execute(str(import_query), connection=connection)
 
-    def create_temporary_table_from_columns(self, table, columns):
+    def create_temporary_table_from_columns(self, table, columns, connection=None):
         """
         Creates a temporary table from a list of columns.
 
         :param table: The name of the new temporary table.
         :param columns: The columns of the new temporary table.
+        :param connection: (Optional) The connection to execute this query with.
         """
         create_query = MySQLQuery \
             .create_table(table) \
             .temporary() \
             .columns(*columns)
 
-        self.execute(str(create_query))
+        self.execute(str(create_query), connection=connection)
 
-    def create_temporary_table_from_select(self, table, select_query):
+    def create_temporary_table_from_select(self, table, select_query, connection=None):
         """
         Creates a temporary table from a SELECT query.
 
         :param table: The name of the new temporary table.
         :param select_query: The query to be used for selecting data of an existing table for the new temporary table.
+        :param connection: (Optional) The connection to execute this query with.
         """
         create_query = MySQLQuery \
             .create_table(table) \
             .temporary() \
             .as_select(select_query)
 
-        self.execute(str(create_query))
+        self.execute(str(create_query), connection=connection)
 
 
 class MySQLTypeEngine(TypeEngine):

--- a/fireant/database/mysql.py
+++ b/fireant/database/mysql.py
@@ -129,61 +129,46 @@ class MySQLDatabase(Database):
 
         return self.fetch(str(columns_query))
 
-    @staticmethod
-    def import_csv(connection, table_name, file_path):
+    def import_csv(self, table, file_path):
         """
         Execute a query to import a file into a table using the provided connection.
 
-        :param connection: The connection for mysql.
-        :param table_name: The name of a table to import data into.
+        :param table: The name of a table to import data into.
         :param file_path: The path of the file to be imported.
         """
-        query = MySQLQuery \
+        import_query = MySQLQuery \
             .load(file_path) \
-            .into(table_name)
+            .into(table)
 
-        cursor = connection.cursor()
-        cursor.execute(str(query))
+        self.execute(str(import_query))
 
-        connection.commit()
-
-    @staticmethod
-    def create_temporary_table_from_columns(connection, table_name, columns):
+    def create_temporary_table_from_columns(self, table, columns):
         """
         Creates a temporary table from a list of columns.
 
-        :param connection: The connection for mysql.
-        :param table_name: The name of the new temporary table.
+        :param table: The name of the new temporary table.
         :param columns: The columns of the new temporary table.
         """
         create_query = MySQLQuery \
-            .create_table(table_name) \
+            .create_table(table) \
             .temporary() \
             .columns(*columns)
 
-        cursor = connection.cursor()
-        cursor.execute(str(create_query))
+        self.execute(str(create_query))
 
-        connection.commit()
-
-    @staticmethod
-    def create_temporary_table_from_select(connection, table_name, select_query):
+    def create_temporary_table_from_select(self, table, select_query):
         """
         Creates a temporary table from a SELECT query.
 
-        :param connection: The connection for mysql.
-        :param table_name: The name of the new temporary table.
+        :param table: The name of the new temporary table.
         :param select_query: The query to be used for selecting data of an existing table for the new temporary table.
         """
         create_query = MySQLQuery \
-            .create_table(table_name) \
+            .create_table(table) \
             .temporary() \
             .as_select(select_query)
 
-        cursor = connection.cursor()
-        cursor.execute(str(create_query))
-
-        connection.commit()
+        self.execute(str(create_query))
 
 
 class MySQLTypeEngine(TypeEngine):

--- a/fireant/database/postgresql.py
+++ b/fireant/database/postgresql.py
@@ -47,8 +47,7 @@ class PostgreSQLDatabase(Database):
     def date_add(self, field, date_part, interval):
         return fn.DateAdd(str(date_part), interval, field)
 
-    def get_column_definitions(self, schema, table):
-        """ Return a list of column name, column data type pairs """
+    def get_column_definitions(self, schema, table, connection=None):
         columns = Table('columns', schema='INFORMATION_SCHEMA')
 
         columns_query = PostgreSQLQuery.from_(columns) \
@@ -58,5 +57,5 @@ class PostgreSQLDatabase(Database):
             .distinct() \
             .orderby(columns.column_name)
 
-        return self.fetch(str(columns_query))
+        return self.fetch(str(columns_query), connection=connection)
 

--- a/fireant/database/snowflake.py
+++ b/fireant/database/snowflake.py
@@ -101,8 +101,7 @@ class SnowflakeDatabase(Database):
                                   format=serialization.PrivateFormat.PKCS8,
                                   encryption_algorithm=serialization.NoEncryption())
 
-    def get_column_definitions(self, schema, table):
-        """ Return a list of column name, column data type pairs """
-        columns = self.fetch('DESCRIBE TABLE {}.{} TYPE=COLUMNS'.format(schema, table))
+    def get_column_definitions(self, schema, table, connection=None):
+        columns = self.fetch('DESCRIBE TABLE {}.{} TYPE=COLUMNS'.format(schema, table), connection=connection)
         return [column[0:2] for column in columns]
 

--- a/fireant/database/vertica.py
+++ b/fireant/database/vertica.py
@@ -98,66 +98,51 @@ class VerticaDatabase(Database):
 
         return self.fetch(str(table_query))
 
-    @staticmethod
-    def import_csv(connection, table_name, file_path):
+    def import_csv(self, table, file_path):
         """
-        Execute a query to import a file into a table using the provided connection.
+        Imports a file into a database table.
 
-        :param connection: The connection for vertica.
-        :param table_name: The name of a table to import data into.
+        :param table: The name of a table to import data into.
         :param file_path: The path of the file to be imported.
         """
-        query = VerticaQuery \
+        import_query = VerticaQuery \
             .from_file(file_path) \
-            .copy_(table_name)
+            .copy_(table)
 
-        cursor = connection.cursor()
-        cursor.execute(str(query))
+        self.execute(str(import_query))
 
-        connection.commit()
-
-    @staticmethod
-    def create_temporary_table_from_columns(connection, table_name, columns):
+    def create_temporary_table_from_columns(self, table, columns):
         """
-        Create a temporary table from a list of columns.
+        Creates a temporary table from a list of columns.
 
-        :param connection: The connection for vertica.
-        :param table_name: The name of the new temporary table.
+        :param table: The name of the new temporary table.
         :param columns: The columns of the new temporary table.
         """
         create_query = VerticaQuery \
-            .create_table(table_name) \
+            .create_table(table) \
             .temporary() \
             .local() \
             .preserve_rows() \
             .columns(*columns)
 
-        cursor = connection.cursor()
-        cursor.execute(str(create_query))
+        self.execute(str(create_query))
 
-        connection.commit()
-
-    @staticmethod
-    def create_temporary_table_from_select(connection, table_name, select_query):
+    def create_temporary_table_from_select(self, table, select_query):
         """
-        Create a temporary table from a SELECT query.
+        Creates a temporary table from a SELECT query.
 
-        :param connection: The connection for vertica.
-        :param table_name: The name of the new temporary table.
+        :param table: The name of the new temporary table.
         :param select_query: The query to be used for selecting data of an existing table for the new temporary table.
         :return:
         """
         create_query = VerticaQuery \
-            .create_table(table_name) \
+            .create_table(table) \
             .temporary() \
             .local() \
             .preserve_rows() \
             .as_select(select_query)
 
-        cursor = connection.cursor()
-        cursor.execute(str(create_query))
-
-        connection.commit()
+        self.execute(str(create_query))
 
 
 class VerticaTypeEngine(TypeEngine):

--- a/fireant/middleware/decorators.py
+++ b/fireant/middleware/decorators.py
@@ -40,9 +40,10 @@ def log(func):
 
 def with_connection(func):
     @wraps(func)
-    def wrapper(database, query):
-        if database.connection:
-            return func(database, query, connection=database.connection)
+    def wrapper(database, query, **kwargs):
+        connection = kwargs.get('connection', None)
+        if connection:
+            return func(database, query, connection=connection)
         with database.connect() as connection:
             return func(database, query, connection=connection)
 

--- a/fireant/middleware/decorators.py
+++ b/fireant/middleware/decorators.py
@@ -36,3 +36,14 @@ def log(func):
         return result
 
     return wrapper
+
+
+def with_connection(func):
+    @wraps(func)
+    def wrapper(database, query):
+        if database.connection:
+            return func(database, query, connection=database.connection)
+        with database.connect() as connection:
+            return func(database, query, connection=connection)
+
+    return wrapper

--- a/fireant/tests/database/test_base_database.py
+++ b/fireant/tests/database/test_base_database.py
@@ -1,11 +1,26 @@
 from unittest import TestCase
-from unittest.mock import Mock
+from unittest.mock import (
+    Mock,
+    patch,
+)
 
 from pypika import Field
 
 from fireant.middleware.concurrency import ThreadPoolConcurrencyMiddleware
 from fireant.database import Database
-from fireant.utils import read_csv
+from fireant.middleware.decorators import with_connection
+
+
+@with_connection
+def test_fetch(database, query, **kwargs):
+    return kwargs.get('connection')
+
+
+def test_connect():
+    mock_connection = Mock()
+    mock_connection.__enter__ = Mock()
+    mock_connection.__exit__ = Mock()
+    return mock_connection
 
 
 class TestBaseDatabase(TestCase):
@@ -30,19 +45,32 @@ class TestBaseDatabase(TestCase):
         self.assertIsInstance(db.concurrency_middleware, ThreadPoolConcurrencyMiddleware)
         self.assertEquals(db.concurrency_middleware.max_processes, 5)
 
+    @patch.object(Database, 'fetch')
+    @patch.object(Database, 'connect')
+    def test_database_session_fetch_reuses_connection(self, mock_connect, mock_fetch):
+        db = Database()
 
-class TestCSVExport(TestCase):
-    def test_export_csv(self):
-        mock_cursor = Mock()
-        mock_cursor.fetchall.return_value = [(1, 'a', True), (2, 'ab', False)]
-        mock_cursor.execute = Mock()
+        mock_connect.side_effect = test_connect
+        mock_fetch.side_effect = test_fetch
 
-        mock_connection = Mock()
-        mock_connection.cursor.return_value = mock_cursor
+        db.begin_session()
+        connection_1 = db.fetch(db, 'SELECT a from abc')
+        connection_2 = db.fetch(db, 'SELECT b from def')
+        db.end_session()
 
-        ntf = Database.export_csv(mock_connection, 'SELECT a FROM abc')
-        ntf_rows = read_csv(ntf.name)
+        self.assertEqual(1, mock_connect.call_count)
+        self.assertEqual(connection_1, connection_2)
 
-        mock_cursor.execute.assert_called_once_with('SELECT a FROM abc')
-        self.assertEqual(['1', 'a', 'True'], ntf_rows[0])
-        self.assertEqual(['2', 'ab', 'False'], ntf_rows[1])
+    @patch.object(Database, 'fetch')
+    @patch.object(Database, 'connect')
+    def test_database_fetch_opens_new_connection(self, mock_connect, mock_fetch):
+        db = Database()
+
+        mock_connect.side_effect = test_connect
+        mock_fetch.side_effect = test_fetch
+
+        connection_1 = db.fetch(db, 'SELECT a from abc')
+        connection_2 = db.fetch(db, 'SELECT b from def')
+
+        self.assertEqual(2, mock_connect.call_count)
+        self.assertNotEqual(connection_1, connection_2)

--- a/fireant/tests/database/test_base_database.py
+++ b/fireant/tests/database/test_base_database.py
@@ -47,23 +47,22 @@ class TestBaseDatabase(TestCase):
 
     @patch.object(Database, 'fetch')
     @patch.object(Database, 'connect')
-    def test_database_session_fetch_reuses_connection(self, mock_connect, mock_fetch):
+    def test_database_reuse_passed_connection(self, mock_connect, mock_fetch):
         db = Database()
 
         mock_connect.side_effect = test_connect
         mock_fetch.side_effect = test_fetch
 
-        db.begin_session()
-        connection_1 = db.fetch(db, 'SELECT a from abc')
-        connection_2 = db.fetch(db, 'SELECT b from def')
-        db.end_session()
+        with db.connect() as connection:
+            connection_1 = db.fetch(db, 'SELECT a from abc', connection=connection)
+            connection_2 = db.fetch(db, 'SELECT b from def', connection=connection)
 
         self.assertEqual(1, mock_connect.call_count)
         self.assertEqual(connection_1, connection_2)
 
     @patch.object(Database, 'fetch')
     @patch.object(Database, 'connect')
-    def test_database_fetch_opens_new_connection(self, mock_connect, mock_fetch):
+    def test_database_opens_new_connection(self, mock_connect, mock_fetch):
         db = Database()
 
         mock_connect.side_effect = test_connect

--- a/fireant/tests/database/test_mysql.py
+++ b/fireant/tests/database/test_mysql.py
@@ -114,18 +114,21 @@ class TestMySQLDatabase(TestCase):
     def test_get_column_definitions(self, mock_fetch):
         MySQLDatabase().get_column_definitions('test_schema', 'test_table')
 
-        mock_fetch.assert_called_once_with('SELECT DISTINCT `column_name`,`column_type` '
-                                           'FROM `INFORMATION_SCHEMA`.`columns` '
-                                           'WHERE `table_schema`=\'test_schema\' AND `table_name`=\'test_table\' '
-                                           'ORDER BY `column_name`')
+        mock_fetch.assert_called_once_with(
+              'SELECT DISTINCT `column_name`,`column_type` '
+              'FROM `INFORMATION_SCHEMA`.`columns` '
+              'WHERE `table_schema`=\'test_schema\' AND `table_name`=\'test_table\' '
+              'ORDER BY `column_name`',
+              connection=None
+        )
 
     @patch.object(MySQLDatabase, 'execute')
     def test_import_csv(self, mock_execute):
-
         MySQLDatabase().import_csv('abc', '/path/to/file')
 
         mock_execute.assert_called_once_with(
-            'LOAD DATA LOCAL INFILE \'/path/to/file\' INTO TABLE `abc` FIELDS TERMINATED BY \',\''
+              'LOAD DATA LOCAL INFILE \'/path/to/file\' INTO TABLE `abc` FIELDS TERMINATED BY \',\'',
+              connection=None
         )
 
     @patch.object(MySQLDatabase, 'execute')
@@ -135,7 +138,8 @@ class TestMySQLDatabase(TestCase):
         MySQLDatabase().create_temporary_table_from_columns('abc', columns)
 
         mock_execute.assert_called_once_with(
-              'CREATE TEMPORARY TABLE "abc" ("a" varchar,"b" varchar(100))'
+              'CREATE TEMPORARY TABLE "abc" ("a" varchar,"b" varchar(100))',
+              connection=None
         )
 
     @patch.object(MySQLDatabase, 'execute')
@@ -145,7 +149,8 @@ class TestMySQLDatabase(TestCase):
         MySQLDatabase().create_temporary_table_from_select('def', query)
 
         mock_execute.assert_called_once_with(
-              'CREATE TEMPORARY TABLE "def" AS (SELECT * FROM "abc")'
+              'CREATE TEMPORARY TABLE "def" AS (SELECT * FROM "abc")',
+              connection=None,
         )
 
 

--- a/fireant/tests/database/test_postgresql.py
+++ b/fireant/tests/database/test_postgresql.py
@@ -94,7 +94,10 @@ class TestPostgreSQL(TestCase):
     def test_get_column_definitions(self, mock_fetch):
         PostgreSQLDatabase().get_column_definitions('test_schema', 'test_table')
 
-        mock_fetch.assert_called_once_with('SELECT DISTINCT "column_name","data_type" ' \
-                                           'FROM "INFORMATION_SCHEMA"."columns" ' \
-                                           'WHERE "table_schema"=\'test_schema\' AND "table_name"=\'test_table\' ' \
-                                           'ORDER BY "column_name"')
+        mock_fetch.assert_called_once_with(
+              'SELECT DISTINCT "column_name","data_type" ' \
+              'FROM "INFORMATION_SCHEMA"."columns" ' \
+              'WHERE "table_schema"=\'test_schema\' AND "table_name"=\'test_table\' ' \
+              'ORDER BY "column_name"',
+              connection=None
+        )

--- a/fireant/tests/database/test_snowflake.py
+++ b/fireant/tests/database/test_snowflake.py
@@ -138,4 +138,7 @@ class TestSnowflake(TestCase):
     def test_get_column_definitions(self, mock_fetch):
         SnowflakeDatabase().get_column_definitions('test_schema', 'test_table')
 
-        mock_fetch.assert_called_once_with('DESCRIBE TABLE test_schema.test_table TYPE=COLUMNS')
+        mock_fetch.assert_called_once_with(
+              'DESCRIBE TABLE test_schema.test_table TYPE=COLUMNS',
+              connection=None
+        )

--- a/fireant/tests/database/test_vertica.py
+++ b/fireant/tests/database/test_vertica.py
@@ -106,15 +106,19 @@ class TestVertica(TestCase):
     def test_get_column_definitions(self, mock_fetch):
         VerticaDatabase().get_column_definitions('test_schema', 'test_table')
 
-        mock_fetch.assert_called_once_with('SELECT DISTINCT "column_name","data_type" FROM "columns" '
-                                           'WHERE "table_schema"=\'test_schema\' AND "table_name"=\'test_table\'')
+        mock_fetch.assert_called_once_with(
+              'SELECT DISTINCT "column_name","data_type" FROM "columns" '
+              'WHERE "table_schema"=\'test_schema\' AND "table_name"=\'test_table\'',
+              connection=None
+        )
 
     @patch.object(VerticaDatabase, 'execute')
     def test_import_csv(self, mock_execute):
         VerticaDatabase().import_csv('abc', '/path/to/file')
 
         mock_execute.assert_called_once_with(
-              'COPY "abc" FROM LOCAL \'/path/to/file\' PARSER fcsvparser(header=false)'
+              'COPY "abc" FROM LOCAL \'/path/to/file\' PARSER fcsvparser(header=false)',
+              connection=None
         )
 
     @patch.object(VerticaDatabase, 'execute')
@@ -124,7 +128,8 @@ class TestVertica(TestCase):
         VerticaDatabase().create_temporary_table_from_columns('abc', columns)
 
         mock_execute.assert_called_once_with(
-              'CREATE LOCAL TEMPORARY TABLE "abc" ("a" varchar,"b" varchar(100)) ON COMMIT PRESERVE ROWS'
+              'CREATE LOCAL TEMPORARY TABLE "abc" ("a" varchar,"b" varchar(100)) ON COMMIT PRESERVE ROWS',
+              connection=None
         )
 
     @patch.object(VerticaDatabase, 'execute')
@@ -134,7 +139,8 @@ class TestVertica(TestCase):
         VerticaDatabase().create_temporary_table_from_select('def', query)
 
         mock_execute.assert_called_once_with(
-              'CREATE LOCAL TEMPORARY TABLE "def" ON COMMIT PRESERVE ROWS AS (SELECT * FROM "abc")'
+              'CREATE LOCAL TEMPORARY TABLE "def" ON COMMIT PRESERVE ROWS AS (SELECT * FROM "abc")',
+              connection=None
         )
 
 


### PR DESCRIPTION
- add optional connection argument to use connections for fetching data
- add execution method to write to database (with commit)

---

1. Example: Fetch using the same database connection
```python
db = Database()

# use same connection for multiple queries
with db.connect()  as connection:
    db.fetch(query, connection=connection)
    db.execute(query, connection=connection)

# open new connection for the query
db.fetch(query)
```
 ---

Regarding thread-based concurrency middleware, it's worth mentioning that thread safety is __not__ guaranteed for sharing connections between threads by default:
- PEP 249: https://www.python.org/dev/peps/pep-0249/#threadsafety
- pymysql: https://github.com/PyMySQL/PyMySQL/blob/master/pymysql/__init__.py#L43
- vertica-python: https://github.com/vertica/vertica-python/blob/master/vertica_python/__init__.py#L66