### PR TITLE
Improvements upon set filter modifier

### DIFF
--- a/fireant/dataset/filters.py
+++ b/fireant/dataset/filters.py
@@ -77,6 +77,10 @@ class ComparatorFilter(Filter):
     def definition(self):
         return getattr(self.field.definition, self.operator)(self.value)
 
+    @property
+    def is_aggregate(self):
+        return self.field.is_aggregate
+
 
 class BooleanFilter(Filter):
     def __init__(self, field, value):

--- a/fireant/dataset/modifiers.py
+++ b/fireant/dataset/modifiers.py
@@ -73,10 +73,16 @@ class FieldModifier:
 
 
 class DimensionModifier(Modifier):
+    """
+    Base class for all dimension modifiers.
+    """
     wrapped_key = "dimension"
 
 
 class FilterModifier(Modifier):
+    """
+    Base class for all filter modifiers.
+    """
     wrapped_key = "filter"
 
     @immutable
@@ -93,18 +99,47 @@ class RollupValue(Term):
 
 
 class Rollup(DimensionModifier):
+    """
+    A field modifier that will make totals be calculated for the wrapped dimension.
+    """
     @property
     def definition(self):
         return RollupValue()
 
 
 class OmitFromRollup(FilterModifier):
+    """
+    A filter modifier that will make the wrapped filter not apply for any total calculations, which might be
+    available if an affected field has a `Rollup` dimension modifier set.
+    """
     pass
 
 
 class ResultSet(FilterModifier):
-    def __init__(self, *args, set_label=None, complement_label=None, will_ignore_dimensions=True, **kwargs):
+    """
+    A filter modifier that will make the wrapped filter not filter the data. Instead, it will create new dimensions
+    for representing membership of a set, given the wrapped filter's conditional.
+    """
+    def __init__(
+        self, *args, set_label=None, complement_label=None, will_replace_referenced_dimension=True,
+        will_group_complement=True, **kwargs
+    ):
+        """
+        :param set_label: A string that will be used for naming the sub-set of the data, for which the
+                          provided conditional evaluates to True (i.e the set itself). If not set,
+                          a placeholder containing the conditional will be used instead.
+        :param complement_label: A string that will be used for naming the sub-set of the data, for which the
+                                 provided conditional evaluates to False (i.e the complement of the set). If not
+                                 set, a placeholder containing the conditional will be used instead.
+        :param will_replace_referenced_dimension: Whether a dimension referenced in the wrapped filter, if any,
+                                                  should be replaced with the new dimension stating set membership.
+                                                  If False, the wrapped filter's dimension will be kept as the
+                                                  dimension right after the new set dimension. Defaults to True.
+        :param will_group_complement: Whether the complement set should be broken down into its elements.
+                                      Defaults to True.
+        """
         super().__init__(*args, **kwargs)
         self.set_label = set_label
         self.complement_label = complement_label
-        self.will_ignore_dimensions = will_ignore_dimensions
+        self.will_replace_referenced_dimension = will_replace_referenced_dimension
+        self.will_group_complement = will_group_complement

--- a/fireant/queries/builder/dataset_blender_query_builder.py
+++ b/fireant/queries/builder/dataset_blender_query_builder.py
@@ -302,10 +302,14 @@ class DataSetBlenderQueryBuilder(DataSetQueryBuilder):
         datasets, field_maps = _datasets_and_field_maps(self.dataset)
         metrics = find_metrics_for_widgets(self._widgets)
         metrics_aliases = {metric.alias for metric in metrics}
-        dimensions_aliases = {dimension.alias for dimension in self._dimensions}
+        dimensions_aliases = {dimension.alias for dimension in self.dimensions}
+
+        orders = self.orders
+        if orders is None:
+            orders = self.default_orders
 
         # Add fields to be ordered on, to metrics if they aren't yet selected in metrics or dimensions
-        for field, orientation in self.orders:
+        for field, orientation in orders:
             if (
                 field.alias not in metrics_aliases
                 and field.alias not in dimensions_aliases
@@ -314,7 +318,7 @@ class DataSetBlenderQueryBuilder(DataSetQueryBuilder):
 
         dataset_metrics = find_dataset_fields(metrics)
         operations = find_operations_for_widgets(self._widgets)
-        share_dimensions = find_share_dimensions(self._dimensions, operations)
+        share_dimensions = find_share_dimensions(self.dimensions, operations)
 
         datasets_queries = []
         for dataset, field_map in zip(datasets, field_maps):
@@ -323,8 +327,8 @@ class DataSetBlenderQueryBuilder(DataSetQueryBuilder):
                     dataset,
                     field_map,
                     dataset_metrics,
-                    self._dimensions,
-                    self._filters,
+                    self.dimensions,
+                    self.filters,
                     self._references,
                     operations,
                     share_dimensions
@@ -362,7 +366,7 @@ class DataSetBlenderQueryBuilder(DataSetQueryBuilder):
         blended_queries = []
         for queryset in query_sets:
             blended_query = _blend_query(
-                self._dimensions, metrics, self.orders, field_maps, queryset
+                self.dimensions, metrics, orders, field_maps, queryset
             )
 
             if blended_query:

--- a/fireant/queries/builder/dimension_choices_query_builder.py
+++ b/fireant/queries/builder/dimension_choices_query_builder.py
@@ -23,12 +23,12 @@ class DimensionChoicesQueryBuilder(QueryBuilder):
         super(DimensionChoicesQueryBuilder, self).__init__(dataset, dataset.table)
 
         self.hint_table = getattr(dimension, "hint_table", None)
-        self._dimensions.append(dimension)
+        self.dimensions.append(dimension)
 
         # TODO remove after 3.0.0
         display_alias = dimension.alias + "_display"
         if display_alias in dataset.fields:
-            self._dimensions.append(dataset.fields[display_alias])
+            self.dimensions.append(dataset.fields[display_alias])
 
     def _extract_hint_filters(self):
         """
@@ -41,7 +41,7 @@ class DimensionChoicesQueryBuilder(QueryBuilder):
         hint_column_names = get_column_names(self.dataset.database, self.hint_table)
 
         filters = []
-        for filter_ in self._filters:
+        for filter_ in self.filters:
             base_fields = [
                 field
                 for field in filter_.definition.fields_()
@@ -81,7 +81,7 @@ class DimensionChoicesQueryBuilder(QueryBuilder):
             A list of pypika terms.
         """
         dimension_terms = []
-        for dimension in self._dimensions:
+        for dimension in self.dimensions:
             dimension_term = make_term_for_field(
                 dimension, self.dataset.database.trunc_date
             )
@@ -100,9 +100,9 @@ class DimensionChoicesQueryBuilder(QueryBuilder):
 
         The dataset query extends this with metrics, references, and totals.
         """
-        dimensions = [] if self.hint_table else self._dimensions
+        dimensions = [] if self.hint_table else self.dimensions
 
-        filters = self._extract_hint_filters() if self.hint_table else self._filters
+        filters = self._extract_hint_filters() if self.hint_table else self.filters
 
         query = (
             make_slicer_query(
@@ -137,7 +137,7 @@ class DimensionChoicesQueryBuilder(QueryBuilder):
             A list of dict (JSON) objects containing the widget configurations.
         """
         query = add_hints(self.sql, hint)[0]
-        dimension = self._dimensions[0]
+        dimension = self.dimensions[0]
         alias_definition = dimension.definition.as_(alias_selector(dimension.alias))
         dimension_definition = dimension.definition
 
@@ -163,7 +163,7 @@ class DimensionChoicesQueryBuilder(QueryBuilder):
         # Order by the dimension definition that the choices are for
         query = query.orderby(alias_definition)
 
-        data = fetch_data(self.dataset.database, [query], self._dimensions)
+        data = fetch_data(self.dataset.database, [query], self.dimensions)
 
         if len(data.index.names) > 1:
             display_alias = data.index.names[1]
@@ -174,7 +174,7 @@ class DimensionChoicesQueryBuilder(QueryBuilder):
             data["display"] = data.index.tolist()
             choices = data["display"]
 
-        dimension_display = self._dimensions[-1]
+        dimension_display = self.dimensions[-1]
         return choices.map(lambda raw: display_value(raw, dimension_display) or raw)
 
     def __repr__(self):

--- a/fireant/queries/builder/dimension_latest_query_builder.py
+++ b/fireant/queries/builder/dimension_latest_query_builder.py
@@ -22,16 +22,14 @@ class DimensionLatestQueryBuilder(QueryBuilder):
     def sql(self):
         """
         Serializes this query builder as a set of SQL queries.  This method will always return a list of one
-        query since
-        only one query is required to retrieve dimension choices.
+        query since only one query is required to retrieve dimension choices.
 
         This function only handles dimensions (select+group by) and filtering (where/having), which is everything
-        needed
-        for the query to fetch choices for dimensions.
+        needed for the query to fetch choices for dimensions.
 
         The dataset query extends this with metrics, references, and totals.
         """
-        if not self._dimensions:
+        if not self.dimensions:
             raise QueryException(
                 "Must select at least one dimension to query latest values"
             )
@@ -40,7 +38,7 @@ class DimensionLatestQueryBuilder(QueryBuilder):
             database=self.dataset.database,
             base_table=self.table,
             joins=self.dataset.joins,
-            dimensions=self._dimensions,
+            dimensions=self.dimensions,
         )
         return [query]
 

--- a/fireant/queries/finders.py
+++ b/fireant/queries/finders.py
@@ -3,7 +3,7 @@ from collections import defaultdict, namedtuple
 from toposort import CircularDependencyError, toposort_flatten
 
 from fireant.dataset.intervals import DATETIME_INTERVALS, DatetimeInterval
-from fireant.dataset.modifiers import OmitFromRollup, Rollup, ResultSet
+from fireant.dataset.modifiers import OmitFromRollup, Rollup
 from fireant.dataset.operations import Share
 from fireant.exceptions import DataSetException
 from fireant.utils import groupby, ordered_distinct_list, ordered_distinct_list_by_attr
@@ -169,16 +169,6 @@ def find_filters_for_totals(filters):
         the `OmitFromRollup` modifier applied to them.
     """
     return [fltr for fltr in filters if not isinstance(fltr, OmitFromRollup)]
-
-
-def find_filters_for_sets(filters):
-    """
-    :param filters:
-    :return:
-        a list of filters sets. This removes any filters from the list that have not the
-        `ResultSet` modifier applied to them.
-    """
-    return [fltr for fltr in filters if isinstance(fltr, ResultSet)]
 
 
 def find_field_in_modified_field(field):

--- a/fireant/tests/queries/test_build_data_blending.py
+++ b/fireant/tests/queries/test_build_data_blending.py
@@ -397,14 +397,14 @@ class DataSetBlenderQueryBuilderTests(TestCase):
                 '"sq1"."$candidate-spend_wow"/"sq0"."$wins_wow" "$candidate-spend-per-wins_wow" '
                 "FROM ("
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('week',1,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('week',1,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 'SUM("is_winner") "$wins_wow" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp"'
                 ') "sq0" '
                 "LEFT JOIN ("
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('week',1,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('week',1,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 'SUM("candidate_spend") "$candidate-spend_wow" '
                 'FROM "politics"."politician_spend" '
                 'GROUP BY "$timestamp"'

--- a/fireant/tests/queries/test_build_dimensions.py
+++ b/fireant/tests/queries/test_build_dimensions.py
@@ -408,7 +408,7 @@ class QueryBuilderDimensionTotalsTests(TestCase):
         with self.subTest("reference query is shifted"):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 '"political_party" "$political_party",'
                 'SUM("votes") "$votes_dod" '
                 'FROM "politics"."politician" '
@@ -436,7 +436,7 @@ class QueryBuilderDimensionTotalsTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 "'_FIREANT_ROLLUP_VALUE_' \"$political_party\","
                 'SUM("votes") "$votes_dod" '
                 'FROM "politics"."politician" '
@@ -480,7 +480,7 @@ class QueryBuilderDimensionTotalsTests(TestCase):
         with self.subTest("reference query is shifted"):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 '"political_party" "$political_party",'
                 'SUM("votes") "$votes_dod" '
                 'FROM "politics"."politician" '
@@ -511,7 +511,7 @@ class QueryBuilderDimensionTotalsTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 "'_FIREANT_ROLLUP_VALUE_' \"$political_party\","
                 'SUM("votes") "$votes_dod" '
                 'FROM "politics"."politician" '

--- a/fireant/tests/queries/test_build_references.py
+++ b/fireant/tests/queries/test_build_references.py
@@ -110,7 +110,7 @@ class QueryBuilderDatetimeReferenceTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 'SUM("votes") "$votes_dod" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp" '
@@ -146,7 +146,7 @@ class QueryBuilderDatetimeReferenceTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('week',1,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('week',1,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 'SUM("votes") "$votes_wow" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp" '
@@ -182,7 +182,7 @@ class QueryBuilderDatetimeReferenceTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('week',4,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('week',4,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 'SUM("votes") "$votes_mom" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp" '
@@ -218,7 +218,7 @@ class QueryBuilderDatetimeReferenceTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('week',12,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('week',12,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 'SUM("votes") "$votes_qoq" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp" '
@@ -254,7 +254,7 @@ class QueryBuilderDatetimeReferenceTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('week',52,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('week',52,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 'SUM("votes") "$votes_yoy" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp" '
@@ -290,7 +290,7 @@ class QueryBuilderDatetimeReferenceTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('month',1,TRUNC(\"timestamp\",'MM') \"$timestamp\"),'MM') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('month',1,TRUNC(\"timestamp\",'MM')),'MM') \"$timestamp\","
                 'SUM("votes") "$votes_mom" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp" '
@@ -326,7 +326,7 @@ class QueryBuilderDatetimeReferenceTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('quarter',1,TRUNC(\"timestamp\",'MM') \"$timestamp\"),'MM') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('quarter',1,TRUNC(\"timestamp\",'MM')),'MM') \"$timestamp\","
                 'SUM("votes") "$votes_qoq" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp" '
@@ -362,7 +362,7 @@ class QueryBuilderDatetimeReferenceTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('year',1,TRUNC(\"timestamp\",'MM') \"$timestamp\"),'MM') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('year',1,TRUNC(\"timestamp\",'MM')),'MM') \"$timestamp\","
                 'SUM("votes") "$votes_yoy" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp" '
@@ -403,7 +403,7 @@ class QueryBuilderDatetimeReferenceWithDeltaTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 'SUM("votes") "$votes_dod" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp" '
@@ -439,7 +439,7 @@ class QueryBuilderDatetimeReferenceWithDeltaTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 'SUM("votes") "$votes_dod" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp" '
@@ -481,7 +481,7 @@ class QueryBuilderDatetimeReferenceIntervalTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'IW') \"$timestamp\"),'IW') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'IW')),'IW') \"$timestamp\","
                 'SUM("votes") "$votes_dod" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp" '
@@ -517,7 +517,7 @@ class QueryBuilderDatetimeReferenceIntervalTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'IW') \"$timestamp\"),'IW') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'IW')),'IW') \"$timestamp\","
                 'SUM("votes") "$votes_dod" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp" '
@@ -553,7 +553,7 @@ class QueryBuilderDatetimeReferenceIntervalTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'MM') \"$timestamp\"),'MM') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'MM')),'MM') \"$timestamp\","
                 'SUM("votes") "$votes_dod" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp" '
@@ -589,7 +589,7 @@ class QueryBuilderDatetimeReferenceIntervalTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'Q') \"$timestamp\"),'Q') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'Q')),'Q') \"$timestamp\","
                 'SUM("votes") "$votes_dod" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp" '
@@ -625,7 +625,7 @@ class QueryBuilderDatetimeReferenceIntervalTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'Y') \"$timestamp\"),'Y') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'Y')),'Y') \"$timestamp\","
                 'SUM("votes") "$votes_dod" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp" '
@@ -669,7 +669,7 @@ class QueryBuilderDatetimeMultipleReferencesTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 'SUM("votes") "$votes_dod" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp" '
@@ -682,7 +682,7 @@ class QueryBuilderDatetimeMultipleReferencesTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('week',52,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('week',52,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 'SUM("votes") "$votes_yoy" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp" '
@@ -721,7 +721,7 @@ class QueryBuilderDatetimeMultipleReferencesTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 'SUM("votes") "$votes_dod" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp" '
@@ -763,7 +763,7 @@ class QueryBuilderDatetimeMultipleReferencesTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 'SUM("votes") "$votes_dod" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp" '
@@ -805,7 +805,7 @@ class QueryBuilderDatetimeMultipleReferencesTests(TestCase):
         with self.subTest("second query for all DoD references"):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 'SUM("votes") "$votes_dod" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp" '
@@ -816,7 +816,7 @@ class QueryBuilderDatetimeMultipleReferencesTests(TestCase):
         with self.subTest("third query for all YoY references"):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('week',52,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('week',52,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 'SUM("votes") "$votes_yoy" '
                 'FROM "politics"."politician" '
                 'GROUP BY "$timestamp" '
@@ -859,7 +859,7 @@ class QueryBuilderDatetimeReferenceMiscellaneousTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('week',52,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('week',52,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 '"political_party" "$political_party",'
                 'SUM("votes") "$votes_yoy" '
                 'FROM "politics"."politician" '
@@ -900,7 +900,7 @@ class QueryBuilderDatetimeReferenceMiscellaneousTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('week',52,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('week',52,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 '"candidate_name" "$candidate-name",'
                 'SUM("votes") "$votes_yoy" '
                 'FROM "politics"."politician" '
@@ -943,7 +943,7 @@ class QueryBuilderDatetimeReferenceMiscellaneousTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 'SUM("votes") "$votes_dod" '
                 'FROM "politics"."politician" '
                 "WHERE \"timestamp\" BETWEEN TIMESTAMPADD('day',-1,'2018-01-01') "
@@ -989,7 +989,7 @@ class QueryBuilderDatetimeReferenceMiscellaneousTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('day',1,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 'SUM("votes") "$votes_dod" '
                 'FROM "politics"."politician" '
                 "WHERE \"timestamp\" BETWEEN TIMESTAMPADD('day',-1,'2018-01-01') AND TIMESTAMPADD('day',-1,'2018-01-31') "
@@ -1040,7 +1040,7 @@ class QueryBuilderReferencesWithRollupTests(TestCase):
         ):
             self.assertEqual(
                 "SELECT "
-                "TRUNC(TIMESTAMPADD('week',1,TRUNC(\"timestamp\",'DD') \"$timestamp\"),'DD') \"$timestamp\","
+                "TRUNC(TIMESTAMPADD('week',1,TRUNC(\"timestamp\",'DD')),'DD') \"$timestamp\","
                 'SUM("votes") "$votes_wow" '
                 'FROM "politics"."politician" '
                 "WHERE \"timestamp\" BETWEEN TIMESTAMPADD('week',-1,'2018-01-01') "

--- a/fireant/tests/queries/test_build_sets.py
+++ b/fireant/tests/queries/test_build_sets.py
@@ -27,6 +27,22 @@ ds = f.DataSet(
 
 # noinspection SqlDialectInspection,SqlNoDataSourceInspection
 class ResultSetTests(TestCase):
+    def test_no_metric_is_removed_when_result_set_metric_filter_is_present(self):
+        queries = (
+            ds.query.widget(f.Pandas(ds.fields.aggr_number))
+            .filter(f.ResultSet(ds.fields.aggr_number > 10))
+            .sql
+        )
+
+        self.assertEqual(len(queries), 1)
+        self.assertEqual(
+            "SELECT "
+            "CASE WHEN SUM(\"number\")>10 THEN 'set(SUM(number)>10)' ELSE 'complement(SUM(number)>10)' END \"$set(SUM(number)>10)\","
+            'SUM("number") "$aggr_number" '
+            'FROM "test"',
+            str(queries[0]),
+        )
+
     def test_dimension_is_replaced_by_default_when_result_set_filter_is_present(self):
         queries = (
             ds.query.widget(f.Pandas(ds.fields.aggr_number))
@@ -38,11 +54,11 @@ class ResultSetTests(TestCase):
         self.assertEqual(len(queries), 1)
         self.assertEqual(
             "SELECT "
-            "CASE WHEN \"text\"='abc' THEN 'set(text=''abc'')' ELSE 'complement(text=''abc'')' END \"$set(text='abc')\","
+            "CASE WHEN \"text\"='abc' THEN 'set(text=''abc'')' ELSE 'complement(text=''abc'')' END \"$text\","
             'SUM("number") "$aggr_number" '
             'FROM "test" '
-            "GROUP BY \"$set(text='abc')\" "
-            "ORDER BY \"$set(text='abc')\"",
+            "GROUP BY \"$text\" "
+            "ORDER BY \"$text\"",
             str(queries[0]),
         )
 
@@ -62,14 +78,51 @@ class ResultSetTests(TestCase):
         self.assertEqual(
             "SELECT "
             '"date" "$date",'
-            "CASE WHEN \"text\"='abc' THEN 'set(text=''abc'')' ELSE 'complement(text=''abc'')' END \"$set(text='abc')\","
+            "CASE WHEN \"text\"='abc' THEN 'set(text=''abc'')' ELSE 'complement(text=''abc'')' END \"$text\","
             '"boolean" "$boolean",'
             'SUM("number") "$aggr_number" '
             'FROM "test" '
-            'GROUP BY "$date","$set(text=\'abc\')","$boolean" '
-            'ORDER BY "$date","$set(text=\'abc\')","$boolean"',
+            'GROUP BY "$date","$text","$boolean" '
+            'ORDER BY "$date","$text","$boolean"',
             str(queries[0]),
         )
+
+    def test_dimension_with_dimension_modifier_is_replaced_by_default_when_result_set_filter_is_present(
+        self,
+    ):
+        queries = (
+            ds.query.widget(f.Pandas(ds.fields.aggr_number))
+            .dimension(ds.fields.date)
+            .dimension(f.Rollup(ds.fields.boolean))
+            .filter(f.ResultSet(ds.fields.boolean == True))
+            .sql
+        )
+
+        self.assertEqual(len(queries), 2)
+
+        with self.subTest('base query is the same as without totals'):
+            self.assertEqual(
+                "SELECT "
+                '"date" "$date",'
+                "CASE WHEN \"boolean\"=true THEN 'set(boolean=true)' ELSE 'complement(boolean=true)' END \"$boolean\","
+                'SUM("number") "$aggr_number" '
+                'FROM "test" '
+                'GROUP BY "$date","$boolean" '
+                'ORDER BY "$date","$boolean"',
+                str(queries[0]),
+            )
+
+        with self.subTest('totals dimension is replaced with _FIREANT_ROLLUP_VALUE_'):
+            self.assertEqual(
+                "SELECT "
+                '"date" "$date",'
+                '\'_FIREANT_ROLLUP_VALUE_\' "$boolean",'
+                'SUM("number") "$aggr_number" '
+                'FROM "test" '
+                'GROUP BY "$date","$boolean" '
+                'ORDER BY "$date","$boolean"',
+                str(queries[1]),
+            )
 
     def test_dimension_is_inserted_before_conditional_dimension_when_result_set_filter_wont_ignore_dimensions(
         self,
@@ -77,7 +130,11 @@ class ResultSetTests(TestCase):
         queries = (
             ds.query.widget(f.Pandas(ds.fields.aggr_number))
             .dimension(ds.fields.text)
-            .filter(f.ResultSet(ds.fields.text == "abc", will_ignore_dimensions=False))
+            .filter(
+                f.ResultSet(
+                    ds.fields.text == "abc", will_replace_referenced_dimension=False
+                )
+            )
             .sql
         )
 
@@ -93,6 +150,27 @@ class ResultSetTests(TestCase):
             str(queries[0]),
         )
 
+    def test_dimension_breaks_complement_down_when_result_set_filter_wont_group_complement(
+        self,
+    ):
+        queries = (
+            ds.query.widget(f.Pandas(ds.fields.aggr_number))
+            .dimension(ds.fields.text)
+            .filter(f.ResultSet(ds.fields.text == "abc", will_group_complement=False))
+            .sql
+        )
+
+        self.assertEqual(len(queries), 1)
+        self.assertEqual(
+            "SELECT "
+            "CASE WHEN \"text\"='abc' THEN 'set(text=''abc'')' ELSE \"text\" END \"$text\","
+            'SUM("number") "$aggr_number" '
+            'FROM "test" '
+            "GROUP BY \"$text\" "
+            "ORDER BY \"$text\"",
+            str(queries[0]),
+        )
+
     def test_dimension_is_inserted_in_dimensions_even_when_not_selected(self):
         queries = (
             ds.query.widget(f.Pandas(ds.fields.aggr_number))
@@ -103,11 +181,11 @@ class ResultSetTests(TestCase):
         self.assertEqual(len(queries), 1)
         self.assertEqual(
             "SELECT "
-            "CASE WHEN \"text\"='abc' THEN 'set(text=''abc'')' ELSE 'complement(text=''abc'')' END \"$set(text='abc')\","
+            "CASE WHEN \"text\"='abc' THEN 'set(text=''abc'')' ELSE 'complement(text=''abc'')' END \"$text\","
             'SUM("number") "$aggr_number" '
             'FROM "test" '
-            "GROUP BY \"$set(text='abc')\" "
-            "ORDER BY \"$set(text='abc')\"",
+            "GROUP BY \"$text\" "
+            "ORDER BY \"$text\"",
             str(queries[0]),
         )
 
@@ -125,11 +203,11 @@ class ResultSetTests(TestCase):
             "SELECT "
             '"date" "$date",'
             '"boolean" "$boolean",'
-            "CASE WHEN \"text\"='abc' THEN 'set(text=''abc'')' ELSE 'complement(text=''abc'')' END \"$set(text='abc')\","
+            "CASE WHEN \"text\"='abc' THEN 'set(text=''abc'')' ELSE 'complement(text=''abc'')' END \"$text\","
             'SUM("number") "$aggr_number" '
             'FROM "test" '
-            'GROUP BY "$date","$boolean","$set(text=\'abc\')" '
-            'ORDER BY "$date","$boolean","$set(text=\'abc\')"',
+            'GROUP BY "$date","$boolean","$text" '
+            'ORDER BY "$date","$boolean","$text"',
             str(queries[0]),
         )
 
@@ -145,11 +223,66 @@ class ResultSetTests(TestCase):
         self.assertEqual(
             "SELECT "
             "CASE WHEN \"text\"='abc' THEN 'Text is ABC' ELSE NULL END "
-            "\"$set(text='abc')\","
+            "\"$text\","
             'SUM("number") "$aggr_number" '
             'FROM "test" '
-            "GROUP BY \"$set(text='abc')\" "
-            "ORDER BY \"$set(text='abc')\"",
+            "GROUP BY \"$text\" "
+            "ORDER BY \"$text\"",
+            str(queries[0]),
+        )
+
+    def test_dimension_breaks_complement_down_even_when_set_label_is_set_when_result_set_filter_wont_group_complement(
+        self,
+    ):
+        queries = (
+            ds.query.widget(f.Pandas(ds.fields.aggr_number))
+            .dimension(ds.fields.text)
+            .filter(
+                f.ResultSet(
+                    ds.fields.text == "abc",
+                    set_label="IS ABC",
+                    will_group_complement=False,
+                )
+            )
+            .sql
+        )
+
+        self.assertEqual(len(queries), 1)
+        self.assertEqual(
+            "SELECT "
+            "CASE WHEN \"text\"='abc' THEN 'IS ABC' ELSE \"text\" END \"$text\","
+            'SUM("number") "$aggr_number" '
+            'FROM "test" '
+            "GROUP BY \"$text\" "
+            "ORDER BY \"$text\"",
+            str(queries[0]),
+        )
+
+    def test_dimension_breaks_complement_down_even_when_both_labels_are_set_but_wont_group_complement(
+        self,
+    ):
+        queries = (
+            ds.query.widget(f.Pandas(ds.fields.aggr_number))
+            .dimension(ds.fields.text)
+            .filter(
+                f.ResultSet(
+                    ds.fields.text == "abc",
+                    set_label="IS ABC",
+                    complement_label="OTHERS",
+                    will_group_complement=False,
+                )
+            )
+            .sql
+        )
+
+        self.assertEqual(len(queries), 1)
+        self.assertEqual(
+            "SELECT "
+            "CASE WHEN \"text\"='abc' THEN 'IS ABC' ELSE \"text\" END \"$text\","
+            'SUM("number") "$aggr_number" '
+            'FROM "test" '
+            "GROUP BY \"$text\" "
+            "ORDER BY \"$text\"",
             str(queries[0]),
         )
 
@@ -167,11 +300,11 @@ class ResultSetTests(TestCase):
         self.assertEqual(
             "SELECT "
             "CASE WHEN \"text\"='abc' THEN NULL ELSE 'Text is NOT ABC' END "
-            "\"$set(text='abc')\","
+            "\"$text\","
             'SUM("number") "$aggr_number" '
             'FROM "test" '
-            "GROUP BY \"$set(text='abc')\" "
-            "ORDER BY \"$set(text='abc')\"",
+            "GROUP BY \"$text\" "
+            "ORDER BY \"$text\"",
             str(queries[0]),
         )
 
@@ -193,10 +326,10 @@ class ResultSetTests(TestCase):
         self.assertEqual(
             "SELECT "
             "CASE WHEN \"text\"='abc' THEN 'Text is ABC' ELSE 'Text is NOT ABC' END "
-            "\"$set(text='abc')\","
+            "\"$text\","
             'SUM("number") "$aggr_number" '
             'FROM "test" '
-            "GROUP BY \"$set(text='abc')\" "
-            "ORDER BY \"$set(text='abc')\"",
+            "GROUP BY \"$text\" "
+            "ORDER BY \"$text\"",
             str(queries[0]),
         )

--- a/fireant/tests/queries/test_data_blending_integration.py
+++ b/fireant/tests/queries/test_data_blending_integration.py
@@ -402,13 +402,13 @@ class DataSetBlenderIntegrationTests(TestCase):
             '"sq0"."$account" "$account",'
             '"sq1"."$metric1_dod" "$metric1_dod" '
             "FROM ("
-            'SELECT TIMESTAMPADD(\'day\',1,"timestamp" "$timestamp") "$timestamp",'
+            'SELECT TIMESTAMPADD(\'day\',1,"timestamp") "$timestamp",'
             '"account" "$account" '
             'FROM "test0" '
             'GROUP BY "$timestamp","$account"'
             ') "sq0" '
             "LEFT JOIN ("
-            'SELECT TIMESTAMPADD(\'day\',1,"timestamp" "$timestamp") "$timestamp",'
+            'SELECT TIMESTAMPADD(\'day\',1,"timestamp") "$timestamp",'
             '"metric" "$metric1_dod" '
             'FROM "test1" '
             'GROUP BY "$timestamp"'
@@ -510,13 +510,13 @@ class DataSetBlenderIntegrationTests(TestCase):
             '"sq0"."$account" "$account",'
             '"sq1"."$metric1_dod" "$metric1_dod" '
             "FROM ("
-            'SELECT TIMESTAMPADD(\'day\',1,"timestamp" "$timestamp") "$timestamp",'
+            'SELECT TIMESTAMPADD(\'day\',1,"timestamp") "$timestamp",'
             '"account" "$account" '
             'FROM "test0" '
             'GROUP BY "$timestamp","$account"'
             ') "sq0" '
             "LEFT JOIN ("
-            'SELECT TIMESTAMPADD(\'day\',1,"timestamp" "$timestamp") "$timestamp",'
+            'SELECT TIMESTAMPADD(\'day\',1,"timestamp") "$timestamp",'
             '"metric" "$metric1_dod" '
             'FROM "test1" '
             'GROUP BY "$timestamp"'
@@ -621,14 +621,14 @@ class DataSetBlenderIntegrationTests(TestCase):
             '"sq1"."$metric1_dod" "$metric1_dod",'
             '"sq0"."$metric0_dod" "$metric0_dod" '
             "FROM ("
-            'SELECT TIMESTAMPADD(\'day\',1,"timestamp" "$timestamp") "$timestamp",'
+            'SELECT TIMESTAMPADD(\'day\',1,"timestamp") "$timestamp",'
             '"account" "$account",'
             '"metric" "$metric0_dod" '
             'FROM "test0" '
             'GROUP BY "$timestamp","$account"'
             ') "sq0" '
             "LEFT JOIN ("
-            'SELECT TIMESTAMPADD(\'day\',1,"timestamp" "$timestamp") "$timestamp",'
+            'SELECT TIMESTAMPADD(\'day\',1,"timestamp") "$timestamp",'
             '"metric" "$metric1_dod" '
             'FROM "test1" '
             'GROUP BY "$timestamp"'

--- a/fireant/tests/test_fireant.py
+++ b/fireant/tests/test_fireant.py
@@ -38,7 +38,7 @@ class APITests(TestCase):
                 self.assertIn(element, vars(fireant))
 
     def test_package_exports_modifiers(self):
-        for element in ("Rollup", "OmitFromRollup"):
+        for element in ("Rollup", "OmitFromRollup", "ResultSet"):
             with self.subTest(element):
                 self.assertIn(element, vars(fireant))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 six
 pandas==0.23.4
-pypika==0.37.3
+pypika==0.37.8
 toposort==1.5
 python-dateutil==2.8.1
 cryptography==2.8


### PR DESCRIPTION
First commit is unrelated to my changes, but was necessary since pypika's version 0.37.6 changed how functions were formatted. Fyi aliases of nested args are no longer serialised. Therefore that broke some tests in fireant. The purpose of updating pypika was to fix an issue in which aggregate expressions, within case statements, wouldn't implement is_aggregate method correctly. And that impeded the correct use of sets using metrics.

Despite that, this PR adds a couple new features to the ResultSet filter modifier, such as the ability to break down the complement set. Some fixes, especially regarding the use of share dimensions/totals 
with sets were also addressed. I've added some documentation on the aforementioned features as well, given API is stabler now.