### PR TITLE
Improve query cancelling with the option for delaying after exit.

### DIFF
--- a/fireant/database/base.py
+++ b/fireant/database/base.py
@@ -43,6 +43,13 @@ class Database(object):
         """
         raise NotImplementedError
 
+    def cancel(self, connection):
+        """
+        Cancel any running query.
+        """
+        if hasattr(connection, "cancel"):
+            connection.cancel()
+
     def get_column_definitions(self, schema, table, connection=None):
         """
         Return a list of column name, column data type pairs.

--- a/fireant/database/vertica.py
+++ b/fireant/database/vertica.py
@@ -1,3 +1,5 @@
+import logging
+
 from pypika import (
     Parameter, Tables,
     VerticaQuery,
@@ -69,6 +71,9 @@ class VerticaDatabase(Database):
         self.read_timeout = read_timeout
         self.type_engine = VerticaTypeEngine()
 
+    def cancel(self, connection):
+        connection.cancel()
+
     def connect(self):
         import vertica_python
 
@@ -80,6 +85,7 @@ class VerticaDatabase(Database):
             password=self.password,
             read_timeout=self.read_timeout,
             unicode_error="replace",
+            log_level=logging.WARNING,
         )
 
     def trunc_date(self, field, interval):

--- a/fireant/tests/database/test_vertica.py
+++ b/fireant/tests/database/test_vertica.py
@@ -1,3 +1,4 @@
+import logging
 from unittest import TestCase
 from unittest.mock import (
     Mock,
@@ -36,9 +37,14 @@ class TestVertica(TestCase):
 
         self.assertEqual('OK', result)
         mock_vertica.connect.assert_called_once_with(
-              host='test_host', port=1234, database='test_database',
-              user='test_user', password='password',
-              read_timeout=None, unicode_error='replace'
+            host='test_host',
+            port=1234,
+            database='test_database',
+            user='test_user',
+            password='password',
+            read_timeout=None,
+            unicode_error='replace',
+            log_level=logging.WARNING,
         )
 
     def test_trunc_hour(self):


### PR DESCRIPTION
This allows for cancelling queries using the SIGINT signal instead of relying on a KeyboardInterrupt. The KeyboardInterupt has as disadvantage that the code stops running and goes into the exception handler.

By using a signal handler on SIGINT, the executing code keeps running. When the signal handler then cancels the query, the connection will remain open until it throws a cancellation exception. This way we don't have to provide our own cancel exception but can just rely on whatever Cancelled exception the database provides.

We also add the option to inject a waiting time after closing a connection.