### PR TITLE
refactor middlewares to always work on multiple queries

### DIFF
--- a/fireant/middleware/__init__.py
+++ b/fireant/middleware/__init__.py
@@ -1,4 +1,2 @@
-from .concurrency import (
-    BaseConcurrencyMiddleware,
-    ThreadPoolConcurrencyMiddleware,
-)
+from .concurrency import ThreadPoolConcurrencyMiddleware
+from .decorators import log_middleware

--- a/fireant/middleware/concurrency.py
+++ b/fireant/middleware/concurrency.py
@@ -1,52 +1,19 @@
-import abc
-
+from functools import wraps
 from multiprocessing.pool import ThreadPool
 
 
-class BaseConcurrencyMiddleware(abc.ABC):
-    """
-    The abstract base class that should be inherited from to define a concurrency middleware.
-    """
-
-    @abc.abstractmethod
-    def fetch_query(self, query, database):
-        """
-        Perform a query on the database.
-
-        :param query: The query to execute.
-        :param database: The database to perform the query on.
-        :return: The result of the query.
-        """
-        pass
-
-    @abc.abstractmethod
-    def fetch_queries_as_dataframe(self, queries, database):
-        """
-        Implementations of this method should execute the given queries on the supplied database and return the results.
-        :return: A list of the results of the executed queries.
-        """
-        pass
-
-
-class ThreadPoolConcurrencyMiddleware(BaseConcurrencyMiddleware):
-    """
-    A concurrency middleware implementation based on threadpools used as a default middleware.
-    """
+class ThreadPoolConcurrencyMiddleware:
 
     def __init__(self, max_processes=1):
         self.max_processes = max_processes
 
-    def fetch_query(self, query, database):
-        return database.fetch(query)
+    def __call__(self, func):
+        @wraps(func)
+        def wrapper(database, *queries, **kwargs):
+            with ThreadPool(processes=self.max_processes) as pool:
+                results = pool.map(lambda query: func(database, query)[0], queries)
+                pool.close()
 
-    def fetch_queries_as_dataframe(self, queries, database):
-        """
-        Executes the different queries in separate threads.
-        """
-        iterable = [(query, ) for query in queries]
+            return results
 
-        with ThreadPool(processes=self.max_processes) as pool:
-            results = pool.map(lambda args: database.fetch_dataframe(*args), iterable)
-            pool.close()
-
-        return results
+        return wrapper

--- a/fireant/queries/execution.py
+++ b/fireant/queries/execution.py
@@ -7,7 +7,6 @@ from typing import (
     Union,
 )
 
-import numpy as np
 import pandas as pd
 
 from fireant.database import Database
@@ -31,9 +30,7 @@ def fetch_data(database: Database,
         str(query.limit(min(query._limit or float("inf"), database.max_result_set_size)))
         for query in queries
     ]
-
-    results = database.concurrency_middleware.fetch_queries_as_dataframe(queries, database)
-
+    results = database.fetch_dataframes(*queries)
     return reduce_result_set(results, reference_groups, dimensions, share_dimensions)
 
 

--- a/fireant/tests/database/test_base_database.py
+++ b/fireant/tests/database/test_base_database.py
@@ -8,10 +8,10 @@ from pypika import Field
 
 from fireant.middleware.concurrency import ThreadPoolConcurrencyMiddleware
 from fireant.database import Database
-from fireant.middleware.decorators import with_connection
+from fireant.middleware.decorators import connection_middleware
 
 
-@with_connection
+@connection_middleware
 def test_fetch(database, query, **kwargs):
     return kwargs.get('connection')
 
@@ -39,11 +39,12 @@ class TestBaseDatabase(TestCase):
         to_char = db.to_char(Field('field'))
         self.assertEqual(str(to_char), 'CAST("field" AS VARCHAR)')
 
-    def test_no_concurrency_middleware_specified_gives_default_threadpool(self):
-        db = Database(max_processes=5)
+    def test_no_custom_middlewares_specified_still_gives_connection_middleware(self):
+        db = Database()
 
-        self.assertIsInstance(db.concurrency_middleware, ThreadPoolConcurrencyMiddleware)
-        self.assertEqual(db.concurrency_middleware.max_processes, 5)
+        self.assertEqual(1, len(db.middlewares))
+        self.assertIs(db.middlewares[0], connection_middleware)
+
 
     @patch.object(Database, 'fetch')
     @patch.object(Database, 'connect')

--- a/fireant/tests/database/test_fetch.py
+++ b/fireant/tests/database/test_fetch.py
@@ -7,13 +7,13 @@ from unittest.mock import (
 )
 
 from fireant import Database
+from fireant.middleware import log_middleware
 
 
 class FetchDataTests(TestCase):
     def setUp(self):
-        self.database = Database()
+        self.database = Database(middlewares=[])
         self.database.slow_query_log_min_seconds = 15
-        self.database.cache_middleware = None
 
         mock_connect = self.database.connect = MagicMock()
         self.mock_connection = mock_connect.return_value.__enter__.return_value
@@ -26,7 +26,7 @@ class FetchDataTests(TestCase):
         self.mock_dimensions[0].is_rollup = False
         self.mock_dimensions[1].is_rollup = True
 
-    def test_do_fetch_data_calls_database_fetch_data(self, ):
+    def test_do_fetch_data_calls_database_fetch_data(self):
         with patch('fireant.queries.execution.pd.read_sql', return_value=self.mock_data_frame) as mock_read_sql:
             self.database.fetch_dataframe(self.mock_query)
 
@@ -41,9 +41,8 @@ class FetchDataLoggingTests(TestCase):
     def setUp(self):
         self.mock_query = 'SELECT *'
 
-        self.database = Database()
+        self.database = Database(middlewares=[log_middleware])
         self.database.slow_query_log_min_seconds = 15
-        self.database.cache_middleware = None
 
         mock_connect = self.database.connect = MagicMock()
         mock_cursor_func = mock_connect.__enter__.return_value.cursor

--- a/fireant/tests/test_middleware.py
+++ b/fireant/tests/test_middleware.py
@@ -6,41 +6,30 @@ from unittest.mock import (
     patch,
 )
 
-from fireant.middleware.concurrency import (
-    BaseConcurrencyMiddleware,
-    ThreadPoolConcurrencyMiddleware,
-)
+from fireant.middleware.concurrency import ThreadPoolConcurrencyMiddleware
 
 
 class TestThreadPoolConcurrencyMiddleware(TestCase):
-    @patch.object(BaseConcurrencyMiddleware, '__abstractmethods__', set())
-    def test_single_query_executes_synchronously(self):
-        query = 'query'
-        mock_database = MagicMock()
-        mock_database.fetch.return_value = 'result'
-
-        concurrency_middleware = ThreadPoolConcurrencyMiddleware()
-
-        result = concurrency_middleware.fetch_query(query, mock_database)
-
-        self.assertEqual(result, 'result')
-        mock_database.fetch.assert_called_with(query)
-
-    @patch('fireant.middleware.concurrency.ThreadPool', autospec=True)
+    @patch("fireant.middleware.concurrency.ThreadPool", autospec=True)
     def test_multiple_queries_execute_in_threadpool(self, mock_threadpool_manager):
-        queries = ['query_a', 'query_b']
+        queries = ["query_a", "query_b"]
         mock_database = MagicMock()
-        mock_database.fetch_dataframe.side_effect = ['result_a', 'result_b']
+        mock_database.fetch_dataframes.side_effect = [["result_a"], ["result_b"]]
 
         def mock_map(func, iterable):
             return [func(args) for args in iterable]
 
-        pool_mock = mock_threadpool_manager.return_value.__enter__.return_value = MagicMock()
+        pool_mock = (
+            mock_threadpool_manager.return_value.__enter__.return_value
+        ) = MagicMock()
         pool_mock.map = mock_map
 
-        middleware = ThreadPoolConcurrencyMiddleware()
+        middleware = ThreadPoolConcurrencyMiddleware(max_processes=2)
 
-        results = middleware.fetch_queries_as_dataframe(queries, mock_database)
+        results = middleware(mock_database.fetch_dataframes)(mock_database, *queries)
 
-        self.assertEqual(results, ['result_a', 'result_b'])
-        mock_database.fetch_dataframe.assert_has_calls([call('query_a'), call('query_b')])
+        self.assertEqual(["result_a", "result_b"], results)
+        mock_database.fetch_dataframes.assert_has_calls(
+            [call(mock_database, "query_a"), call(mock_database, "query_b")]
+        )
+        mock_threadpool_manager.assert_called_with(processes=2)


### PR DESCRIPTION
I refactored the middlewares so that they actually work as proper middlewares in all cases. They will now always be applied to multiple queries instead of one.

I kept `fetch` and `fetch_dataframe` for backwards compatibility as `fetch_queries` and `fetch_dataframes` return lists of results.

I will add more tests after feedback as I'm not super happy about what these changes have caused to for instance the log_middlware implementation.