### PR TITLE
Make tooltip.shared defaults to false in certain cases

### DIFF
--- a/fireant/tests/widgets/test_highcharts.py
+++ b/fireant/tests/widgets/test_highcharts.py
@@ -379,7 +379,7 @@ class HighChartsLineChartTransformerTests(TestCase):
                             "visible": True,
                         }
                     ],
-                    "tooltip": {"shared": True, "useHTML": True, "enabled": True},
+                    "tooltip": {"shared": False, "useHTML": True, "enabled": True},
                     "legend": {"useHTML": True},
                     "series": [
                         {
@@ -489,7 +489,7 @@ class HighChartsLineChartTransformerTests(TestCase):
                             "visible": True,
                         }
                     ],
-                    "tooltip": {"shared": True, "useHTML": True, "enabled": True},
+                    "tooltip": {"shared": False, "useHTML": True, "enabled": True},
                     "legend": {"useHTML": True},
                     "series": [
                         {
@@ -597,7 +597,7 @@ class HighChartsLineChartTransformerTests(TestCase):
                             "visible": True,
                         }
                     ],
-                    "tooltip": {"shared": True, "useHTML": True, "enabled": True},
+                    "tooltip": {"shared": False, "useHTML": True, "enabled": True},
                     "legend": {"useHTML": True},
                     "series": [
                         {
@@ -642,7 +642,7 @@ class HighChartsLineChartTransformerTests(TestCase):
                             "visible": True,
                         }
                     ],
-                    "tooltip": {"shared": True, "useHTML": True, "enabled": True},
+                    "tooltip": {"shared": False, "useHTML": True, "enabled": True},
                     "legend": {"useHTML": True},
                     "series": [
                         {
@@ -764,7 +764,7 @@ class HighChartsLineChartTransformerTests(TestCase):
                         "visible": True,
                     },
                 ],
-                "tooltip": {"shared": True, "useHTML": True, "enabled": True},
+                "tooltip": {"shared": False, "useHTML": True, "enabled": True},
                 "legend": {"useHTML": True},
                 "series": [
                     {
@@ -990,7 +990,7 @@ class HighChartsLineChartTransformerTests(TestCase):
                         "dashStyle": "Solid",
                     },
                 ],
-                "tooltip": {"shared": True, "useHTML": True, "enabled": True},
+                "tooltip": {"shared": False, "useHTML": True, "enabled": True},
                 "legend": {"useHTML": True},
             },
         )
@@ -1032,7 +1032,7 @@ class HighChartsLineChartTransformerTests(TestCase):
                         "visible": True,
                     },
                 ],
-                "tooltip": {"shared": True, "useHTML": True, "enabled": True},
+                "tooltip": {"shared": False, "useHTML": True, "enabled": True},
                 "legend": {"useHTML": True},
                 "series": [
                     {
@@ -1241,7 +1241,7 @@ class HighChartsLineChartTransformerTests(TestCase):
                         "visible": True,
                     },
                 ],
-                "tooltip": {"shared": True, "useHTML": True, "enabled": True},
+                "tooltip": {"shared": False, "useHTML": True, "enabled": True},
                 "legend": {"useHTML": True},
                 "series": [
                     {
@@ -1869,7 +1869,7 @@ class HighChartsBarChartTransformerTests(TestCase):
                         "visible": True,
                     }
                 ],
-                "tooltip": {"shared": True, "useHTML": True, "enabled": True},
+                "tooltip": {"shared": False, "useHTML": True, "enabled": True},
                 "legend": {"useHTML": True},
                 "series": [
                     {
@@ -1914,7 +1914,7 @@ class HighChartsBarChartTransformerTests(TestCase):
                         "visible": True,
                     }
                 ],
-                "tooltip": {"shared": True, "useHTML": True, "enabled": True},
+                "tooltip": {"shared": False, "useHTML": True, "enabled": True},
                 "legend": {"useHTML": True},
                 "series": [
                     {
@@ -2089,7 +2089,7 @@ class HighChartsBarChartTransformerTests(TestCase):
                         "visible": True,
                     }
                 ],
-                "tooltip": {"shared": True, "useHTML": True, "enabled": True},
+                "tooltip": {"shared": False, "useHTML": True, "enabled": True},
                 "legend": {"useHTML": True},
                 "series": [
                     {
@@ -2178,7 +2178,7 @@ class HighChartsBarChartTransformerTests(TestCase):
                         "visible": True,
                     }
                 ],
-                "tooltip": {"shared": True, "useHTML": True, "enabled": True},
+                "tooltip": {"shared": False, "useHTML": True, "enabled": True},
                 "legend": {"useHTML": True},
                 "series": [
                     {
@@ -2324,7 +2324,7 @@ class HighChartsBarChartTransformerTests(TestCase):
                         "visible": True,
                     },
                 ],
-                "tooltip": {"shared": True, "useHTML": True, "enabled": True},
+                "tooltip": {"shared": False, "useHTML": True, "enabled": True},
                 "legend": {"useHTML": True},
                 "series": [
                     {
@@ -2633,7 +2633,7 @@ class HighChartsBarChartTransformerTests(TestCase):
                         "yAxis": "0",
                     },
                 ],
-                "tooltip": {"enabled": True, "shared": True, "useHTML": True},
+                "tooltip": {"enabled": True, "shared": False, "useHTML": True},
                 "annotations": [],
                 "colors": DEFAULT_COLORS,
             },
@@ -2659,7 +2659,7 @@ class HighChartsBarChartTransformerTests(TestCase):
                         "visible": False,
                     }
                 ],
-                "tooltip": {"shared": True, "useHTML": True, "enabled": True},
+                "tooltip": {"shared": False, "useHTML": True, "enabled": True},
                 "legend": {"useHTML": True},
                 "series": [
                     {
@@ -2733,7 +2733,7 @@ class HighChartsPieChartTransformerTests(TestCase):
         self.assertEqual(
             {
                 "title": {"text": "All Votes"},
-                "tooltip": {"shared": True, "useHTML": True, "enabled": True},
+                "tooltip": {"shared": False, "useHTML": True, "enabled": True},
                 "legend": {"useHTML": True},
                 "series": [
                     {
@@ -2777,7 +2777,7 @@ class HighChartsPieChartTransformerTests(TestCase):
         self.assertEqual(
             {
                 "title": {"text": "Votes and Wins"},
-                "tooltip": {"shared": True, "useHTML": True, "enabled": True},
+                "tooltip": {"shared": False, "useHTML": True, "enabled": True},
                 "legend": {"useHTML": True},
                 "series": [
                     {
@@ -3484,7 +3484,7 @@ class HighChartsLineChartAnnotationTransformerTests(TestCase):
                         "visible": True,
                     }
                 ],
-                "tooltip": {"shared": True, "useHTML": True, "enabled": True},
+                "tooltip": {"shared": False, "useHTML": True, "enabled": True},
                 "legend": {"useHTML": True},
                 "series": [
                     {

--- a/fireant/widgets/highcharts.py
+++ b/fireant/widgets/highcharts.py
@@ -232,9 +232,11 @@ class HighCharts(ChartWidget, TransformableWidget):
             "colors": self.colors,
             "series": series,
             "tooltip": {
-                "shared": True,
                 "useHTML": True,
                 "enabled": self.tooltip_visible,
+                # When only a single datapoint per series is available, shared tooltips should be avoided.
+                # Since it looks clunky and often supersedes most of the chart.
+                "shared": all([len(item['data']) > 1 for item in series])
             },
             "legend": {"useHTML": True},
             "annotations": annotations,


### PR DESCRIPTION
Make tooltip.shared defaults to false, when only a single data point per series exists.  Since it looks clunky and often supersedes most of the chart.