### PR TITLE
Ensure precision is retained after converting percentage to decimal

### DIFF
--- a/fireant/formats.py
+++ b/fireant/formats.py
@@ -63,17 +63,21 @@ def _format_decimal(value, thousands="", precision=None, suffix=None, use_raw_va
     if not isinstance(value, (int, float)):
         return value
 
+    if use_raw_value and suffix == '%':
+        # When raw values are required, we divide percentage values by 100 to ensure they
+        # work well with Spreadsheet applications like Excel.
+        value /= 100
+
+        # Add extra precision to offset the division
+        if precision is not None:
+            precision += 2
+
     if use_raw_value:
         precision_pattern = f'{{:.{precision if precision is not None else 16}f}}'
     elif precision is not None:
         precision_pattern = f'{{:{thousands}.{precision}f}}'
     else:
         precision_pattern = f'{{:{thousands}f}}'
-
-    if use_raw_value and suffix == '%':
-        # When raw values are required, we divide percentage values by 100 to ensure they
-        # work well with Spreadsheet applications like Excel.
-        value /= 100
 
     value = precision_pattern.format(value)
     if precision is None:

--- a/fireant/tests/test_formats.py
+++ b/fireant/tests/test_formats.py
@@ -262,5 +262,10 @@ class FormatDisplayValueStyleTests(TestCase):
         self.assertEqual("1244996.1138", formats.display_value(1244996.1138000000000000, field, use_raw_value=True))
 
     def test_converts_percentage_to_decimal_when_use_raw_value_True_and_suffix_is_percentage(self):
-        field = Field("number", None, data_type=DataType.number, suffix="%")
-        self.assertEqual("0.87123123131", formats.display_value(87.123123131, field, use_raw_value=True))
+        with self.subTest('when no precision'):
+            field = Field("number", None, data_type=DataType.number, suffix="%")
+            self.assertEqual("0.87123123131", formats.display_value(87.123123131, field, use_raw_value=True))
+
+        with self.subTest('when precision'):
+            field = Field("number", None, data_type=DataType.number, suffix="%", precision=2)
+            self.assertEqual("0.0739", formats.display_value(7.38652, field, use_raw_value=True))


### PR DESCRIPTION
This ensures the raw values after the percentage to decimal conversion match the precision shown when not setting use_raw_value=True.