### PR TITLE
Change how highcharts widget references dimensions during x axis rendering

### DIFF
--- a/fireant/queries/builder/dataset_query_builder.py
+++ b/fireant/queries/builder/dataset_query_builder.py
@@ -163,7 +163,6 @@ class DataSetQueryBuilder(
         return [
             widget.transform(
                 data_frame,
-                self.dataset,
                 self.dimensions,
                 self._references,
                 annotation_frame,
@@ -304,7 +303,7 @@ class DataSetQueryBuilder(
                 ],
                 *[
                     "orderby({}, {})".format(definition.alias, orientation)
-                    for (definition, orientation) in self.orders
+                    for (definition, orientation) in (self.orders or self.default_orders)
                 ],
             ]
         )

--- a/fireant/tests/queries/test_fetch_data.py
+++ b/fireant/tests/queries/test_fetch_data.py
@@ -268,7 +268,6 @@ class QueryBuilderFetchDataTests(TestCase):
 
         mock_widget.transform.assert_called_once_with(
             mock_paginate.return_value,
-            mock_dataset,
             FieldMatcher(mock_dataset.fields.timestamp),
             [],
             None,

--- a/fireant/tests/widgets/test_csv.py
+++ b/fireant/tests/widgets/test_csv.py
@@ -29,7 +29,7 @@ class CSVWidgetTests(TestCase):
 
     def test_single_metric(self):
         result = CSV(mock_dataset.fields.votes) \
-            .transform(dimx0_metricx1_df, mock_dataset, [], [])
+            .transform(dimx0_metricx1_df, [], [])
 
         expected = dimx0_metricx1_df.copy()[[f('votes')]]
         expected.columns = ['Votes']
@@ -39,7 +39,7 @@ class CSVWidgetTests(TestCase):
 
     def test_multiple_metrics(self):
         result = CSV(mock_dataset.fields.votes, mock_dataset.fields.wins) \
-            .transform(dimx0_metricx2_df, mock_dataset, [], [])
+            .transform(dimx0_metricx2_df, [], [])
 
         expected = dimx0_metricx2_df.copy()[[f('votes'), f('wins')]]
         expected.columns = ['Votes', 'Wins']
@@ -49,7 +49,7 @@ class CSVWidgetTests(TestCase):
 
     def test_multiple_metrics_reversed(self):
         result = CSV(mock_dataset.fields.wins, mock_dataset.fields.votes) \
-            .transform(dimx0_metricx2_df, mock_dataset, [], [])
+            .transform(dimx0_metricx2_df, [], [])
 
         expected = dimx0_metricx2_df.copy()[[f('wins'), f('votes')]]
         expected.columns = ['Wins', 'Votes']
@@ -59,7 +59,7 @@ class CSVWidgetTests(TestCase):
 
     def test_time_series_dim(self):
         result = CSV(mock_dataset.fields.wins) \
-            .transform(dimx1_date_df, mock_dataset, [mock_dataset.fields.timestamp], [])
+            .transform(dimx1_date_df, [mock_dataset.fields.timestamp], [])
 
         expected = dimx1_date_df.copy()[[f('wins')]]
         expected.index.names = ['Timestamp']
@@ -71,7 +71,7 @@ class CSVWidgetTests(TestCase):
     def test_time_series_dim_with_operation(self):
         query_dimensions = [mock_dataset.fields.timestamp]
         result = CSV(CumSum(mock_dataset.fields.votes)) \
-            .transform(dimx1_date_operation_df, mock_dataset, query_dimensions, [])
+            .transform(dimx1_date_operation_df, query_dimensions, [])
 
         expected = dimx1_date_operation_df.copy()[[f('cumsum(votes)')]]
         expected.index.names = ['Timestamp']
@@ -82,7 +82,7 @@ class CSVWidgetTests(TestCase):
 
     def test_str_dim(self):
         result = CSV(mock_dataset.fields.wins) \
-            .transform(dimx1_str_df, mock_dataset, [mock_dataset.fields.political_party], [])
+            .transform(dimx1_str_df, [mock_dataset.fields.political_party], [])
 
         expected = dimx1_str_df.copy()[[f('wins')]]
         expected.index = pd.Index(['Democrat', 'Independent', 'Republican'], name='Party')
@@ -92,7 +92,7 @@ class CSVWidgetTests(TestCase):
 
     def test_int_dim(self):
         result = CSV(mock_dataset.fields.wins) \
-            .transform(dimx1_num_df, mock_dataset, [mock_dataset.fields['candidate-id']], [])
+            .transform(dimx1_num_df, [mock_dataset.fields['candidate-id']], [])
 
         expected = dimx1_num_df.copy()[[f('wins')]]
         expected.index = pd.Index(list(range(1, 12)), name='Candidate ID')
@@ -103,7 +103,7 @@ class CSVWidgetTests(TestCase):
     def test_multi_dimx2_date_str(self):
         query_dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
         result = CSV(mock_dataset.fields.wins) \
-            .transform(dimx2_date_str_df, mock_dataset, query_dimensions, [])
+            .transform(dimx2_date_str_df, query_dimensions, [])
 
         expected = dimx2_date_str_df.copy()[[f('wins')]]
         expected.index.names = ['Timestamp', 'Party']
@@ -113,7 +113,7 @@ class CSVWidgetTests(TestCase):
 
     def test_pivoted_single_dimension_transposes_data_frame(self):
         result = CSV(mock_dataset.fields.wins, pivot=[mock_dataset.fields.political_party]) \
-            .transform(dimx1_str_df, mock_dataset, [mock_dataset.fields.political_party], [])
+            .transform(dimx1_str_df, [mock_dataset.fields.political_party], [])
 
         expected = dimx1_str_df.copy()[[f('wins')]]
         expected.index = pd.Index(['Democrat', 'Independent', 'Republican'], name='Party')
@@ -125,7 +125,7 @@ class CSVWidgetTests(TestCase):
 
     def test_pivoted_multi_dimx2_date_str(self):
         result = CSV(mock_dataset.fields.wins, pivot=[mock_dataset.fields.political_party]) \
-            .transform(dimx2_date_str_df, mock_dataset,
+            .transform(dimx2_date_str_df,
                        [mock_dataset.fields.timestamp, mock_dataset.fields.political_party], [])
 
         expected = dimx2_date_str_df.copy()[[f('wins')]]
@@ -139,7 +139,7 @@ class CSVWidgetTests(TestCase):
     def test_pivoted_multi_dimx2_date_num(self):
         query_dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields['candidate-id']]
         result = CSV(mock_dataset.fields.votes, pivot=[mock_dataset.fields['candidate-id']]) \
-            .transform(dimx2_date_num_df, mock_dataset, query_dimensions, [])
+            .transform(dimx2_date_num_df, query_dimensions, [])
 
         expected = dimx2_date_num_df.copy()[[f('votes')]]
         expected = expected.unstack(level=1)
@@ -153,7 +153,7 @@ class CSVWidgetTests(TestCase):
         query_dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
         query_references = [ElectionOverElection(mock_dataset.fields.timestamp)]
         result = CSV(mock_dataset.fields.votes) \
-            .transform(dimx2_date_str_ref_df, mock_dataset, query_dimensions, query_references)
+            .transform(dimx2_date_str_ref_df, query_dimensions, query_references)
 
         expected = dimx2_date_str_ref_df.copy()[[f('votes'), f('votes_eoe')]]
         expected.index.names = ['Timestamp', 'Party']
@@ -166,7 +166,7 @@ class CSVWidgetTests(TestCase):
         query_dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
         query_references = [ElectionOverElection(mock_dataset.fields.timestamp)]
         result = CSV(mock_dataset.fields.votes, mock_dataset.fields.wins) \
-            .transform(dimx2_date_str_ref_df, mock_dataset, query_dimensions, query_references)
+            .transform(dimx2_date_str_ref_df, query_dimensions, query_references)
 
         expected = dimx2_date_str_ref_df.copy()[[f('votes'), f('votes_eoe'), f('wins'), f('wins_eoe')]]
         expected.index.names = ['Timestamp', 'Party']

--- a/fireant/tests/widgets/test_highcharts.py
+++ b/fireant/tests/widgets/test_highcharts.py
@@ -40,7 +40,7 @@ class HighChartsLineChartTransformerTests(TestCase):
         result = (
             HighCharts(title="Time Series, Single Metric")
             .axis(self.chart_class(mock_dataset.fields.votes))
-            .transform(dimx1_date_df, mock_dataset, [mock_dataset.fields.timestamp], [])
+            .transform(dimx1_date_df, [mock_dataset.fields.timestamp], [])
         )
 
         self.assertEqual(
@@ -92,7 +92,7 @@ class HighChartsLineChartTransformerTests(TestCase):
             HighCharts(title="Time Series, Single Metric")
             .axis(self.chart_class(mock_dataset.fields.votes))
             .transform(
-                dimx1_date_df, mock_dataset, [year(mock_dataset.fields.timestamp)], []
+                dimx1_date_df, [year(mock_dataset.fields.timestamp)], []
             )
         )
 
@@ -144,7 +144,7 @@ class HighChartsLineChartTransformerTests(TestCase):
         result = (
             HighCharts(title="Time Series, Single Metric")
             .axis(self.chart_class(mock_dataset.fields.turnout))
-            .transform(dimx1_date_df, mock_dataset, [mock_dataset.fields.timestamp], [])
+            .transform(dimx1_date_df, [mock_dataset.fields.timestamp], [])
         )
 
         self.assertEqual(
@@ -195,7 +195,7 @@ class HighChartsLineChartTransformerTests(TestCase):
         result = (
             HighCharts(title="Time Series, Single Metric")
             .axis(self.chart_class(mock_dataset.fields.wins_with_style))
-            .transform(dimx1_date_df, mock_dataset, [mock_dataset.fields.timestamp], [])
+            .transform(dimx1_date_df, [mock_dataset.fields.timestamp], [])
         )
 
         self.assertEqual(
@@ -248,7 +248,6 @@ class HighChartsLineChartTransformerTests(TestCase):
             .axis(self.chart_class(CumSum(mock_dataset.fields.votes)))
             .transform(
                 dimx1_date_operation_df,
-                mock_dataset,
                 [mock_dataset.fields.timestamp],
                 [],
             )
@@ -303,7 +302,7 @@ class HighChartsLineChartTransformerTests(TestCase):
         result = (
             HighCharts(title="Time Series with Unique Dimension and Single Metric")
             .axis(self.chart_class(mock_dataset.fields.votes))
-            .transform(dimx2_date_str_df, mock_dataset, dimensions, [])
+            .transform(dimx2_date_str_df, dimensions, [])
         )
 
         self.assertEqual(
@@ -398,7 +397,6 @@ class HighChartsLineChartTransformerTests(TestCase):
             )
             .transform(
                 dimx2_date_str_df,
-                mock_dataset,
                 [mock_dataset.fields.timestamp, mock_dataset.fields.state],
                 [],
             )
@@ -555,7 +553,6 @@ class HighChartsLineChartTransformerTests(TestCase):
             .axis(self.chart_class(mock_dataset.fields.wins))
             .transform(
                 dimx2_date_str_df,
-                mock_dataset,
                 [mock_dataset.fields.timestamp, mock_dataset.fields.state],
                 [],
             )
@@ -733,7 +730,6 @@ class HighChartsLineChartTransformerTests(TestCase):
             .axis(self.chart_class(mock_dataset.fields.wins))
             .transform(
                 dataframe,
-                mock_dataset,
                 [mock_dataset.fields.timestamp, Rollup(mock_dataset.fields.state)],
                 [],
             )
@@ -819,7 +815,6 @@ class HighChartsLineChartTransformerTests(TestCase):
             .axis(self.chart_class(mock_dataset.fields.wins))
             .transform(
                 dimx2_date_str_totals_df,
-                mock_dataset,
                 [mock_dataset.fields.timestamp, Rollup(mock_dataset.fields.state)],
                 [],
             )
@@ -1026,7 +1021,6 @@ class HighChartsLineChartTransformerTests(TestCase):
             .axis(self.chart_class(mock_dataset.fields.wins))
             .transform(
                 dimx2_date_str_totalsx2_df,
-                mock_dataset,
                 [
                     Rollup(mock_dataset.fields.timestamp),
                     Rollup(mock_dataset.fields.state),
@@ -1233,7 +1227,7 @@ class HighChartsLineChartTransformerTests(TestCase):
         result = (
             HighCharts(title="Time Series with Unique Dimension and Reference")
             .axis(self.chart_class(mock_dataset.fields.votes))
-            .transform(dimx2_date_str_ref_df, mock_dataset, dimensions, references)
+            .transform(dimx2_date_str_ref_df, dimensions, references)
         )
 
         self.assertEqual(
@@ -1351,7 +1345,7 @@ class HighChartsLineChartTransformerTests(TestCase):
             HighCharts(title="Time Series with Unique Dimension and Delta Reference")
             .axis(self.chart_class(mock_dataset.fields.votes))
             .transform(
-                dimx2_date_str_ref_delta_df, mock_dataset, dimensions, references
+                dimx2_date_str_ref_delta_df, dimensions, references
             )
         )
 
@@ -1476,7 +1470,7 @@ class HighChartsLineChartTransformerTests(TestCase):
         result = (
             HighCharts(title="Time Series, Single Metric")
             .axis(self.chart_class(mock_dataset.fields.votes), y_axis_visible=False)
-            .transform(dimx1_date_df, mock_dataset, [mock_dataset.fields.timestamp], [])
+            .transform(dimx1_date_df, [mock_dataset.fields.timestamp], [])
         )
 
         self.assertEqual(
@@ -1530,7 +1524,7 @@ class HighChartsLineChartTransformerTests(TestCase):
             HighCharts(title="Time Series with Unique Dimension and Delta Reference")
             .axis(self.chart_class(mock_dataset.fields.votes), y_axis_visible=False)
             .transform(
-                dimx2_date_str_ref_delta_df, mock_dataset, dimensions, references
+                dimx2_date_str_ref_delta_df, dimensions, references
             )
         )
 
@@ -1663,7 +1657,7 @@ class HighChartsBarChartTransformerTests(TestCase):
         result = (
             HighCharts(title="All Votes")
             .axis(self.chart_class(mock_dataset.fields.votes))
-            .transform(dimx0_metricx1_df, mock_dataset, [], [])
+            .transform(dimx0_metricx1_df, [], [])
         )
 
         self.assertEqual(
@@ -1708,7 +1702,7 @@ class HighChartsBarChartTransformerTests(TestCase):
                 self.chart_class(mock_dataset.fields.votes),
                 self.chart_class(mock_dataset.fields.wins),
             )
-            .transform(dimx0_metricx2_df, mock_dataset, [], [])
+            .transform(dimx0_metricx2_df, [], [])
         )
 
         self.assertEqual(
@@ -1764,7 +1758,7 @@ class HighChartsBarChartTransformerTests(TestCase):
             HighCharts("Votes and Wins")
             .axis(self.chart_class(mock_dataset.fields.votes))
             .transform(
-                dimx1_str_df, mock_dataset, [mock_dataset.fields.political_party], []
+                dimx1_str_df, [mock_dataset.fields.political_party], []
             )
         )
 
@@ -1819,7 +1813,7 @@ class HighChartsBarChartTransformerTests(TestCase):
                 self.chart_class(mock_dataset.fields.wins),
             )
             .transform(
-                dimx1_str_df, mock_dataset, [mock_dataset.fields.political_party], []
+                dimx1_str_df, [mock_dataset.fields.political_party], []
             )
         )
 
@@ -1884,7 +1878,7 @@ class HighChartsBarChartTransformerTests(TestCase):
         result = (
             HighCharts("Election Votes by State")
             .axis(self.chart_class(mock_dataset.fields.votes))
-            .transform(dimx2_date_str_df, mock_dataset, dimensions, [])
+            .transform(dimx2_date_str_df, dimensions, [])
         )
 
         self.assertEqual(
@@ -1970,7 +1964,7 @@ class HighChartsBarChartTransformerTests(TestCase):
                 self.chart_class(mock_dataset.fields.votes),
                 self.chart_class(mock_dataset.fields.wins),
             )
-            .transform(dimx2_date_str_df, mock_dataset, dimensions, [])
+            .transform(dimx2_date_str_df, dimensions, [])
         )
 
         self.assertEqual(
@@ -2107,7 +2101,7 @@ class HighChartsBarChartTransformerTests(TestCase):
             HighCharts(title="Election Votes by State")
             .axis(self.chart_class(mock_dataset.fields.votes))
             .axis(self.chart_class(mock_dataset.fields.wins))
-            .transform(dimx2_date_str_df, mock_dataset, dimensions, [])
+            .transform(dimx2_date_str_df, dimensions, [])
         )
 
         self.assertEqual(
@@ -2250,7 +2244,6 @@ class HighChartsBarChartTransformerTests(TestCase):
             .axis(self.chart_class(mock_dataset.fields.votes))
             .transform(
                 dimx1_str_totals_df,
-                mock_dataset,
                 [Rollup(mock_dataset.fields.political_party)],
                 [],
             )
@@ -2314,7 +2307,7 @@ class HighChartsBarChartTransformerTests(TestCase):
         result = (
             HighCharts(title="Categorical Dimension with Totals")
             .axis(self.chart_class(mock_dataset.fields.votes))
-            .transform(df, mock_dataset, dimensions, [])
+            .transform(df, dimensions, [])
         )
 
         self.assertEqual(
@@ -2451,7 +2444,7 @@ class HighChartsBarChartTransformerTests(TestCase):
         result = (
             HighCharts(title="All Votes")
             .axis(self.chart_class(mock_dataset.fields.votes), y_axis_visible=False)
-            .transform(dimx0_metricx1_df, mock_dataset, [], [])
+            .transform(dimx0_metricx1_df, [], [])
         )
 
         self.assertEqual(
@@ -2534,7 +2527,7 @@ class HighChartsPieChartTransformerTests(TestCase):
         result = (
             HighCharts(title="All Votes")
             .axis(self.chart_class(mock_dataset.fields.votes))
-            .transform(dimx0_metricx1_df, mock_dataset, [], [])
+            .transform(dimx0_metricx1_df, [], [])
         )
 
         self.assertEqual(
@@ -2578,7 +2571,7 @@ class HighChartsPieChartTransformerTests(TestCase):
                 self.chart_class(mock_dataset.fields.votes),
                 self.chart_class(mock_dataset.fields.wins),
             )
-            .transform(dimx0_metricx2_df, mock_dataset, [], [])
+            .transform(dimx0_metricx2_df, [], [])
         )
 
         self.assertEqual(
@@ -2631,7 +2624,7 @@ class HighChartsPieChartTransformerTests(TestCase):
         result = (
             HighCharts("Votes and Wins By Day")
             .axis(self.chart_class(mock_dataset.fields.votes))
-            .transform(dimx1_date_df, mock_dataset, [mock_dataset.fields.timestamp], [])
+            .transform(dimx1_date_df, [mock_dataset.fields.timestamp], [])
         )
 
         self.assertEqual(
@@ -2682,7 +2675,7 @@ class HighChartsPieChartTransformerTests(TestCase):
             HighCharts("Votes and Wins By Day")
             .axis(self.chart_class(mock_dataset.fields.votes))
             .transform(
-                dimx1_date_df, mock_dataset, [year(mock_dataset.fields.timestamp)], []
+                dimx1_date_df, [year(mock_dataset.fields.timestamp)], []
             )
         )
 
@@ -2734,7 +2727,7 @@ class HighChartsPieChartTransformerTests(TestCase):
             HighCharts("Votes and Wins By Party")
             .axis(self.chart_class(mock_dataset.fields.votes))
             .transform(
-                dimx1_str_df, mock_dataset, [mock_dataset.fields.political_party], []
+                dimx1_str_df, [mock_dataset.fields.political_party], []
             )
         )
 
@@ -2785,7 +2778,7 @@ class HighChartsPieChartTransformerTests(TestCase):
             HighCharts(title="Votes and Wins By Election")
             .axis(self.chart_class(mock_dataset.fields.votes))
             .transform(
-                dimx1_num_df, mock_dataset, [mock_dataset.fields["candidate-id"]], []
+                dimx1_num_df, [mock_dataset.fields["candidate-id"]], []
             )
         )
 
@@ -2860,7 +2853,7 @@ class HighChartsPieChartTransformerTests(TestCase):
         result = (
             HighCharts(title="Votes by Date, Party")
             .axis(self.chart_class(mock_dataset.fields.votes))
-            .transform(dimx2_date_str_df, mock_dataset, dimensions, [])
+            .transform(dimx2_date_str_df, dimensions, [])
         )
 
         self.assertEqual(
@@ -2920,7 +2913,7 @@ class HighChartsPieChartTransformerTests(TestCase):
         result = (
             HighCharts(title="Election Votes by Day and Candidate ID")
             .axis(self.chart_class(mock_dataset.fields.votes))
-            .transform(dimx2_date_num_df, mock_dataset, dimensions, [])
+            .transform(dimx2_date_num_df, dimensions, [])
         )
 
         self.assertEqual(
@@ -2979,7 +2972,7 @@ class HighChartsPieChartTransformerTests(TestCase):
         result = (
             HighCharts(title="Election Votes by Day and Candidate ID")
             .axis(self.chart_class(mock_dataset.fields.votes))
-            .transform(dimx2_date_num_df, mock_dataset, dimensions, [])
+            .transform(dimx2_date_num_df, dimensions, [])
         )
 
         self.assertEqual(
@@ -3039,7 +3032,7 @@ class HighChartsPieChartTransformerTests(TestCase):
                 self.chart_class(mock_dataset.fields.votes),
                 self.chart_class(mock_dataset.fields.wins),
             )
-            .transform(dimx2_date_str_df, mock_dataset, dimensions, references)
+            .transform(dimx2_date_str_df, dimensions, references)
         )
 
         self.assertEqual(
@@ -3186,7 +3179,6 @@ class HighChartsLineChartAnnotationTransformerTests(TestCase):
             .axis(self.chart_class(mock_dataset.fields.votes))
             .transform(
                 dimx1_date_meticx1_votes_df,
-                mock_dataset,
                 [mock_dataset.fields.timestamp],
                 [],
                 dimx2_date_index_str_df,
@@ -3277,7 +3269,6 @@ class HighChartsLineChartAnnotationTransformerTests(TestCase):
             .axis(self.chart_class(mock_dataset.fields.votes))
             .transform(
                 dimx2_date_str_df,
-                mock_dataset,
                 [mock_dataset.fields.timestamp, mock_dataset.fields.political_party],
                 [],
                 dimx2_date_index_str_df,
@@ -3405,7 +3396,6 @@ class HighChartsLineChartAnnotationTransformerTests(TestCase):
             .axis(self.chart_class(mock_dataset.fields.votes))
             .transform(
                 dimx1_str_df,
-                mock_dataset,
                 [mock_dataset.fields.political_party],
                 [],
                 dimx2_category_index_str_df,

--- a/fireant/tests/widgets/test_matplotlib.py
+++ b/fireant/tests/widgets/test_matplotlib.py
@@ -21,7 +21,7 @@ try:
         def test_single_metric_line_chart(self):
             result = Matplotlib(title="Time Series, Single Metric") \
                 .axis(self.chart_class(mock_dataset.fields.votes)) \
-                .transform(dimx1_date_df, mock_dataset, [mock_dataset.fields.timestamp], [])
+                .transform(dimx1_date_df, [mock_dataset.fields.timestamp], [])
 
             self.assertEqual(1, len(result))
 

--- a/fireant/tests/widgets/test_pandas.py
+++ b/fireant/tests/widgets/test_pandas.py
@@ -39,7 +39,7 @@ class PandasTransformerTests(TestCase):
 
     def test_metricx1(self):
         result = Pandas(mock_dataset.fields.votes) \
-            .transform(dimx0_metricx1_df, mock_dataset, [], [])
+            .transform(dimx0_metricx1_df, [], [])
 
         expected = dimx0_metricx1_df.copy()[[f('votes')]]
         expected.columns = ['Votes']
@@ -50,7 +50,7 @@ class PandasTransformerTests(TestCase):
 
     def test_metricx2(self):
         result = Pandas(mock_dataset.fields.votes, mock_dataset.fields.wins) \
-            .transform(dimx0_metricx2_df, mock_dataset, [], [])
+            .transform(dimx0_metricx2_df, [], [])
 
         expected = dimx0_metricx2_df.copy()[[f('votes'), f('wins')]]
         expected.columns = ['Votes', 'Wins']
@@ -61,7 +61,7 @@ class PandasTransformerTests(TestCase):
 
     def test_metricx2_reversed(self):
         result = Pandas(mock_dataset.fields.wins, mock_dataset.fields.votes) \
-            .transform(dimx0_metricx2_df, mock_dataset, [], [])
+            .transform(dimx0_metricx2_df, [], [])
 
         expected = dimx0_metricx2_df.copy()[[f('wins'), f('votes')]]
         expected.columns = ['Wins', 'Votes']
@@ -72,7 +72,7 @@ class PandasTransformerTests(TestCase):
 
     def test_dimx1_date(self):
         result = Pandas(mock_dataset.fields.wins) \
-            .transform(dimx1_date_df, mock_dataset, [mock_dataset.fields.timestamp], [])
+            .transform(dimx1_date_df, [mock_dataset.fields.timestamp], [])
 
         expected = dimx1_date_df.copy()[[f('wins')]]
         expected.index.names = ['Timestamp']
@@ -84,7 +84,7 @@ class PandasTransformerTests(TestCase):
 
     def test_dimx1_date_with_operation(self):
         result = Pandas(CumSum(mock_dataset.fields.votes)) \
-            .transform(dimx1_date_operation_df, mock_dataset, [mock_dataset.fields.timestamp], [])
+            .transform(dimx1_date_operation_df, [mock_dataset.fields.timestamp], [])
 
         expected = dimx1_date_operation_df.copy()[[f('cumsum(votes)')]]
         expected.index.names = ['Timestamp']
@@ -96,7 +96,7 @@ class PandasTransformerTests(TestCase):
 
     def test_dimx1_str(self):
         result = Pandas(mock_dataset.fields.wins) \
-            .transform(dimx1_str_df, mock_dataset, [mock_dataset.fields.political_party], [])
+            .transform(dimx1_str_df, [mock_dataset.fields.political_party], [])
 
         expected = dimx1_str_df.copy()[[f('wins')]]
         expected.index = pd.Index(['Democrat', 'Independent', 'Republican'], name='Party')
@@ -108,7 +108,7 @@ class PandasTransformerTests(TestCase):
 
     def test_dimx1_int(self):
         result = Pandas(mock_dataset.fields.wins) \
-            .transform(dimx1_str_df, mock_dataset, [mock_dataset.fields['candidate-id']], [])
+            .transform(dimx1_str_df, [mock_dataset.fields['candidate-id']], [])
 
         expected = dimx1_str_df.copy()[[f('wins')]]
         expected.index.names = ['Candidate ID']
@@ -121,7 +121,7 @@ class PandasTransformerTests(TestCase):
     def test_dimx2_date_str(self):
         dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
         result = Pandas(mock_dataset.fields.wins) \
-            .transform(dimx2_date_str_df, mock_dataset, dimensions, [])
+            .transform(dimx2_date_str_df, dimensions, [])
 
         expected = dimx2_date_str_df.copy()[[f('wins')]]
         expected.index.names = ['Timestamp', 'Party']
@@ -133,7 +133,7 @@ class PandasTransformerTests(TestCase):
 
     def test_transpose_dimx2_str(self):
         result = Pandas(mock_dataset.fields.wins, transpose=True) \
-            .transform(dimx1_str_df, mock_dataset, [mock_dataset.fields.political_party], [])
+            .transform(dimx1_str_df, [mock_dataset.fields.political_party], [])
 
         expected = dimx1_str_df.copy()[[f('wins')]]
         expected.index = pd.Index(['Democrat', 'Independent', 'Republican'], name='Party')
@@ -146,7 +146,7 @@ class PandasTransformerTests(TestCase):
 
     def test_pivoted_dimx1_str_transposes_data_frame(self):
         result = Pandas(mock_dataset.fields.wins, pivot=[mock_dataset.fields.political_party]) \
-            .transform(dimx1_str_df, mock_dataset, [mock_dataset.fields.political_party], [])
+            .transform(dimx1_str_df, [mock_dataset.fields.political_party], [])
 
         expected = dimx1_str_df.copy()[[f('wins')]]
         expected.index = pd.Index(['Democrat', 'Independent', 'Republican'], name='Party')
@@ -159,7 +159,7 @@ class PandasTransformerTests(TestCase):
 
     def test_pivoted_dimx2_date_str(self):
         result = Pandas(mock_dataset.fields.wins, pivot=[mock_dataset.fields.political_party]) \
-            .transform(dimx2_date_str_df, mock_dataset,
+            .transform(dimx2_date_str_df,
                        [mock_dataset.fields.timestamp, mock_dataset.fields.political_party], [])
 
         expected = dimx2_date_str_df.copy()[[f('wins')]]
@@ -175,7 +175,7 @@ class PandasTransformerTests(TestCase):
         dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
         references = [ElectionOverElection(mock_dataset.fields.timestamp)]
         result = Pandas(mock_dataset.fields.votes) \
-            .transform(dimx2_date_str_ref_df, mock_dataset,
+            .transform(dimx2_date_str_ref_df,
                        dimensions, references)
 
         expected = dimx2_date_str_ref_df.copy()[[f('votes'), f('votes_eoe')]]
@@ -195,7 +195,7 @@ class PandasTransformerTests(TestCase):
 
         # divide the data frame by 3 to get a repeating decimal so we can check precision
         result = Pandas(votes) \
-            .transform(dimx1_date_df / 3, mock_dataset, [mock_dataset.fields.timestamp], [])
+            .transform(dimx1_date_df / 3, [mock_dataset.fields.timestamp], [])
 
         f_votes = f('votes')
         expected = dimx1_date_df.copy()[[f_votes]]
@@ -213,7 +213,7 @@ class PandasTransformerTests(TestCase):
         cat_dim_df_with_nan.iloc[2, 1] = np.nan
 
         result = Pandas(mock_dataset.fields.wins) \
-            .transform(cat_dim_df_with_nan, mock_dataset, [mock_dataset.fields.political_party], [])
+            .transform(cat_dim_df_with_nan, [mock_dataset.fields.political_party], [])
 
         expected = cat_dim_df_with_nan.copy()[[f('wins')]]
         expected.index = pd.Index(['Democrat', 'Independent', 'Republican'], name='Party')
@@ -229,7 +229,7 @@ class PandasTransformerTests(TestCase):
         cat_dim_df_with_nan.iloc[2, 1] = np.inf
 
         result = Pandas(mock_dataset.fields.wins) \
-            .transform(cat_dim_df_with_nan, mock_dataset, [mock_dataset.fields.political_party], [])
+            .transform(cat_dim_df_with_nan, [mock_dataset.fields.political_party], [])
 
         expected = cat_dim_df_with_nan.copy()[[f('wins')]]
         expected.index = pd.Index(['Democrat', 'Independent', 'Republican'], name='Party')
@@ -245,7 +245,7 @@ class PandasTransformerTests(TestCase):
         cat_dim_df_with_nan.iloc[2, 1] = np.inf
 
         result = Pandas(mock_dataset.fields.wins) \
-            .transform(cat_dim_df_with_nan, mock_dataset, [mock_dataset.fields.political_party], [])
+            .transform(cat_dim_df_with_nan, [mock_dataset.fields.political_party], [])
 
         expected = cat_dim_df_with_nan.copy()[[f('wins')]]
         expected.index = pd.Index(['Democrat', 'Independent', 'Republican'], name='Party')
@@ -260,11 +260,11 @@ class PandasTransformerTests(TestCase):
         cat_dim_df_with_nan['$wins'] = cat_dim_df_with_nan['$wins'].apply(float)
         cat_dim_df_with_nan.iloc[2, 1] = np.inf
 
-        slicer_modified = copy.deepcopy(mock_dataset)
-        slicer_modified.fields.wins.precision = 0
+        mock_modified_dataset = copy.deepcopy(mock_dataset)
+        mock_modified_dataset.fields.wins.precision = 0
 
-        result = Pandas(slicer_modified.fields.wins) \
-            .transform(cat_dim_df_with_nan, slicer_modified, [slicer_modified.fields.political_party], [])
+        result = Pandas(mock_modified_dataset.fields.wins) \
+            .transform(cat_dim_df_with_nan, [mock_modified_dataset.fields.political_party], [])
 
         expected = cat_dim_df_with_nan.copy()[[f('wins')]]
         expected.index = pd.Index(['Democrat', 'Independent', 'Republican'], name='Party')
@@ -278,7 +278,7 @@ class PandasTransformerTests(TestCase):
 class PandasTransformerSortTests(TestCase):
     def test_metricx2_sort_index_asc(self):
         result = Pandas(mock_dataset.fields.wins, sort=[0]) \
-            .transform(dimx1_date_df, mock_dataset, [mock_dataset.fields.timestamp], [])
+            .transform(dimx1_date_df, [mock_dataset.fields.timestamp], [])
 
         expected = dimx1_date_df.copy()[[f('wins')]]
         expected.index.names = ['Timestamp']
@@ -292,7 +292,7 @@ class PandasTransformerSortTests(TestCase):
 
     def test_metricx2_sort_index_desc(self):
         result = Pandas(mock_dataset.fields.wins, sort=[0], ascending=[False]) \
-            .transform(dimx1_date_df, mock_dataset, [mock_dataset.fields.timestamp], [])
+            .transform(dimx1_date_df, [mock_dataset.fields.timestamp], [])
 
         expected = dimx1_date_df.copy()[[f('wins')]]
         expected.index.names = ['Timestamp']
@@ -306,7 +306,7 @@ class PandasTransformerSortTests(TestCase):
 
     def test_metricx2_sort_value_asc(self):
         result = Pandas(mock_dataset.fields.wins, sort=[1]) \
-            .transform(dimx1_date_df, mock_dataset, [mock_dataset.fields.timestamp], [])
+            .transform(dimx1_date_df, [mock_dataset.fields.timestamp], [])
 
         expected = dimx1_date_df.copy()[[f('wins')]]
         expected.index.names = ['Timestamp']
@@ -320,7 +320,7 @@ class PandasTransformerSortTests(TestCase):
 
     def test_metricx2_sort_value_desc(self):
         result = Pandas(mock_dataset.fields.wins, sort=[1], ascending=[False]) \
-            .transform(dimx1_date_df, mock_dataset, [mock_dataset.fields.timestamp], [])
+            .transform(dimx1_date_df, [mock_dataset.fields.timestamp], [])
 
         expected = dimx1_date_df.copy()[[f('wins')]]
         expected.index.names = ['Timestamp']
@@ -334,7 +334,7 @@ class PandasTransformerSortTests(TestCase):
 
     def test_metricx2_sort_index_and_value(self):
         result = Pandas(mock_dataset.fields.wins, sort=[-0, 1]) \
-            .transform(dimx1_date_df, mock_dataset, [mock_dataset.fields.timestamp], [])
+            .transform(dimx1_date_df, [mock_dataset.fields.timestamp], [])
 
         expected = dimx1_date_df.copy()[[f('wins')]]
         expected.index.names = ['Timestamp']
@@ -350,7 +350,7 @@ class PandasTransformerSortTests(TestCase):
 
     def test_pivoted_dimx2_date_str_with_sort_index_asc(self):
         result = Pandas(mock_dataset.fields.votes, pivot=[mock_dataset.fields.political_party], sort=[0]) \
-            .transform(dimx2_date_str_df, mock_dataset,
+            .transform(dimx2_date_str_df,
                        [mock_dataset.fields.timestamp, mock_dataset.fields.political_party], [])
 
         expected = dimx2_date_str_df.copy()[[f('votes')]]
@@ -367,7 +367,7 @@ class PandasTransformerSortTests(TestCase):
     def test_pivoted_dimx2_date_str_with_sort_index_desc(self):
         result = Pandas(mock_dataset.fields.votes, pivot=[mock_dataset.fields.political_party], sort=[0],
                         ascending=[False]) \
-            .transform(dimx2_date_str_df, mock_dataset,
+            .transform(dimx2_date_str_df,
                        [mock_dataset.fields.timestamp, mock_dataset.fields.political_party], [])
 
         expected = dimx2_date_str_df.copy()[[f('votes')]]
@@ -383,7 +383,7 @@ class PandasTransformerSortTests(TestCase):
 
     def test_pivoted_dimx2_date_str_with_sort_first_metric_asc(self):
         result = Pandas(mock_dataset.fields.votes, pivot=[mock_dataset.fields.political_party], sort=[1]) \
-            .transform(dimx2_date_str_df, mock_dataset,
+            .transform(dimx2_date_str_df,
                        [mock_dataset.fields.timestamp, mock_dataset.fields.political_party], [])
 
         expected = dimx2_date_str_df.copy()[[f('votes')]]
@@ -402,7 +402,7 @@ class PandasTransformerSortTests(TestCase):
     def test_pivoted_dimx2_date_str_with_sort_metric_desc(self):
         result = Pandas(mock_dataset.fields.votes, pivot=[mock_dataset.fields.political_party], sort=[1],
                         ascending=[False]) \
-            .transform(dimx2_date_str_df, mock_dataset,
+            .transform(dimx2_date_str_df,
                        [mock_dataset.fields.timestamp, mock_dataset.fields.political_party], [])
 
         expected = dimx2_date_str_df.copy()[[f('votes')]]
@@ -420,7 +420,7 @@ class PandasTransformerSortTests(TestCase):
 
     def test_pivoted_dimx2_date_str_with_sort_metric_asc(self):
         result = Pandas(mock_dataset.fields.votes, pivot=[mock_dataset.fields.political_party], sort=[1]) \
-            .transform(dimx2_date_str_df, mock_dataset,
+            .transform(dimx2_date_str_df,
                        [mock_dataset.fields.timestamp, mock_dataset.fields.political_party], [])
 
         expected = dimx2_date_str_df.copy()[[f('votes')]]
@@ -438,7 +438,7 @@ class PandasTransformerSortTests(TestCase):
 
     def test_pivoted_dimx1_metricx2(self):
         result = Pandas(mock_dataset.fields.votes, mock_dataset.fields.wins, pivot=[mock_dataset.fields.timestamp]) \
-            .transform(dimx2_date_str_df, mock_dataset,
+            .transform(dimx2_date_str_df,
                        [mock_dataset.fields.timestamp, mock_dataset.fields.political_party], [])
 
         expected = dimx2_date_str_df.copy()[[f('votes'), f('wins')]]
@@ -466,7 +466,7 @@ class PandasTransformerSortTests(TestCase):
                         pivot=[mock_dataset.fields.political_party],
                         sort=1,
                         ascending=False) \
-            .transform(dimx2_date_str_df, mock_dataset,
+            .transform(dimx2_date_str_df,
                        [mock_dataset.fields.timestamp, mock_dataset.fields.political_party], [])
 
         expected = dimx2_date_str_df.copy()[[f('votes')]]
@@ -485,7 +485,7 @@ class PandasTransformerSortTests(TestCase):
     def test_pivoted_dimx2_date_str_with_sort_index_and_columns(self):
         result = Pandas(mock_dataset.fields.votes, pivot=[mock_dataset.fields.political_party], sort=[0, 2],
                         ascending=[True, False]) \
-            .transform(dimx2_date_str_df, mock_dataset,
+            .transform(dimx2_date_str_df,
                        [mock_dataset.fields.timestamp, mock_dataset.fields.political_party], [])
 
         expected = dimx2_date_str_df.copy()[[f('votes')]]
@@ -504,7 +504,7 @@ class PandasTransformerSortTests(TestCase):
     def test_use_first_value_for_ascending_when_arg_has_invalid_length(self):
         result = Pandas(mock_dataset.fields.votes, pivot=[mock_dataset.fields.political_party], sort=[0, 2],
                         ascending=[True]) \
-            .transform(dimx2_date_str_df, mock_dataset,
+            .transform(dimx2_date_str_df,
                        [mock_dataset.fields.timestamp, mock_dataset.fields.political_party], [])
 
         expected = dimx2_date_str_df.copy()[[f('votes')]]
@@ -523,7 +523,7 @@ class PandasTransformerSortTests(TestCase):
     def test_use_pandas_default_for_ascending_when_arg_empty_list(self):
         result = Pandas(mock_dataset.fields.votes, pivot=[mock_dataset.fields.political_party], sort=[0, 2],
                         ascending=[]) \
-            .transform(dimx2_date_str_df, mock_dataset,
+            .transform(dimx2_date_str_df,
                        [mock_dataset.fields.timestamp, mock_dataset.fields.political_party], [])
 
         expected = dimx2_date_str_df.copy()[[f('votes')]]
@@ -541,7 +541,7 @@ class PandasTransformerSortTests(TestCase):
 
     def test_dimx2_date_str_sort_index_level_0_default_ascending(self):
         result = Pandas(mock_dataset.fields.wins, sort=[0]) \
-            .transform(dimx2_date_str_df, mock_dataset,
+            .transform(dimx2_date_str_df,
                        [mock_dataset.fields.timestamp, mock_dataset.fields.political_party], [])
 
         expected = dimx2_date_str_df.copy()[[f('wins')]]
@@ -558,7 +558,7 @@ class PandasTransformerSortTests(TestCase):
 
     def test_dimx2_date_str_sort_index_level_0_asc(self):
         result = Pandas(mock_dataset.fields.wins, sort=[0], ascending=True) \
-            .transform(dimx2_date_str_df, mock_dataset,
+            .transform(dimx2_date_str_df,
                        [mock_dataset.fields.timestamp, mock_dataset.fields.political_party], [])
 
         expected = dimx2_date_str_df.copy()[[f('wins')]]
@@ -575,7 +575,7 @@ class PandasTransformerSortTests(TestCase):
 
     def test_pivoted_dimx2_date_str_sort_index_level_1_desc(self):
         result = Pandas(mock_dataset.fields.wins, sort=[1], ascending=[False]) \
-            .transform(dimx2_date_str_df, mock_dataset,
+            .transform(dimx2_date_str_df,
                        [mock_dataset.fields.timestamp, mock_dataset.fields.political_party], [])
 
         expected = dimx2_date_str_df.copy()[[f('wins')]]
@@ -592,7 +592,7 @@ class PandasTransformerSortTests(TestCase):
 
     def test_pivoted_dimx2_date_str_sort_index_and_values(self):
         result = Pandas(mock_dataset.fields.wins, sort=[0, 2], ascending=[False, True]) \
-            .transform(dimx2_date_str_df, mock_dataset,
+            .transform(dimx2_date_str_df,
                        [mock_dataset.fields.timestamp, mock_dataset.fields.political_party], [])
 
         expected = dimx2_date_str_df.copy()[[f('wins')]]
@@ -609,7 +609,7 @@ class PandasTransformerSortTests(TestCase):
 
     def test_empty_sort_array_is_ignored(self):
         result = Pandas(mock_dataset.fields.wins, sort=[]) \
-            .transform(dimx1_date_df, mock_dataset, [mock_dataset.fields.timestamp], [])
+            .transform(dimx1_date_df, [mock_dataset.fields.timestamp], [])
 
         expected = dimx1_date_df.copy()[[f('wins')]]
         expected.index.names = ['Timestamp']
@@ -621,7 +621,7 @@ class PandasTransformerSortTests(TestCase):
 
     def test_sort_value_greater_than_number_of_columns_is_ignored(self):
         result = Pandas(mock_dataset.fields.wins, sort=[5]) \
-            .transform(dimx1_date_df, mock_dataset, [mock_dataset.fields.timestamp], [])
+            .transform(dimx1_date_df, [mock_dataset.fields.timestamp], [])
 
         expected = dimx1_date_df.copy()[[f('wins')]]
         expected.index.names = ['Timestamp']
@@ -633,7 +633,7 @@ class PandasTransformerSortTests(TestCase):
 
     def test_sort_with_no_index(self):
         result = Pandas(mock_dataset.fields.wins, sort=[0]) \
-            .transform(no_index_df, mock_dataset, [mock_dataset.fields.timestamp], [])
+            .transform(no_index_df, [mock_dataset.fields.timestamp], [])
 
         expected = no_index_df.copy()[[f('wins')]]
         expected.index.names = ['Timestamp']

--- a/fireant/tests/widgets/test_reacttable.py
+++ b/fireant/tests/widgets/test_reacttable.py
@@ -63,7 +63,7 @@ class FormattingRulesTests(TestCase):
                     self.dataset.fields.metric0, ComparisonOperator.gt, 2, "#EEEEEE"
                 )
             ],
-        ).transform(self.df, mock_dataset, [], [])
+        ).transform(self.df, [], [])
 
         self.assertEqual(
             {
@@ -89,7 +89,7 @@ class FormattingRulesTests(TestCase):
                     self.dataset.fields.metric0, ComparisonOperator.lt, 2, "#AAAAAA"
                 ),
             ],
-        ).transform(self.df, mock_dataset, [], [])
+        ).transform(self.df, [], [])
 
         self.assertEqual(
             {
@@ -110,7 +110,7 @@ class ReactTableTransformerTests(TestCase):
 
     def test_single_metric(self):
         result = ReactTable(mock_dataset.fields.votes).transform(
-            dimx0_metricx1_df, mock_dataset, [], []
+            dimx0_metricx1_df, [], []
         )
 
         self.assertEqual(
@@ -124,7 +124,7 @@ class ReactTableTransformerTests(TestCase):
     def test_multiple_metrics(self):
         result = ReactTable(
             mock_dataset.fields.votes, mock_dataset.fields.wins
-        ).transform(dimx0_metricx2_df, mock_dataset, [], [])
+        ).transform(dimx0_metricx2_df, [], [])
 
         self.assertEqual(
             {
@@ -145,7 +145,7 @@ class ReactTableTransformerTests(TestCase):
     def test_multiple_metrics_reversed(self):
         result = ReactTable(
             mock_dataset.fields.wins, mock_dataset.fields.votes
-        ).transform(dimx0_metricx2_df, mock_dataset, [], [])
+        ).transform(dimx0_metricx2_df, [], [])
 
         self.assertEqual(
             {
@@ -165,7 +165,7 @@ class ReactTableTransformerTests(TestCase):
 
     def test_time_series_dim(self):
         result = ReactTable(mock_dataset.fields.wins).transform(
-            dimx1_date_df, mock_dataset, [day(mock_dataset.fields.timestamp)], []
+            dimx1_date_df, [day(mock_dataset.fields.timestamp)], []
         )
 
         self.assertEqual(
@@ -225,7 +225,6 @@ class ReactTableTransformerTests(TestCase):
     def test_time_series_dim_with_operation(self):
         result = ReactTable(CumSum(mock_dataset.fields.votes)).transform(
             dimx1_date_operation_df,
-            mock_dataset,
             [day(mock_dataset.fields.timestamp)],
             [],
         )
@@ -286,7 +285,7 @@ class ReactTableTransformerTests(TestCase):
 
     def test_dimx1_str(self):
         result = ReactTable(mock_dataset.fields.wins).transform(
-            dimx1_str_df, mock_dataset, [mock_dataset.fields.political_party], []
+            dimx1_str_df, [mock_dataset.fields.political_party], []
         )
 
         self.assertEqual(
@@ -324,7 +323,7 @@ class ReactTableTransformerTests(TestCase):
 
     def test_dimx1_int(self):
         result = ReactTable(mock_dataset.fields.wins).transform(
-            dimx1_num_df, mock_dataset, [mock_dataset.fields["candidate-id"]], []
+            dimx1_num_df, [mock_dataset.fields["candidate-id"]], []
         )
 
         self.assertEqual(
@@ -386,7 +385,6 @@ class ReactTableTransformerTests(TestCase):
     def test_dimx2_date_str(self):
         result = ReactTable(mock_dataset.fields.wins).transform(
             dimx2_date_str_df,
-            mock_dataset,
             [day(mock_dataset.fields.timestamp), mock_dataset.fields.political_party],
             [],
         )
@@ -437,7 +435,7 @@ class ReactTableTransformerTests(TestCase):
             Rollup(mock_dataset.fields.political_party),
         ]
         result = ReactTable(mock_dataset.fields.wins).transform(
-            dimx2_date_str_totals_df, mock_dataset, dimensions, []
+            dimx2_date_str_totals_df, dimensions, []
         )
 
         self.assertIn("data", result)
@@ -498,7 +496,7 @@ class ReactTableTransformerTests(TestCase):
             Rollup(mock_dataset.fields.political_party),
         ]
         result = ReactTable(mock_dataset.fields.wins).transform(
-            dimx2_date_str_totalsx2_df, mock_dataset, dimensions, []
+            dimx2_date_str_totalsx2_df, dimensions, []
         )
         self.assertIn("data", result)
         result["data"] = (
@@ -567,7 +565,7 @@ class ReactTableTransformerTests(TestCase):
         ]
         references = [ElectionOverElection(mock_dataset.fields.timestamp)]
         result = ReactTable(mock_dataset.fields.votes).transform(
-            dimx2_date_str_ref_df, mock_dataset, dimensions, references
+            dimx2_date_str_ref_df, dimensions, references
         )
 
         self.assertIn("data", result)
@@ -621,7 +619,7 @@ class ReactTableTransformerTests(TestCase):
         references = [ElectionOverElection(mock_dataset.fields.timestamp)]
         result = ReactTable(
             mock_dataset.fields.votes, mock_dataset.fields.wins
-        ).transform(dimx2_date_str_ref_df, mock_dataset, dimensions, references)
+        ).transform(dimx2_date_str_ref_df, dimensions, references)
 
         self.assertIn("data", result)
         result["data"] = result["data"][
@@ -675,7 +673,7 @@ class ReactTableTransformerTests(TestCase):
     def test_transpose(self):
         dimensions = [mock_dataset.fields.political_party]
         result = ReactTable(mock_dataset.fields.wins, transpose=True).transform(
-            dimx1_str_df, mock_dataset, dimensions, []
+            dimx1_str_df, dimensions, []
         )
 
         self.assertEqual(
@@ -701,7 +699,7 @@ class ReactTableTransformerTests(TestCase):
     def test_transpose_without_dimension(self):
         result = ReactTable(
             mock_dataset.fields.votes, mock_dataset.fields.wins, transpose=True
-        ).transform(dimx1_none_df, mock_dataset, [], [])
+        ).transform(dimx1_none_df, [], [])
 
         self.assertEqual(
             {
@@ -727,7 +725,7 @@ class ReactTableTransformerTests(TestCase):
         ]
         result = ReactTable(
             mock_dataset.fields.wins, pivot=[mock_dataset.fields.timestamp]
-        ).transform(dimx2_date_str_df, mock_dataset, dimensions, [])
+        ).transform(dimx2_date_str_df, dimensions, [])
 
         self.assertIn("data", result)
         result["data"] = result["data"][
@@ -786,7 +784,7 @@ class ReactTableTransformerTests(TestCase):
         ]
         result = ReactTable(
             mock_dataset.fields.wins, pivot=[mock_dataset.fields.timestamp], sort=[0]
-        ).transform(dimx2_date_str_df, mock_dataset, dimensions, [])
+        ).transform(dimx2_date_str_df, dimensions, [])
 
         self.assertIn("data", result)
         result["data"] = result["data"][
@@ -845,7 +843,7 @@ class ReactTableTransformerTests(TestCase):
         ]
         result = ReactTable(
             mock_dataset.fields.wins, pivot=[mock_dataset.fields.political_party]
-        ).transform(dimx2_date_str_df, mock_dataset, dimensions, [])
+        ).transform(dimx2_date_str_df, dimensions, [])
 
         self.assertIn("data", result)
         result["data"] = result["data"][
@@ -897,7 +895,7 @@ class ReactTableTransformerTests(TestCase):
             mock_dataset.fields.wins,
             mock_dataset.fields.votes,
             pivot=[mock_dataset.fields.political_party],
-        ).transform(dimx2_date_str_df, mock_dataset, dimensions, [])
+        ).transform(dimx2_date_str_df, dimensions, [])
 
         self.assertIn("data", result)
         result["data"] = result["data"][
@@ -973,7 +971,7 @@ class ReactTableTransformerTests(TestCase):
             mock_dataset.fields.votes,
             mock_dataset.fields.wins,
             pivot=[mock_dataset.fields.political_party],
-        ).transform(dimx2_date_str_ref_df, mock_dataset, dimensions, references)
+        ).transform(dimx2_date_str_ref_df, dimensions, references)
 
         self.assertIn("data", result)
         result["data"] = result["data"][
@@ -1073,7 +1071,7 @@ class ReactTableTransformerTests(TestCase):
         result = ReactTable(
             mock_dataset.fields.wins, pivot=[mock_dataset.fields["candidate-id"]]
         ).transform(
-            dimx1_num_df, mock_dataset, [mock_dataset.fields["candidate-id"]], []
+            dimx1_num_df, [mock_dataset.fields["candidate-id"]], []
         )
 
         self.assertEqual(
@@ -1118,7 +1116,7 @@ class ReactTableTransformerTests(TestCase):
             pivot=[mock_dataset.fields["candidate-id"]],
             transpose=True,
         ).transform(
-            dimx1_num_df, mock_dataset, [mock_dataset.fields["candidate-id"]], []
+            dimx1_num_df, [mock_dataset.fields["candidate-id"]], []
         )
 
         self.assertEqual(
@@ -1183,7 +1181,7 @@ class ReactTableTransformerTests(TestCase):
             mock_dataset.fields.votes,
             pivot=[mock_dataset.fields["candidate-id"]],
         ).transform(
-            dimx1_num_df, mock_dataset, [mock_dataset.fields["candidate-id"]], []
+            dimx1_num_df, [mock_dataset.fields["candidate-id"]], []
         )
 
         self.assertEqual(
@@ -1238,7 +1236,7 @@ class ReactTableTransformerTests(TestCase):
 
     def test_dimx1_date_metricx1(self):
         result = ReactTable(mock_dataset.fields.wins).transform(
-            dimx1_date_df, mock_dataset, [day(mock_dataset.fields.timestamp)], []
+            dimx1_date_df, [day(mock_dataset.fields.timestamp)], []
         )
 
         self.assertEqual(
@@ -1302,7 +1300,7 @@ class ReactTableTransformerTests(TestCase):
         ]
         result = ReactTable(
             mock_dataset.fields.votes, pivot=[mock_dataset.fields.political_party]
-        ).transform(dimx2_date_str_totalsx2_df, mock_dataset, dimensions, [])
+        ).transform(dimx2_date_str_totalsx2_df, dimensions, [])
 
         self.assertIn("data", result)
         result["data"] = (
@@ -1366,7 +1364,7 @@ class ReactTableTransformerTests(TestCase):
         dimensions = [Rollup(day(mock_dataset.fields.timestamp)), political_party]
         result = ReactTable(
             mock_dataset.fields.wins, mock_dataset.fields.votes, pivot=[political_party]
-        ).transform(dimx2_date_str_totalsx2_df, mock_dataset, dimensions, [])
+        ).transform(dimx2_date_str_totalsx2_df, dimensions, [])
 
         self.assertIn("data", result)
         result["data"] = (
@@ -1466,7 +1464,7 @@ class ReactTableTransformerTests(TestCase):
         dimensions = [Rollup(day(mock_dataset.fields.timestamp)), political_party]
         result = ReactTable(
             mock_dataset.fields.wins, mock_dataset.fields.votes, pivot=[political_party]
-        ).transform(dimx2_date_str_totalsx2_df, mock_dataset, dimensions, [])
+        ).transform(dimx2_date_str_totalsx2_df, dimensions, [])
 
         self.assertIn("data", result)
         result["data"] = result["data"][
@@ -1590,7 +1588,7 @@ class ReactTableTransformerTests(TestCase):
             mock_dataset.fields.votes,
             pivot=[political_party],
             transpose=True,
-        ).transform(dimx2_date_str_totalsx2_df, mock_dataset, dimensions, [])
+        ).transform(dimx2_date_str_totalsx2_df, dimensions, [])
 
         self.assertIn("data", result)
         result["data"] = result["data"][
@@ -1658,7 +1656,7 @@ class ReactTableTransformerTests(TestCase):
             mock_dataset.fields.votes,
             pivot=[mock_dataset.fields.political_party],
             transpose=True,
-        ).transform(dimx2_date_str_totalsx2_df, mock_dataset, dimensions, [])
+        ).transform(dimx2_date_str_totalsx2_df, dimensions, [])
 
         self.assertIn("data", result)
         result["data"] = result["data"][
@@ -1720,13 +1718,9 @@ class ReactTableTransformerTests(TestCase):
 class ReactTableHyperlinkTransformerTests(TestCase):
     maxDiff = None
 
-    @classmethod
-    def setUpClass(cls):
-        cls.slicer = mock_dataset
-
     def test_add_hyperlink_with_formatted_values(self):
-        result = ReactTable(self.slicer.fields.wins).transform(
-            dimx1_str_df, self.slicer, [self.slicer.fields.political_party], []
+        result = ReactTable(mock_dataset.fields.wins).transform(
+            dimx1_str_df, [mock_dataset.fields.political_party], []
         )
 
         self.assertEqual(
@@ -1763,9 +1757,9 @@ class ReactTableHyperlinkTransformerTests(TestCase):
         )
 
     def test_do_not_add_hyperlink_to_pivoted_dimensions(self):
-        dimensions = [self.slicer.fields.political_party]
-        result = ReactTable(self.slicer.fields.wins, pivot=dimensions).transform(
-            dimx1_str_df, self.slicer, dimensions, []
+        dimensions = [mock_dataset.fields.political_party]
+        result = ReactTable(mock_dataset.fields.wins, pivot=dimensions).transform(
+            dimx1_str_df, dimensions, []
         )
 
         self.assertEqual(
@@ -1791,8 +1785,8 @@ class ReactTableHyperlinkTransformerTests(TestCase):
     def test_dim_with_hyperlink_depending_on_another_dim_not_included_if_other_dim_is_not_selected(
         self,
     ):
-        result = ReactTable(self.slicer.fields.wins).transform(
-            dimx1_str_df, self.slicer, [self.slicer.fields.political_party], []
+        result = ReactTable(mock_dataset.fields.wins).transform(
+            dimx1_str_df, [mock_dataset.fields.political_party], []
         )
 
         self.assertIn("data", result)
@@ -1829,10 +1823,9 @@ class ReactTableHyperlinkTransformerTests(TestCase):
     def test_dim_with_hyperlink_depending_on_another_dim_included_if_other_dim_is_selected(
         self,
     ):
-        result = ReactTable(self.slicer.fields.wins).transform(
+        result = ReactTable(mock_dataset.fields.wins).transform(
             dimx2_str_str_df,
-            self.slicer,
-            [self.slicer.fields.political_party, self.slicer.fields["candidate-name"]],
+            [mock_dataset.fields.political_party, mock_dataset.fields["candidate-name"]],
             [],
         )
 

--- a/fireant/widgets/base.py
+++ b/fireant/widgets/base.py
@@ -62,7 +62,7 @@ class TransformableWidget(Widget):
     # should be applied to the number of series rather than the number of data points.
     group_pagination = False
 
-    def transform(self, data_frame, dataset, dimensions, references, annotation_frame=None):
+    def transform(self, data_frame, dimensions, references, annotation_frame=None):
         """
         - Main entry point -
 
@@ -71,8 +71,6 @@ class TransformableWidget(Widget):
 
         :param data_frame:
             The data frame containing the data. Index must match the dimensions parameter.
-        :param dataset:
-            The dataset that is in use.
         :param dimensions:
             A list of dimensions that are being rendered.
         :param references:

--- a/fireant/widgets/csv.py
+++ b/fireant/widgets/csv.py
@@ -16,14 +16,13 @@ class CSV(Pandas):
     def transform(
         self,
         data_frame,
-        slicer,
         dimensions,
         references,
         annotation_frame=None,
         use_raw_values=None,
     ):
         result_df = super(CSV, self).transform(
-            data_frame, slicer, dimensions, references, use_raw_values=True
+            data_frame, dimensions, references, use_raw_values=True
         )
         # Unset the column level names because they're a bit confusing in a csv file
         result_df.columns.names = [None] * len(result_df.columns.names)

--- a/fireant/widgets/highcharts.py
+++ b/fireant/widgets/highcharts.py
@@ -69,7 +69,7 @@ class HighCharts(ChartWidget, TransformableWidget):
         return ".".join(["HighCharts()"] + [repr(axis) for axis in self.items])
 
     def transform(
-        self, data_frame, dataset, dimensions, references, annotation_frame=None
+        self, data_frame, dimensions, references, annotation_frame=None
     ):
         """
         - Main entry point -
@@ -80,8 +80,6 @@ class HighCharts(ChartWidget, TransformableWidget):
 
         :param data_frame:
             The data frame containing the data. Index must match the dimensions parameter.
-        :param dataset:
-            The slicer that is in use.
         :param dimensions:
             A list of dimensions that are being rendered.
         :param references:
@@ -143,7 +141,7 @@ class HighCharts(ChartWidget, TransformableWidget):
                 is_timeseries,
             )
 
-        x_axis = self._render_x_axis(data_frame, dimensions, dataset.fields)
+        x_axis = self._render_x_axis(data_frame, dimensions, dimension_map)
 
         annotations = []
         if has_only_line_series(axis) and annotation_frame is not None:
@@ -164,7 +162,7 @@ class HighCharts(ChartWidget, TransformableWidget):
             "annotations": annotations,
         }
 
-    def _render_x_axis(self, data_frame, dimensions, fields):
+    def _render_x_axis(self, data_frame, dimensions, dimension_map):
         """
         Renders the xAxis configuration.
 
@@ -172,6 +170,7 @@ class HighCharts(ChartWidget, TransformableWidget):
 
         :param data_frame:
         :param dimensions:
+        :param dimension_map:
         :return:
         """
         is_mi = isinstance(data_frame.index, pd.MultiIndex)
@@ -183,8 +182,8 @@ class HighCharts(ChartWidget, TransformableWidget):
 
         categories = ["All"]
         if first_level.name is not None:
-            dimension_alias = utils.alias_for_alias_selector(first_level.name)
-            dimension = fields[dimension_alias]
+            dimension_alias = first_level.name
+            dimension = dimension_map[dimension_alias]
             categories = [
                 formats.display_value(category, dimension) or category
                 for category in first_level

--- a/fireant/widgets/matplotlib.py
+++ b/fireant/widgets/matplotlib.py
@@ -26,7 +26,7 @@ class Matplotlib(ChartWidget, TransformableWidget):
         super(Matplotlib, self).__init__()
         self.title = title
 
-    def transform(self, data_frame, dataset, dimensions, references, annotation_frame=None):
+    def transform(self, data_frame, dimensions, references, annotation_frame=None):
         import matplotlib.pyplot as plt
         data_frame = data_frame.copy()
 

--- a/fireant/widgets/pandas.py
+++ b/fireant/widgets/pandas.py
@@ -35,7 +35,6 @@ class Pandas(TransformableWidget):
     def transform(
         self,
         data_frame,
-        dataset,
         dimensions,
         references,
         annotation_frame=None,
@@ -45,7 +44,6 @@ class Pandas(TransformableWidget):
         WRITEME
 
         :param data_frame:
-        :param dataset:
         :param dimensions:
         :param references:
         :param annotation_frame:

--- a/fireant/widgets/reacttable.py
+++ b/fireant/widgets/reacttable.py
@@ -477,7 +477,6 @@ class ReactTable(Pandas):
     def transform(
         self,
         data_frame,
-        dataset,
         dimensions,
         references,
         annotation_frame=None,
@@ -489,8 +488,6 @@ class ReactTable(Pandas):
 
         :param data_frame:
             The result set data frame
-        :param dataset:
-            The dataset that generated the data query
         :param dimensions:
             A list of dimensions that were selected in the data query
         :param references:


### PR DESCRIPTION
Also removed dataset/slicer arg from Widget.transform method, given it's not used anywhere anymore. The only place it was used was in the highcharts widget, but that's no longer the case.