### PR TITLE
Bump pandas to v1.1.1

### DIFF
--- a/fireant/queries/pagination.py
+++ b/fireant/queries/pagination.py
@@ -135,19 +135,25 @@ def _group_paginate(data_frame, start=None, end=None, orders=()):
     )
 
     def _apply_pagination(df):
-        # This function applies sorting by using the sorted dimension values as an index to select values in the right
-        # order out of the data frame. The index must be filtered to only values that are in this data frame, since
-        # there might be missing combinations of index values.
+        """
+        This function applies sorting by using the sorted dimension values as an index to select values in the right
+        order out of the data frame. The index must be filtered to only values that are in this data frame, since
+        there might be missing combinations of index values.
+        """
         dfx = df.reset_index(level=0, drop=True)
         value_in_index = sorted_dimension_values.isin(dfx.index)
         index_slice = sorted_dimension_values[value_in_index].values
 
         """
-        In the case of bool dimensions, convert index_slice to an array of literal `True`, because pandas `.loc` handles
-        lists of bool as a mask.
+        In the case of bool dimensions, convert index_slice to an array of literal `True` and/or `False`,
+        because pandas `.loc` handles lists of bool as a mask. In which `True` returns the row and `False` won't.
         """
         if bool in {type(x) for x in sorted_dimension_values}:
-            index_slice |= True
+            num_missing_entries_in_boolean_mask = len(index_slice)
+            index_slice = [False]*len(dfx.index)
+
+            for i in range(num_missing_entries_in_boolean_mask):
+                index_slice[i] = True
 
         # Need to include nulls so append them to the end of the sorted data frame
         isnull = _index_isnull(dfx)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 six
-pandas==0.23.4
+pandas==1.1.1
 pypika==0.37.14
 toposort==1.5
 python-dateutil==2.8.1

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
-        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3",
         "Programming Language :: PL/SQL",
         "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
The change in behaviour regarding _apply_pagination and its bool mask was actually the result of a bug fix in Pandas. Previously boolean masks could not match the number of rows in length, but that wasn't consistent with other loc/iloc usages. So the Pandas team changed that on 0.25.0. See https://github.com/pandas-dev/pandas/issues/26658 or the indexing section on https://pandas.pydata.org/docs/whatsnew/v0.25.0.html for more info. 