### PR TITLE
Specify date dimensions when querying dataframes

### DIFF
--- a/fireant/database/base.py
+++ b/fireant/database/base.py
@@ -92,12 +92,12 @@ class Database(object):
             connection.commit()
 
     @apply_middlewares
-    def fetch_dataframes(self, *queries, **kwargs):
+    def fetch_dataframes(self, *queries, parse_dates=None, **kwargs):
         connection = kwargs.get("connection")
         dataframes = []
         for query in queries:
             dataframes.append(
-                pd.read_sql(query, connection, coerce_float=True, parse_dates=True)
+                pd.read_sql(query, connection, coerce_float=True, parse_dates=parse_dates)
             )
         return dataframes
 

--- a/fireant/middleware/concurrency.py
+++ b/fireant/middleware/concurrency.py
@@ -11,7 +11,7 @@ class ThreadPoolConcurrencyMiddleware:
         @wraps(func)
         def wrapper(database, *queries, **kwargs):
             with ThreadPool(processes=self.max_processes) as pool:
-                results = pool.map(lambda query: func(database, query)[0], queries)
+                results = pool.map(lambda query: func(database, query, **kwargs)[0], queries)
                 pool.close()
 
             return results

--- a/fireant/middleware/decorators.py
+++ b/fireant/middleware/decorators.py
@@ -17,7 +17,7 @@ def log_middleware(func):
             start_time = time.time()
             query_logger.debug(query)
 
-            results.append(func(database, query)[0])
+            results.append(func(database, query, **kwargs)[0])
 
             duration = round(time.time() - start_time, 4)
             query_log_msg = '[{duration} seconds]: {query}'.format(duration=duration,
@@ -36,11 +36,11 @@ def connection_middleware(func):
 
     @wraps(func)
     def wrapper(database, *queries, **kwargs):
-        connection = kwargs.get('connection', None)
+        connection = kwargs.pop('connection', None)
         if connection:
-            return func(database, *queries, connection=connection)
+            return func(database, *queries, connection=connection, **kwargs)
         with database.connect() as connection:
-            return func(database, *queries, connection=connection)
+            return func(database, *queries, connection=connection, **kwargs)
 
     return wrapper
 

--- a/fireant/tests/database/test_fetch.py
+++ b/fireant/tests/database/test_fetch.py
@@ -28,12 +28,12 @@ class FetchDataTests(TestCase):
 
     def test_do_fetch_data_calls_database_fetch_data(self):
         with patch('fireant.queries.execution.pd.read_sql', return_value=self.mock_data_frame) as mock_read_sql:
-            self.database.fetch_dataframe(self.mock_query)
+            self.database.fetch_dataframe(self.mock_query, parse_dates="hi")
 
             mock_read_sql.assert_called_once_with(self.mock_query,
                                                   self.mock_connection,
                                                   coerce_float=True,
-                                                  parse_dates=True)
+                                                  parse_dates="hi")
 
 
 @patch('fireant.queries.execution.pd.read_sql')

--- a/fireant/tests/dataset/test_execution.py
+++ b/fireant/tests/dataset/test_execution.py
@@ -35,6 +35,7 @@ from .mocks import (
     politicians_hint_table,
     politicians_table,
 )
+from ..test_formats import date_field, text_field, boolean_field, number_field
 
 pd.set_option("display.expand_frame_repr", False)
 metrics = ["$votes", "$wins", "$wins_with_style", "$turnout"]
@@ -81,9 +82,24 @@ class TestFetchData(TestCase):
         database.fetch_dataframes.assert_called_with(
             'SELECT * FROM "politics"."politician" LIMIT 5',
             'SELECT * FROM "politics"."hints" LIMIT 5',
+            parse_dates=[]
         )
         reduce_mock.assert_called_once_with(
             [self.test_result_a, self.test_result_b], (), self.test_dimensions, ()
+        )
+
+    @patch("fireant.queries.execution.reduce_result_set")
+    def test_fetch_data_with_date_dimensions(self, reduce_mock):
+        database = MagicMock()
+        database.max_result_set_size = 5
+        dimensions = [number_field, date_field, boolean_field, text_field]
+
+        fetch_data(database, self.test_queries, dimensions)
+
+        database.fetch_dataframes.assert_called_with(
+            'SELECT * FROM "politics"."politician" LIMIT 5',
+            'SELECT * FROM "politics"."hints" LIMIT 5',
+            parse_dates=['$date']
         )
 
 


### PR DESCRIPTION
This improvement made sense anyway as pandas' api for the parse_dates parameter on read_sql had evolved anyway.

This solved a problem we had with calculating totals on datablended dimensions.