### PR TITLE
Fix set usage with pattern expressions for data blending

### DIFF
--- a/fireant/dataset/filters.py
+++ b/fireant/dataset/filters.py
@@ -113,15 +113,10 @@ class ContainsFilter(Filter):
         return self.field.definition.isin(self.values)
 
 
-class NegatedFilterMixin:
+class ExcludesFilter(ContainsFilter):
     @property
     def definition(self):
-        definition = super().definition
-        return definition.negate()
-
-
-class ExcludesFilter(NegatedFilterMixin, ContainsFilter):
-    pass
+        return self.field.definition.notin(self.values)
 
 
 class RangeFilter(Filter):
@@ -132,7 +127,7 @@ class RangeFilter(Filter):
 
     @property
     def definition(self):
-        return self.field.definition[self.start:self.stop]
+        return self.field.definition.between(self.start, self.stop)
 
 
 class PatternFilter(Filter):
@@ -149,6 +144,13 @@ class PatternFilter(Filter):
             definition |= Lower(self.field.definition).like(Lower(pattern))
 
         return definition
+
+
+class NegatedFilterMixin:
+    @property
+    def definition(self):
+        definition = super().definition
+        return definition.negate()
 
 
 class AntiPatternFilter(NegatedFilterMixin, PatternFilter):

--- a/fireant/tests/dataset/mocks.py
+++ b/fireant/tests/dataset/mocks.py
@@ -188,7 +188,7 @@ mock_spend_dataset = DataSet(
         Field(
             "state",
             label="State",
-            definition=politicians_spend_table.state,
+            definition=politicians_spend_table.state_name,
             data_type=DataType.text,
         ),
         Field(


### PR DESCRIPTION
Pattern expressions, such as like/not like, were being replaced by a field, even though its left side of the operation was a LOWER function. Besides, I have found similar issues with IN, NOT IN and BETWEEN operations. Those were also fixed and tests were added to prevent regressions.