### PR TITLE
Add fetch only param to field

### DIFF
--- a/fireant/dataset/fields.py
+++ b/fireant/dataset/fields.py
@@ -86,10 +86,22 @@ class Field(Node):
         A precision value for rounding decimals. By default, no rounding will be applied.
 
     :param prefix: (optional)
-        A prefix for rendering labels in visualizations such as '$'
+        A prefix for rendering labels in visualizations such as '$'.
 
-    :param suffix:
-        A suffix for rendering labels in visualizations such as '€'
+    :param suffix: (optional)
+        A suffix for rendering labels in visualizations such as '€'.
+
+    :param thousands: (optional)
+        A character to be used as a thousand separator when rendering values.
+
+    :param hyperlink_template: (optional)
+        A url string that can also reference other fields in a dataset. To reference a field put its alias
+        between {}. This is only used in certain widgets (i.e. react table).
+
+    :param fetch_only: (optional)
+        Whether the field data should be ignored in widgets. This is useful for not displaying hyperlink
+        dependencies, which might be necessary only for the purpose of generating a hyperlink and have no
+        effect on the dimension grouping.
     """
 
     def __init__(
@@ -104,6 +116,7 @@ class Field(Node):
         thousands: str = None,
         precision: int = None,
         hyperlink_template: str = None,
+        fetch_only: bool = False,
     ):
         self.alias = alias
         self.data_type = data_type
@@ -115,6 +128,7 @@ class Field(Node):
         self.thousands = thousands
         self.precision = precision
         self.hyperlink_template = hyperlink_template
+        self.fetch_only = fetch_only
 
         # An artificial field is created dynamically as the query is mounted, instead of being defined during
         # instantiation. That's the case for set dimensions, for instance. The only practical aspect of this

--- a/fireant/tests/widgets/test_csv.py
+++ b/fireant/tests/widgets/test_csv.py
@@ -125,6 +125,20 @@ class CSVWidgetTests(TestCase):
 
         self.assertEqual(expected.to_csv(**csv_options), result)
 
+    def test_fetch_only_dimx2_date_str(self):
+        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
+        dimensions[1].fetch_only = True
+        result = CSV(mock_dataset.fields.wins).transform(dimx2_date_str_df, dimensions, [])
+        dimensions[1].fetch_only = False
+
+        expected = dimx2_date_str_df.copy()[[f('wins')]]
+        expected.reset_index('$political_party', inplace=True, drop=True)
+        expected.index.names = ['Timestamp']
+        expected.columns = ['Wins']
+        expected.columns.name = 'Metrics'
+
+        self.assertEqual(expected.to_csv(**csv_options), result)
+
     def test_pivoted_single_dimension_transposes_data_frame(self):
         result = CSV(mock_dataset.fields.wins, pivot=[mock_dataset.fields.political_party]) \
             .transform(dimx1_str_df, [mock_dataset.fields.political_party], [])

--- a/fireant/tests/widgets/test_highcharts.py
+++ b/fireant/tests/widgets/test_highcharts.py
@@ -299,13 +299,15 @@ class HighChartsLineChartTransformerTests(TestCase):
             result,
         )
 
-    def test_single_metric_with_uni_dim_line_chart(self):
+    def test_single_metric_with_fetch_only_uni_dim_line_chart(self):
         dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
+        dimensions[1].fetch_only = True
         result = (
             HighCharts(title="Time Series with Unique Dimension and Single Metric")
             .axis(self.chart_class(mock_dataset.fields.votes))
             .transform(dimx2_date_str_df, dimensions, [])
         )
+        dimensions[1].fetch_only = False
 
         self.assertEqual(
             {
@@ -327,53 +329,23 @@ class HighChartsLineChartTransformerTests(TestCase):
                     {
                         "color": "#DDDF0D",
                         "dashStyle": "Solid",
-                        "data": [
+                        'data': [
                             (820454400000, 7579518),
-                            (946684800000, 8294949),
-                            (1072915200000, 9578189),
-                            (1199145600000, 11803106),
-                            (1325376000000, 12424128),
-                            (1451606400000, 4871678),
-                        ],
-                        "marker": {"fillColor": "#DDDF0D", "symbol": "circle"},
-                        "name": "Votes (Democrat)",
-                        "stacking": self.stacking,
-                        "tooltip": {
-                            "valueDecimals": None,
-                            "valuePrefix": None,
-                            "valueSuffix": None,
-                        },
-                        "type": self.chart_type,
-                        "yAxis": "0",
-                    },
-                    {
-                        "color": "#55BF3B",
-                        "dashStyle": "Solid",
-                        "data": [(820454400000, 1076384)],
-                        "marker": {"fillColor": "#DDDF0D", "symbol": "square"},
-                        "name": "Votes (Independent)",
-                        "stacking": self.stacking,
-                        "tooltip": {
-                            "valueDecimals": None,
-                            "valuePrefix": None,
-                            "valueSuffix": None,
-                        },
-                        "type": self.chart_type,
-                        "yAxis": "0",
-                    },
-                    {
-                        "color": "#DF5353",
-                        "dashStyle": "Solid",
-                        "data": [
+                            (820454400000, 1076384),
                             (820454400000, 6564547),
+                            (946684800000, 8294949),
                             (946684800000, 8367068),
+                            (1072915200000, 9578189),
                             (1072915200000, 10036743),
+                            (1199145600000, 11803106),
                             (1199145600000, 9491109),
+                            (1325376000000, 12424128),
                             (1325376000000, 8148082),
+                            (1451606400000, 4871678),
                             (1451606400000, 13438835),
                         ],
-                        "marker": {"fillColor": "#DDDF0D", "symbol": "diamond"},
-                        "name": "Votes (Republican)",
+                        "marker": {"fillColor": "#DDDF0D", "symbol": "circle"},
+                        "name": "Votes",
                         "stacking": self.stacking,
                         "tooltip": {
                             "valueDecimals": None,

--- a/fireant/tests/widgets/test_pandas.py
+++ b/fireant/tests/widgets/test_pandas.py
@@ -16,7 +16,6 @@ from fireant.tests.dataset.mocks import (
     dimx1_str_df,
     dimx2_date_str_df,
     dimx2_date_str_ref_df,
-    dimx2_str_str_df,
     mock_dataset,
     no_index_df,
 )
@@ -177,6 +176,21 @@ class PandasTransformerTests(TestCase):
         dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
         result = Pandas(mock_dataset.fields.wins, hide=[mock_dataset.fields.political_party]) \
             .transform(dimx2_date_str_df, dimensions, [])
+
+        expected = dimx2_date_str_df.copy()[[f('wins')]]
+        expected.reset_index('$political_party', inplace=True, drop=True)
+        expected.index.names = ['Timestamp']
+        expected.columns = ['Wins']
+        expected.columns.name = 'Metrics'
+        expected = expected.applymap(_format_float)
+
+        pandas.testing.assert_frame_equal(expected, result)
+
+    def test_fetch_only_dimx2_date_str(self):
+        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
+        dimensions[1].fetch_only = True
+        result = Pandas(mock_dataset.fields.wins).transform(dimx2_date_str_df, dimensions, [])
+        dimensions[1].fetch_only = False
 
         expected = dimx2_date_str_df.copy()[[f('wins')]]
         expected.reset_index('$political_party', inplace=True, drop=True)

--- a/fireant/tests/widgets/test_reacttable.py
+++ b/fireant/tests/widgets/test_reacttable.py
@@ -1,9 +1,16 @@
-import pandas as pd
 from unittest import TestCase
 
+import pandas as pd
 from pypika import Table
 
-from fireant import DataType, Rollup, day, DataSet, Field, DayOverDay
+from fireant import (
+    DataSet,
+    DataType,
+    DayOverDay,
+    Field,
+    Rollup,
+    day,
+)
 from fireant.dataset.filters import ComparisonOperator
 from fireant.tests.database.mock_database import TestDatabase
 from fireant.tests.dataset.mocks import (
@@ -20,15 +27,15 @@ from fireant.tests.dataset.mocks import (
     dimx2_date_str_ref_df,
     dimx2_date_str_totals_df,
     dimx2_date_str_totalsx2_df,
-    mock_dataset,
     dimx2_str_str_df,
+    mock_dataset,
 )
 from fireant.widgets.base import ReferenceItem
 from fireant.widgets.reacttable import (
-    ReactTable,
     FormattingConditionRule,
     FormattingField,
     FormattingHeatMapRule,
+    ReactTable,
 )
 
 
@@ -733,7 +740,6 @@ class ReactTableTransformerTests(TestCase):
                         "$political_party": {
                             "display": "Totals",
                             "raw": "$totals",
-                            "hyperlink": "http://example.com/~~totals",
                         },
                         "$timestamp": {
                             "display": "2016-01-01",
@@ -804,7 +810,6 @@ class ReactTableTransformerTests(TestCase):
                         "$political_party": {
                             "display": "Totals",
                             "raw": "$totals",
-                            "hyperlink": "http://example.com/~~totals",
                         },
                         "$timestamp": {"display": "Totals", "raw": "$totals"},
                         "$wins": {"display": "12", "raw": 12.0},
@@ -978,6 +983,44 @@ class ReactTableTransformerTests(TestCase):
         result = ReactTable(
             mock_dataset.fields.wins, hide=[mock_dataset.fields.political_party]
         ).transform(dimx2_date_str_df, dimensions, [])
+
+        self.assertIn("data", result)
+        result["data"] = result["data"][:2]  # shorten the results to make the test easier to read
+
+        self.assertEqual(
+            {
+                'columns': [
+                    {'Header': 'Timestamp', 'accessor': '$timestamp'},
+                    {'Header': 'Wins', 'accessor': '$wins'},
+                ],
+                'data': [
+                    {
+                        '$timestamp': {
+                            'display': '1996-01-01',
+                            'raw': '1996-01-01T00:00:00'
+                        },
+                        '$wins': {'display': '2', 'raw': 2}
+                    },
+                    {
+                        '$timestamp': {
+                            'display': '1996-01-01',
+                            'raw': '1996-01-01T00:00:00'
+                        },
+                        '$wins': {'display': '0', 'raw': 0}
+                    }
+                ]
+            },
+            result,
+        )
+
+    def test_dimx2_fetch_only_dim1(self):
+        dimensions = [
+            day(mock_dataset.fields.timestamp),
+            mock_dataset.fields.political_party,
+        ]
+        dimensions[1].fetch_only = True
+        result = ReactTable(mock_dataset.fields.wins).transform(dimx2_date_str_df, dimensions, [])
+        dimensions[1].fetch_only = False
 
         self.assertIn("data", result)
         result["data"] = result["data"][:2]  # shorten the results to make the test easier to read

--- a/fireant/widgets/base.py
+++ b/fireant/widgets/base.py
@@ -1,5 +1,7 @@
 from typing import Union
 
+import pandas as pd
+
 from fireant.dataset.fields import Field
 from fireant.dataset.operations import Operation
 from fireant.dataset.references import Reference
@@ -11,6 +13,7 @@ from fireant.reference_helpers import (
     reference_suffix,
 )
 from fireant.utils import (
+    alias_selector,
     deepcopy,
     immutable,
 )
@@ -61,6 +64,17 @@ class TransformableWidget(Widget):
     # This attribute can be overridden in order to paginate in groups. Useful in cases like for charts where pagination
     # should be applied to the number of series rather than the number of data points.
     group_pagination = False
+
+    @staticmethod
+    def hide_data_frame_indexes(data_frame, dimensions_to_hide):
+        data_frame_indexes = (
+            [data_frame.index.name] if not isinstance(data_frame.index, pd.MultiIndex) else data_frame.index.names
+        )
+
+        for dimension in dimensions_to_hide:
+            dimesion_alias = alias_selector(dimension.alias)
+            if dimesion_alias in data_frame_indexes:
+                data_frame.reset_index(level=dimesion_alias, drop=True, inplace=True)
 
     def transform(self, data_frame, dimensions, references, annotation_frame=None):
         """

--- a/fireant/widgets/highcharts.py
+++ b/fireant/widgets/highcharts.py
@@ -98,6 +98,11 @@ class HighCharts(ChartWidget, TransformableWidget):
         """
         result_df = data_frame.copy()
 
+        hide_dimensions = {
+            dimension for dimension in dimensions if dimension.fetch_only
+        }
+        self.hide_data_frame_indexes(result_df, hide_dimensions)
+
         dimension_map = {
             alias_selector(dimension.alias): dimension for dimension in dimensions
         }
@@ -242,7 +247,7 @@ class HighCharts(ChartWidget, TransformableWidget):
         colors,
         data_frame,
         series_data_frames,
-        dimension_fields,
+        dimensions,
         references,
         is_timeseries=False,
     ):
@@ -256,7 +261,7 @@ class HighCharts(ChartWidget, TransformableWidget):
         :param axis_color:
         :param colors:
         :param series_data_frames:
-        :param dimension_fields:
+        :param dimensions:
         :param references:
         :param is_timeseries:
         :return:
@@ -270,7 +275,7 @@ class HighCharts(ChartWidget, TransformableWidget):
                 for reference in [None] + references:
                     hc_series.append(
                         self._render_pie_series(
-                            series.metric, reference, data_frame, dimension_fields
+                            series.metric, reference, data_frame, dimensions
                         )
                     )
                 continue
@@ -283,7 +288,7 @@ class HighCharts(ChartWidget, TransformableWidget):
             ):
                 dimension_values = utils.wrap_list(dimension_values)
                 dimension_label = self._format_dimension_values(
-                    dimension_fields[1:], dimension_values
+                    dimensions[1:], dimension_values
                 )
 
                 hc_series += self._render_highcharts_series(
@@ -567,8 +572,8 @@ class HighCharts(ChartWidget, TransformableWidget):
         return data_frame.groupby(level=levels, sort=False)
 
     @staticmethod
-    def _format_dimension_values(dimension_fields, dimension_values):
+    def _format_dimension_values(dimensions, dimension_values):
         return ", ".join(
-            str.strip(formats.display_value(value, dimension_field) or str(value))
-            for value, dimension_field in zip(dimension_values, dimension_fields)
+            str.strip(formats.display_value(value, dimension) or str(value))
+            for value, dimension in zip(dimension_values, dimensions)
         )

--- a/fireant/widgets/matplotlib.py
+++ b/fireant/widgets/matplotlib.py
@@ -30,6 +30,11 @@ class Matplotlib(ChartWidget, TransformableWidget):
         import matplotlib.pyplot as plt
         result_df = data_frame.copy()
 
+        hide_dimensions = {
+            dimension for dimension in dimensions if dimension.fetch_only
+        }
+        self.hide_data_frame_indexes(result_df, hide_dimensions)
+
         n_axes = len(self.items)
         figsize = (14, 5 * n_axes)
         fig, plt_axes = plt.subplots(n_axes,


### PR DESCRIPTION
This adds a fetch_only optional kwarg to Field class' dunder init. When set to true a widget will ignore the presence of such field's alias when transforming dataframes, as part of the transform method. The use case is allowing hyperlink templates to be properly generated while avoiding the dependency field to be rendered as part of the widget. Fyi hyperlink templates are only supported in react table widget.