### PR TITLE
Fix number formatting when using use_raw_value=True

### DIFF
--- a/fireant/formats.py
+++ b/fireant/formats.py
@@ -64,7 +64,7 @@ def _format_decimal(value, thousands="", precision=None, suffix=None, use_raw_va
         return value
 
     if use_raw_value:
-        precision_pattern = '{}'
+        precision_pattern = f'{{:.{precision if precision is not None else 16}f}}'
     elif precision is not None:
         precision_pattern = f'{{:{thousands}.{precision}f}}'
     else:
@@ -76,7 +76,7 @@ def _format_decimal(value, thousands="", precision=None, suffix=None, use_raw_va
         value /= 100
 
     value = precision_pattern.format(value)
-    if precision is None and value != '0':
+    if precision is None:
         value = value.rstrip('0').rstrip('.')
 
     return value

--- a/fireant/tests/test_formats.py
+++ b/fireant/tests/test_formats.py
@@ -249,6 +249,18 @@ class FormatDisplayValueStyleTests(TestCase):
         field = Field("number", None, data_type=DataType.number, suffix="€", prefix="$")
         self.assertEqual("1234", formats.display_value(1234, field, use_raw_value=True))
 
+    def test_raw_value_formats_integers_with_trailing_zeros(self):
+        field = Field("number", None, data_type=DataType.number)
+        self.assertEqual("126500", formats.display_value(126500, field, use_raw_value=True))
+
+    def test_raw_value_does_not_trim_zero_value(self):
+        field = Field("number", None, data_type=DataType.number)
+        self.assertEqual("0", formats.display_value(0, field, use_raw_value=True))
+
+    def test_raw_value_when_precision_specified(self):
+        field = Field("number", None, data_type=DataType.number, precision=4)
+        self.assertEqual("1244996.1138", formats.display_value(1244996.1138000000000000, field, use_raw_value=True))
+
     def test_converts_percentage_to_decimal_when_use_raw_value_True_and_suffix_is_percentage(self):
         field = Field("number", None, data_type=DataType.number, suffix="%")
         self.assertEqual("0.87123123131", formats.display_value(87.123123131, field, use_raw_value=True))


### PR DESCRIPTION
In some cases when precision was not applied and use_raw_value=True, integers were losing a trailing zero.