### PR TITLE
Add hide arg to pandas based widgets

### DIFF
--- a/fireant/dataset/klass.py
+++ b/fireant/dataset/klass.py
@@ -1,15 +1,13 @@
 import itertools
 
-from fireant.utils import (
-    immutable,
-    deepcopy,
-    ordered_distinct_list,
-    ordered_distinct_list_by_attr,
-)
 from fireant.queries.builder import (
     DataSetQueryBuilder,
     DimensionChoicesQueryBuilder,
     DimensionLatestQueryBuilder,
+)
+from fireant.utils import (
+    deepcopy,
+    immutable,
 )
 
 

--- a/fireant/queries/builder/dimension_choices_query_builder.py
+++ b/fireant/queries/builder/dimension_choices_query_builder.py
@@ -23,12 +23,12 @@ class DimensionChoicesQueryBuilder(QueryBuilder):
         super(DimensionChoicesQueryBuilder, self).__init__(dataset, dataset.table)
 
         self.hint_table = getattr(dimension, "hint_table", None)
-        self.dimensions.append(dimension)
+        self._dimensions.append(dimension)
 
         # TODO remove after 3.0.0
         display_alias = dimension.alias + "_display"
         if display_alias in dataset.fields:
-            self.dimensions.append(dataset.fields[display_alias])
+            self._dimensions.append(dataset.fields[display_alias])
 
     def _extract_hint_filters(self):
         """

--- a/fireant/queries/sets.py
+++ b/fireant/queries/sets.py
@@ -95,7 +95,7 @@ def apply_set_dimensions(fields, filters):
     set_filters = [fltr for fltr in filters if isinstance(fltr, ResultSet)]
 
     if not set_filters:
-        return fields
+        return [*fields]
 
     fields_per_set_filter = {
         set_filter.field: set_filter for set_filter in set_filters

--- a/fireant/tests/queries/test_build_orderbys.py
+++ b/fireant/tests/queries/test_build_orderbys.py
@@ -12,7 +12,7 @@ class QueryBuilderOrderTests(TestCase):
 
     def test_build_query_order_by(self):
         queries = mock_dataset.query \
-            .widget(f.ReactTable(mock_dataset.fields.votes)) \
+            .widget(f.Pandas(mock_dataset.fields.votes)) \
             .dimension(timestamp_daily) \
             .orderby(timestamp_daily) \
             .sql
@@ -28,7 +28,7 @@ class QueryBuilderOrderTests(TestCase):
 
     def test_build_query_order_by_asc(self):
         queries = mock_dataset.query \
-            .widget(f.ReactTable(mock_dataset.fields.votes)) \
+            .widget(f.Pandas(mock_dataset.fields.votes)) \
             .dimension(timestamp_daily) \
             .orderby(timestamp_daily, orientation=Order.asc) \
             .sql
@@ -44,7 +44,7 @@ class QueryBuilderOrderTests(TestCase):
 
     def test_build_query_order_by_desc(self):
         queries = mock_dataset.query \
-            .widget(f.ReactTable(mock_dataset.fields.votes)) \
+            .widget(f.Pandas(mock_dataset.fields.votes)) \
             .dimension(timestamp_daily) \
             .orderby(timestamp_daily, orientation=Order.desc) \
             .sql
@@ -60,7 +60,7 @@ class QueryBuilderOrderTests(TestCase):
 
     def test_build_query_order_by_aggregate_field(self):
         queries = mock_dataset.query \
-            .widget(f.ReactTable(mock_dataset.fields.votes)) \
+            .widget(f.Pandas(mock_dataset.fields.votes)) \
             .dimension(timestamp_daily) \
             .orderby(mock_dataset.fields.votes) \
             .sql
@@ -76,7 +76,7 @@ class QueryBuilderOrderTests(TestCase):
 
     def test_build_query_order_by_aggregate_field_asc(self):
         queries = mock_dataset.query \
-            .widget(f.ReactTable(mock_dataset.fields.votes)) \
+            .widget(f.Pandas(mock_dataset.fields.votes)) \
             .dimension(timestamp_daily) \
             .orderby(mock_dataset.fields.votes, orientation=Order.asc) \
             .sql
@@ -92,7 +92,7 @@ class QueryBuilderOrderTests(TestCase):
 
     def test_build_query_order_by_aggregate_field_desc(self):
         queries = mock_dataset.query \
-            .widget(f.ReactTable(mock_dataset.fields.votes)) \
+            .widget(f.Pandas(mock_dataset.fields.votes)) \
             .dimension(timestamp_daily) \
             .orderby(mock_dataset.fields.votes, orientation=Order.desc) \
             .sql
@@ -108,7 +108,7 @@ class QueryBuilderOrderTests(TestCase):
 
     def test_build_query_order_by_multiple_dimensions(self):
         queries = mock_dataset.query \
-            .widget(f.ReactTable(mock_dataset.fields.votes)) \
+            .widget(f.Pandas(mock_dataset.fields.votes)) \
             .dimension(timestamp_daily, mock_dataset.fields['candidate-name']) \
             .orderby(timestamp_daily) \
             .orderby(mock_dataset.fields['candidate-name']) \
@@ -126,7 +126,7 @@ class QueryBuilderOrderTests(TestCase):
 
     def test_build_query_order_by_multiple_dimensions_with_different_orientations(self):
         queries = mock_dataset.query \
-            .widget(f.ReactTable(mock_dataset.fields.votes)) \
+            .widget(f.Pandas(mock_dataset.fields.votes)) \
             .dimension(timestamp_daily, mock_dataset.fields['candidate-name']) \
             .orderby(timestamp_daily, orientation=Order.desc) \
             .orderby(mock_dataset.fields['candidate-name'], orientation=Order.asc) \
@@ -144,7 +144,7 @@ class QueryBuilderOrderTests(TestCase):
 
     def test_build_query_order_by_aggregate_fields_and_fields(self):
         queries = mock_dataset.query \
-            .widget(f.ReactTable(mock_dataset.fields.votes)) \
+            .widget(f.Pandas(mock_dataset.fields.votes)) \
             .dimension(timestamp_daily) \
             .orderby(timestamp_daily) \
             .orderby(mock_dataset.fields.votes) \
@@ -161,7 +161,7 @@ class QueryBuilderOrderTests(TestCase):
 
     def test_build_query_order_by_aggregate_fields_and_fields_with_different_orientations(self):
         queries = mock_dataset.query \
-            .widget(f.ReactTable(mock_dataset.fields.votes)) \
+            .widget(f.Pandas(mock_dataset.fields.votes)) \
             .dimension(timestamp_daily) \
             .orderby(timestamp_daily, orientation=Order.asc) \
             .orderby(mock_dataset.fields.votes, orientation=Order.desc) \
@@ -178,7 +178,7 @@ class QueryBuilderOrderTests(TestCase):
 
     def test_build_query_order_by_field_not_selected_in_query_added_to_selects(self):
         queries = mock_dataset.query \
-            .widget(f.ReactTable(mock_dataset.fields.votes)) \
+            .widget(f.Pandas(mock_dataset.fields.votes)) \
             .dimension(timestamp_daily) \
             .orderby(mock_dataset.fields.wins) \
             .sql

--- a/fireant/tests/widgets/test_csv.py
+++ b/fireant/tests/widgets/test_csv.py
@@ -16,6 +16,7 @@ from fireant.tests.dataset.mocks import (
     dimx2_date_num_df,
     dimx2_date_str_df,
     dimx2_date_str_ref_df,
+    dimx2_str_str_df,
     mock_dataset,
 )
 from fireant.tests.widgets.test_pandas import _format_float
@@ -108,6 +109,19 @@ class CSVWidgetTests(TestCase):
         expected = dimx2_date_str_df.copy()[[f('wins')]]
         expected.index.names = ['Timestamp', 'Party']
         expected.columns = ['Wins']
+
+        self.assertEqual(expected.to_csv(**csv_options), result)
+
+    def test_hidden_dimx2_date_str(self):
+        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
+        result = CSV(mock_dataset.fields.wins, hide=[mock_dataset.fields.political_party]) \
+            .transform(dimx2_date_str_df, dimensions, [])
+
+        expected = dimx2_date_str_df.copy()[[f('wins')]]
+        expected.reset_index('$political_party', inplace=True, drop=True)
+        expected.index.names = ['Timestamp']
+        expected.columns = ['Wins']
+        expected.columns.name = 'Metrics'
 
         self.assertEqual(expected.to_csv(**csv_options), result)
 

--- a/fireant/tests/widgets/test_highcharts.py
+++ b/fireant/tests/widgets/test_highcharts.py
@@ -23,6 +23,8 @@ from fireant.tests.dataset.mocks import (
     dimx2_date_str_totalsx2_df,
     dimx2_str_num_df,
     dimx2_category_index_str_df,
+    dimx2_str_str_df,
+    dimx3_date_str_str_df,
     mock_dataset,
     year,
 )
@@ -298,7 +300,7 @@ class HighChartsLineChartTransformerTests(TestCase):
         )
 
     def test_single_metric_with_uni_dim_line_chart(self):
-        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.state]
+        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
         result = (
             HighCharts(title="Time Series with Unique Dimension and Single Metric")
             .axis(self.chart_class(mock_dataset.fields.votes))
@@ -397,7 +399,7 @@ class HighChartsLineChartTransformerTests(TestCase):
             )
             .transform(
                 dimx2_date_str_df,
-                [mock_dataset.fields.timestamp, mock_dataset.fields.state],
+                [mock_dataset.fields.timestamp, mock_dataset.fields.political_party],
                 [],
             )
         )
@@ -553,7 +555,7 @@ class HighChartsLineChartTransformerTests(TestCase):
             .axis(self.chart_class(mock_dataset.fields.wins))
             .transform(
                 dimx2_date_str_df,
-                [mock_dataset.fields.timestamp, mock_dataset.fields.state],
+                [mock_dataset.fields.timestamp, mock_dataset.fields.political_party],
                 [],
             )
         )
@@ -730,7 +732,7 @@ class HighChartsLineChartTransformerTests(TestCase):
             .axis(self.chart_class(mock_dataset.fields.wins))
             .transform(
                 dataframe,
-                [mock_dataset.fields.timestamp, Rollup(mock_dataset.fields.state)],
+                [mock_dataset.fields.timestamp, Rollup(mock_dataset.fields.political_party)],
                 [],
             )
         )
@@ -815,7 +817,7 @@ class HighChartsLineChartTransformerTests(TestCase):
             .axis(self.chart_class(mock_dataset.fields.wins))
             .transform(
                 dimx2_date_str_totals_df,
-                [mock_dataset.fields.timestamp, Rollup(mock_dataset.fields.state)],
+                [mock_dataset.fields.timestamp, Rollup(mock_dataset.fields.political_party)],
                 [],
             )
         )
@@ -1023,7 +1025,7 @@ class HighChartsLineChartTransformerTests(TestCase):
                 dimx2_date_str_totalsx2_df,
                 [
                     Rollup(mock_dataset.fields.timestamp),
-                    Rollup(mock_dataset.fields.state),
+                    Rollup(mock_dataset.fields.political_party),
                 ],
                 [],
             )
@@ -1222,7 +1224,7 @@ class HighChartsLineChartTransformerTests(TestCase):
         )
 
     def test_uni_dim_with_ref_line_chart(self):
-        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.state]
+        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
         references = [ElectionOverElection(mock_dataset.fields.timestamp)]
         result = (
             HighCharts(title="Time Series with Unique Dimension and Reference")
@@ -1339,7 +1341,7 @@ class HighChartsLineChartTransformerTests(TestCase):
         )
 
     def test_uni_dim_with_ref_delta_line_chart(self):
-        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.state]
+        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
         references = [ElectionOverElection(mock_dataset.fields.timestamp, delta=True)]
         result = (
             HighCharts(title="Time Series with Unique Dimension and Delta Reference")
@@ -1518,7 +1520,7 @@ class HighChartsLineChartTransformerTests(TestCase):
         )
 
     def test_ref_axes_set_to_same_visibility_as_parent_axis(self):
-        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.state]
+        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
         references = [ElectionOverElection(mock_dataset.fields.timestamp, delta=True)]
         result = (
             HighCharts(title="Time Series with Unique Dimension and Delta Reference")
@@ -1874,7 +1876,7 @@ class HighChartsBarChartTransformerTests(TestCase):
         )
 
     def test_cont_uni_dims_single_metric_bar_chart(self):
-        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.state]
+        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
         result = (
             HighCharts("Election Votes by State")
             .axis(self.chart_class(mock_dataset.fields.votes))
@@ -1957,7 +1959,7 @@ class HighChartsBarChartTransformerTests(TestCase):
         )
 
     def test_cont_uni_dims_multi_metric_single_axis_bar_chart(self):
-        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.state]
+        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
         result = (
             HighCharts(title="Election Votes by State")
             .axis(
@@ -2096,7 +2098,7 @@ class HighChartsBarChartTransformerTests(TestCase):
         )
 
     def test_cont_uni_dims_multi_metric_multi_axis_bar_chart(self):
-        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.state]
+        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
         result = (
             HighCharts(title="Election Votes by State")
             .axis(self.chart_class(mock_dataset.fields.votes))
@@ -3024,7 +3026,7 @@ class HighChartsPieChartTransformerTests(TestCase):
         )
 
     def test_pie_chart_dimx2_date_str_reference(self):
-        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.state]
+        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
         references = [ElectionOverElection(mock_dataset.fields.timestamp)]
         result = (
             HighCharts(title="Election Votes by State")

--- a/fireant/tests/widgets/test_pandas.py
+++ b/fireant/tests/widgets/test_pandas.py
@@ -12,9 +12,11 @@ from fireant.tests.dataset.mocks import (
     dimx0_metricx2_df,
     dimx1_date_df,
     dimx1_date_operation_df,
+    dimx1_num_df,
     dimx1_str_df,
     dimx2_date_str_df,
     dimx2_date_str_ref_df,
+    dimx2_str_str_df,
     mock_dataset,
     no_index_df,
 )
@@ -108,9 +110,9 @@ class PandasTransformerTests(TestCase):
 
     def test_dimx1_int(self):
         result = Pandas(mock_dataset.fields.wins) \
-            .transform(dimx1_str_df, [mock_dataset.fields['candidate-id']], [])
+            .transform(dimx1_num_df, [mock_dataset.fields['candidate-id']], [])
 
-        expected = dimx1_str_df.copy()[[f('wins')]]
+        expected = dimx1_num_df.copy()[[f('wins')]]
         expected.index.names = ['Candidate ID']
         expected.columns = ['Wins']
         expected.columns.name = 'Metrics'
@@ -167,6 +169,20 @@ class PandasTransformerTests(TestCase):
         expected.index.names = ['Timestamp']
         expected.columns = ['Democrat', 'Independent', 'Republican']
         expected.columns.names = ['Party']
+        expected = expected.applymap(_format_float)
+
+        pandas.testing.assert_frame_equal(expected, result)
+
+    def test_hidden_dimx2_date_str(self):
+        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
+        result = Pandas(mock_dataset.fields.wins, hide=[mock_dataset.fields.political_party]) \
+            .transform(dimx2_date_str_df, dimensions, [])
+
+        expected = dimx2_date_str_df.copy()[[f('wins')]]
+        expected.reset_index('$political_party', inplace=True, drop=True)
+        expected.index.names = ['Timestamp']
+        expected.columns = ['Wins']
+        expected.columns.name = 'Metrics'
         expected = expected.applymap(_format_float)
 
         pandas.testing.assert_frame_equal(expected, result)

--- a/fireant/tests/widgets/test_reacttable.py
+++ b/fireant/tests/widgets/test_reacttable.py
@@ -825,6 +825,46 @@ class ReactTableTransformerTests(TestCase):
             result,
         )
 
+    def test_dimx2_hide_dim1(self):
+        dimensions = [
+            day(mock_dataset.fields.timestamp),
+            mock_dataset.fields.political_party,
+        ]
+        result = ReactTable(
+            mock_dataset.fields.wins, hide=[mock_dataset.fields.political_party]
+        ).transform(dimx2_date_str_df, dimensions, [])
+
+        self.assertIn("data", result)
+        result["data"] = result["data"][
+            :2
+        ]  # shorten the results to make the test easier to read
+
+        self.assertEqual(
+            {
+                'columns': [
+                    {'Header': 'Timestamp', 'accessor': '$timestamp'},
+                    {'Header': 'Wins', 'accessor': '$wins'},
+                ],
+                'data': [
+                    {
+                         '$timestamp': {
+                             'display': '1996-01-01',
+                             'raw': '1996-01-01T00:00:00'
+                         },
+                         '$wins': {'display': '2', 'raw': 2}
+                     },
+                     {
+                         '$timestamp': {
+                             'display': '1996-01-01',
+                             'raw': '1996-01-01T00:00:00'
+                         },
+                         '$wins': {'display': '0', 'raw': 0}
+                     }
+                ]
+            },
+            result,
+        )
+
     def test_dimx2_pivot_dim1(self):
         dimensions = [
             day(mock_dataset.fields.timestamp),
@@ -1965,6 +2005,49 @@ class ReactTableHyperlinkTransformerTests(TestCase):
                         "$political_party": {
                             "raw": "Democrat",
                             "hyperlink": "http://example.com/Democrat",
+                        },
+                        "$wins": {"display": "4", "raw": 4},
+                    },
+                ],
+            },
+            result,
+        )
+
+    def test_dim_with_hyperlink_depending_on_another_dim_included_if_other_dim_is_selected_even_if_hidden(
+        self,
+    ):
+        result = ReactTable(mock_dataset.fields.wins, hide=[mock_dataset.fields.political_party]).transform(
+            dimx2_str_str_df,
+            [
+                mock_dataset.fields.political_party,
+                mock_dataset.fields["candidate-name"],
+            ],
+            [],
+        )
+
+        self.assertIn("data", result)
+        result["data"] = result["data"][
+            :2
+        ]  # shorten the results to make the test easier to read
+
+        self.assertEqual(
+            {
+                "columns": [
+                    {"Header": "Candidate Name", "accessor": "$candidate-name"},
+                    {"Header": "Wins", "accessor": "$wins"},
+                ],
+                "data": [
+                    {
+                        "$candidate-name": {
+                            "hyperlink": "http://example.com/Democrat/Al Gore",
+                            "raw": "Al Gore",
+                        },
+                        "$wins": {"display": "0", "raw": 0},
+                    },
+                    {
+                        "$candidate-name": {
+                            "hyperlink": "http://example.com/Democrat/Barrack Obama",
+                            "raw": "Barrack Obama",
                         },
                         "$wins": {"display": "4", "raw": 4},
                     },

--- a/fireant/tests/widgets/test_widgets.py
+++ b/fireant/tests/widgets/test_widgets.py
@@ -15,7 +15,7 @@ class BaseWidgetTests(TestCase):
         widget = Widget(0, 1, 2).item(3)
         self.assertListEqual(widget.items, [0, 1, 2, 3])
 
-    def test_item_func_immuatable(self):
+    def test_item_func_immutable(self):
         widget1 = Widget(0, 1, 2)
         widget2 = widget1.item(3)
         self.assertIsNot(widget1, widget2)

--- a/fireant/widgets/matplotlib.py
+++ b/fireant/widgets/matplotlib.py
@@ -28,7 +28,7 @@ class Matplotlib(ChartWidget, TransformableWidget):
 
     def transform(self, data_frame, dimensions, references, annotation_frame=None):
         import matplotlib.pyplot as plt
-        data_frame = data_frame.copy()
+        result_df = data_frame.copy()
 
         n_axes = len(self.items)
         figsize = (14, 5 * n_axes)
@@ -51,7 +51,7 @@ class Matplotlib(ChartWidget, TransformableWidget):
                     f_metric_key = utils.alias_selector(reference_alias(metric, reference))
                     f_metric_label = reference_label(metric, reference)
 
-                    plot = self.get_plot_func_for_series_type(data_frame[f_metric_key], f_metric_label, series)
+                    plot = self.get_plot_func_for_series_type(result_df[f_metric_key], f_metric_label, series)
                     plot(ax=plt_axis,
                          label=axis.label,
                          color=series_color,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 six
 pandas==0.23.4
-pypika==0.37.8
+pypika==0.37.14
 toposort==1.5
 python-dateutil==2.8.1
 cryptography==2.8


### PR DESCRIPTION
This PR adds a new kwarg called hide to pandas based widgets' (i.e. pandas, csv and reacttable) constructors. Dimensions referenced in this new kwarg will be removed within the scope of a widget's transform method. The reacttable widget has a special behaviour in regard to its hyperlink handling. A hidden dimension that another hyperlink may depend on is still taken into account, when serialising a non hidden dimension.

The apply_set_dimensions was changed to return a new list, given that could result in other methods being able to change QueryBuilder._dimensions via the return of its QueryBuilder.dimensions property. A very likely source of bugs for any new implementation that created artificial dimensions, such as the set feature.

Finally, the transform methods of widgets were made more consistent in terms of what drives the final dataframe. Previously highcharts widget would use the columns in the dataframe, while pandas base widgets would use the provided dimensions. For consistency purposes the highcharts widget was changed to use the provided dimensions as well. This required some changes in highcharts' widget tests, given some tests serialised data that wasn't even part of its selected dimensions.