### PR TITLE
Add set filter modifier

### DIFF
--- a/fireant/__init__.py
+++ b/fireant/__init__.py
@@ -19,6 +19,7 @@ from .dataset.klass import DataSet
 from .dataset.modifiers import (
     OmitFromRollup,
     Rollup,
+    ResultSet,
 )
 from .dataset.operations import (
     CumMean,

--- a/fireant/dataset/klass.py
+++ b/fireant/dataset/klass.py
@@ -127,7 +127,7 @@ class DataSet:
             A Database reference. Holds the connection details used by this dataset to execute queries.
         :param fields: (Required: At least one)
             A list of fields mapping definitions of data in the data set. Fields are similar to a column in a database
-            query result set. They are the values
+            query result set. They are the values.
         :param joins:  (Optional)
             A list of join descriptions for joining additional tables.  Joined tables are only used when querying a
             metric or dimension which requires it.

--- a/fireant/dataset/modifiers.py
+++ b/fireant/dataset/modifiers.py
@@ -100,3 +100,11 @@ class Rollup(DimensionModifier):
 
 class OmitFromRollup(FilterModifier):
     pass
+
+
+class ResultSet(FilterModifier):
+    def __init__(self, *args, set_label=None, complement_label=None, will_ignore_dimensions=True, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.set_label = set_label
+        self.complement_label = complement_label
+        self.will_ignore_dimensions = will_ignore_dimensions

--- a/fireant/queries/finders.py
+++ b/fireant/queries/finders.py
@@ -3,7 +3,7 @@ from collections import defaultdict, namedtuple
 from toposort import CircularDependencyError, toposort_flatten
 
 from fireant.dataset.intervals import DATETIME_INTERVALS, DatetimeInterval
-from fireant.dataset.modifiers import OmitFromRollup, Rollup
+from fireant.dataset.modifiers import OmitFromRollup, Rollup, ResultSet
 from fireant.dataset.operations import Share
 from fireant.exceptions import DataSetException
 from fireant.utils import groupby, ordered_distinct_list, ordered_distinct_list_by_attr
@@ -165,15 +165,25 @@ def find_filters_for_totals(filters):
     """
     :param filters:
     :return:
-        a list of filters that should be applied to totals queries. This removes any filters from the list that have the
-        `OmitFromRollup` modifier applied to them.
+        a list of filters that should be applied to totals queries. This removes any filters from the list that have
+        the `OmitFromRollup` modifier applied to them.
     """
     return [fltr for fltr in filters if not isinstance(fltr, OmitFromRollup)]
 
 
+def find_filters_for_sets(filters):
+    """
+    :param filters:
+    :return:
+        a list of filters sets. This removes any filters from the list that have not the
+        `ResultSet` modifier applied to them.
+    """
+    return [fltr for fltr in filters if isinstance(fltr, ResultSet)]
+
+
 def find_field_in_modified_field(field):
     """
-    Returns the field from a modified field argument (or just the field argument if it is not modified). A modified 
+    Returns the field from a modified field argument (or just the field argument if it is not modified). A modified
     field represents either a wrapped dimension (e.g. DatetimeInterval) or a field wrapped in a filter.
     """
     modified_field = field

--- a/fireant/queries/sets.py
+++ b/fireant/queries/sets.py
@@ -1,0 +1,91 @@
+from copy import deepcopy
+
+from pypika import Case
+
+from .finders import find_filters_for_sets
+from ..utils import (
+    alias_selector,
+    flatten,
+)
+
+
+def _make_set_dimension(set_filter):
+    """
+    Returns a dimension that uses a CASE statement as its definition, in order to represent membership to a set,
+    given the provided conditional.
+
+    :param set_filter:
+    :return:
+    """
+    old_definition = set_filter.filter.definition
+    old_definition_sql = old_definition.get_sql(quote_char="")
+
+    new_dimension = deepcopy(set_filter.filter.field)
+    has_no_in_and_out_labels_sets = not set_filter.set_label and not set_filter.complement_label
+
+    new_dimension.alias = alias_selector('set({})'.format(old_definition_sql))
+    new_dimension.label = 'Set({})'.format(old_definition_sql) if has_no_in_and_out_labels_sets else set_filter.set_label
+    new_dimension.definition = Case().when(
+        old_definition, "set({})".format(old_definition_sql) if has_no_in_and_out_labels_sets else set_filter.set_label
+    ).else_("complement({})".format(old_definition_sql) if has_no_in_and_out_labels_sets else set_filter.complement_label)
+
+    return new_dimension
+
+
+def _replace_dimension_if_needed(dimension, dimensions_per_set_filter):
+    set_filter = dimensions_per_set_filter.get(dimension)
+
+    if not set_filter:
+        return (dimension,)
+
+    set_dimension = _make_set_dimension(set_filter)
+
+    if set_filter.will_ignore_dimensions:
+        return (set_dimension,)
+    else:
+        return (set_dimension, dimension)
+
+
+def adapt_for_sets_query(dimensions, orders, filters):
+    """
+    Adapt filters for sets query. This function will select filters with `ResultSet` modifier. A `ResultSet` modifier
+    operates as a special kind of filter, which won't actually filter the data. Instead it will create
+    dimensions so as to represent membership to a set, given the provided conditional. If will_ignore_dimensions
+    kwarg is False, which is the case by default, it will replace the dimension used in the conditional, if selected.
+
+    :param dimensions:
+    :param orders:
+    :param filters:
+    :return:
+    """
+    set_filters = find_filters_for_sets(filters)
+
+    if not set_filters:
+        return dimensions, orders, filters
+
+    dimensions_per_set_filter = {
+        set_filter.field: set_filter
+        for set_filter in set_filters
+    }
+    dimensions_that_are_not_selected = set(dimensions_per_set_filter.keys())
+
+    current_dimensions = []
+    for dimension in dimensions:
+        current_dimensions.append(_replace_dimension_if_needed(dimension, dimensions_per_set_filter))
+        dimensions_that_are_not_selected.discard(dimension)
+    current_dimensions = flatten(current_dimensions)
+
+    current_orders = []
+    for (dimension, ordering) in orders:
+        current_orders.append([(dim, ordering) for dim in _replace_dimension_if_needed(dimension, dimensions_per_set_filter)])
+    current_orders = flatten(current_orders)
+
+    for dimension in dimensions_that_are_not_selected:
+        set_filter = dimensions_per_set_filter[dimension]
+        new_dimension = _make_set_dimension(set_filter)
+        current_dimensions.append(new_dimension)
+        current_orders.append((new_dimension, None))
+
+    other_filters = [fltr for fltr in filters if fltr not in set_filters]
+
+    return current_dimensions, current_orders, other_filters

--- a/fireant/tests/queries/test_build_sets.py
+++ b/fireant/tests/queries/test_build_sets.py
@@ -1,0 +1,202 @@
+from unittest import TestCase
+
+from pypika import (
+    Table,
+    functions as fn,
+)
+
+import fireant as f
+from fireant.tests.dataset.mocks import test_database
+
+test_table = Table("test")
+ds = f.DataSet(
+    table=test_table,
+    database=test_database,
+    fields=[
+        f.Field("date", definition=test_table.date, data_type=f.DataType.date),
+        f.Field("text", definition=test_table.text, data_type=f.DataType.text),
+        f.Field("number", definition=test_table.number, data_type=f.DataType.number),
+        f.Field("boolean", definition=test_table.boolean, data_type=f.DataType.boolean),
+        f.Field(
+            "aggr_number",
+            definition=fn.Sum(test_table.number),
+            data_type=f.DataType.number,
+        ),
+    ],
+)
+
+# noinspection SqlDialectInspection,SqlNoDataSourceInspection
+class ResultSetTests(TestCase):
+    def test_dimension_is_replaced_by_default_when_result_set_filter_is_present(self):
+        queries = (
+            ds.query.widget(f.Pandas(ds.fields.aggr_number))
+            .dimension(ds.fields.text)
+            .filter(f.ResultSet(ds.fields.text == "abc"))
+            .sql
+        )
+
+        self.assertEqual(len(queries), 1)
+        self.assertEqual(
+            "SELECT "
+            "CASE WHEN \"text\"='abc' THEN 'set(text=''abc'')' ELSE 'complement(text=''abc'')' END \"$set(text='abc')\","
+            'SUM("number") "$aggr_number" '
+            'FROM "test" '
+            "GROUP BY \"$set(text='abc')\" "
+            "ORDER BY \"$set(text='abc')\"",
+            str(queries[0]),
+        )
+
+    def test_dimension_is_replaced_by_default_in_the_target_dimension_place_when_result_set_filter_is_present(
+        self,
+    ):
+        queries = (
+            ds.query.widget(f.Pandas(ds.fields.aggr_number))
+            .dimension(ds.fields.date)
+            .dimension(ds.fields.text)
+            .dimension(ds.fields.boolean)
+            .filter(f.ResultSet(ds.fields.text == "abc"))
+            .sql
+        )
+
+        self.assertEqual(len(queries), 1)
+        self.assertEqual(
+            "SELECT "
+            '"date" "$date",'
+            "CASE WHEN \"text\"='abc' THEN 'set(text=''abc'')' ELSE 'complement(text=''abc'')' END \"$set(text='abc')\","
+            '"boolean" "$boolean",'
+            'SUM("number") "$aggr_number" '
+            'FROM "test" '
+            'GROUP BY "$date","$set(text=\'abc\')","$boolean" '
+            'ORDER BY "$date","$set(text=\'abc\')","$boolean"',
+            str(queries[0]),
+        )
+
+    def test_dimension_is_inserted_before_conditional_dimension_when_result_set_filter_wont_ignore_dimensions(
+        self,
+    ):
+        queries = (
+            ds.query.widget(f.Pandas(ds.fields.aggr_number))
+            .dimension(ds.fields.text)
+            .filter(f.ResultSet(ds.fields.text == "abc", will_ignore_dimensions=False))
+            .sql
+        )
+
+        self.assertEqual(len(queries), 1)
+        self.assertEqual(
+            "SELECT "
+            "CASE WHEN \"text\"='abc' THEN 'set(text=''abc'')' ELSE 'complement(text=''abc'')' END \"$set(text='abc')\","
+            '"text" "$text",'
+            'SUM("number") "$aggr_number" '
+            'FROM "test" '
+            'GROUP BY "$set(text=\'abc\')","$text" '
+            'ORDER BY "$set(text=\'abc\')","$text"',
+            str(queries[0]),
+        )
+
+    def test_dimension_is_inserted_in_dimensions_even_when_not_selected(self):
+        queries = (
+            ds.query.widget(f.Pandas(ds.fields.aggr_number))
+            .filter(f.ResultSet(ds.fields.text == "abc"))
+            .sql
+        )
+
+        self.assertEqual(len(queries), 1)
+        self.assertEqual(
+            "SELECT "
+            "CASE WHEN \"text\"='abc' THEN 'set(text=''abc'')' ELSE 'complement(text=''abc'')' END \"$set(text='abc')\","
+            'SUM("number") "$aggr_number" '
+            'FROM "test" '
+            "GROUP BY \"$set(text='abc')\" "
+            "ORDER BY \"$set(text='abc')\"",
+            str(queries[0]),
+        )
+
+    def test_dimension_is_inserted_as_last_dimension_when_not_selected(self):
+        queries = (
+            ds.query.widget(f.Pandas(ds.fields.aggr_number))
+            .dimension(ds.fields.date)
+            .dimension(ds.fields.boolean)
+            .filter(f.ResultSet(ds.fields.text == "abc"))
+            .sql
+        )
+
+        self.assertEqual(len(queries), 1)
+        self.assertEqual(
+            "SELECT "
+            '"date" "$date",'
+            '"boolean" "$boolean",'
+            "CASE WHEN \"text\"='abc' THEN 'set(text=''abc'')' ELSE 'complement(text=''abc'')' END \"$set(text='abc')\","
+            'SUM("number") "$aggr_number" '
+            'FROM "test" '
+            'GROUP BY "$date","$boolean","$set(text=\'abc\')" '
+            'ORDER BY "$date","$boolean","$set(text=\'abc\')"',
+            str(queries[0]),
+        )
+
+    def test_dimension_uses_set_label_kwarg_and_None_for_complement(self):
+        queries = (
+            ds.query.widget(f.Pandas(ds.fields.aggr_number))
+            .dimension(ds.fields.text)
+            .filter(f.ResultSet(ds.fields.text == "abc", set_label="Text is ABC"))
+            .sql
+        )
+
+        self.assertEqual(len(queries), 1)
+        self.assertEqual(
+            "SELECT "
+            "CASE WHEN \"text\"='abc' THEN 'Text is ABC' ELSE NULL END "
+            "\"$set(text='abc')\","
+            'SUM("number") "$aggr_number" '
+            'FROM "test" '
+            "GROUP BY \"$set(text='abc')\" "
+            "ORDER BY \"$set(text='abc')\"",
+            str(queries[0]),
+        )
+
+    def test_dimension_uses_complement_label_kwarg_and_None_for_set(self):
+        queries = (
+            ds.query.widget(f.Pandas(ds.fields.aggr_number))
+            .dimension(ds.fields.text)
+            .filter(
+                f.ResultSet(ds.fields.text == "abc", complement_label="Text is NOT ABC")
+            )
+            .sql
+        )
+
+        self.assertEqual(len(queries), 1)
+        self.assertEqual(
+            "SELECT "
+            "CASE WHEN \"text\"='abc' THEN NULL ELSE 'Text is NOT ABC' END "
+            "\"$set(text='abc')\","
+            'SUM("number") "$aggr_number" '
+            'FROM "test" '
+            "GROUP BY \"$set(text='abc')\" "
+            "ORDER BY \"$set(text='abc')\"",
+            str(queries[0]),
+        )
+
+    def test_dimension_uses_both_set_and_complement_label_kwargs_when_available(self):
+        queries = (
+            ds.query.widget(f.Pandas(ds.fields.aggr_number))
+            .dimension(ds.fields.text)
+            .filter(
+                f.ResultSet(
+                    ds.fields.text == "abc",
+                    set_label="Text is ABC",
+                    complement_label="Text is NOT ABC",
+                )
+            )
+            .sql
+        )
+
+        self.assertEqual(len(queries), 1)
+        self.assertEqual(
+            "SELECT "
+            "CASE WHEN \"text\"='abc' THEN 'Text is ABC' ELSE 'Text is NOT ABC' END "
+            "\"$set(text='abc')\","
+            'SUM("number") "$aggr_number" '
+            'FROM "test" '
+            "GROUP BY \"$set(text='abc')\" "
+            "ORDER BY \"$set(text='abc')\"",
+            str(queries[0]),
+        )


### PR DESCRIPTION
This implements sets as a special filter modifier (i.e. ResultSet), just like OmitRollup. When a filter is wrapped with it set, it won't really be used as a filter in the SQL query generation. Instead it will be used to generate dimensions with a CASE statement as its definition, which will represent set membership given the filter conditional.

The newly created dimension (i.e. CASE dimension) will by default replace the original dimension, if the original dimension was selected in the query builder, otherwise it will be appended as the last dimension. This behaviour can be changed with the will_ignore_dimensions as False, which means that instead of replacing the original dimension in place, we simply insert the newly created dimension (i.e. CASE dimension) just before the original dimension. Again assuming it was selected in the query builder, otherwise we simply append to the end of the dimensions array.

The newly created dimension (i.e. CASE dimension) basically returns a string stating whether that row is part of the set or not. The actual string used for each of those can be configured via the set_label and complement_label kwargs, which are part of the aforementioned filter modifier constructor. If just one of them is set, the other one is going to be NULL. If both are set, both are used. If neither are set, we default to set(stringified conditional) and complement(stringified conditional) (e.g. set(set(text=''abc'') and complement(text=''abc'')). This is done in order to facilitate data identification in chart legends, for instance, given true/or false wouldn't really tell much, especially in multi set scenarios.