### PR TITLE
Strip rows over max row count from query result

### DIFF
--- a/fireant/database/vertica.py
+++ b/fireant/database/vertica.py
@@ -62,13 +62,13 @@ class VerticaDatabase(Database):
         database="vertica",
         user="vertica",
         password=None,
-        read_timeout=None,
+        connection_timeout=None,
         **kwags
     ):
         super(VerticaDatabase, self).__init__(host, port, database, **kwags)
         self.user = user
         self.password = password
-        self.read_timeout = read_timeout
+        self.connection_timeout = connection_timeout
         self.type_engine = VerticaTypeEngine()
 
     def cancel(self, connection):
@@ -83,7 +83,7 @@ class VerticaDatabase(Database):
             database=self.database,
             user=self.user,
             password=self.password,
-            read_timeout=self.read_timeout,
+            connection_timeout=self.connection_timeout,
             unicode_error="replace",
             log_level=logging.WARNING,
         )

--- a/fireant/tests/database/test_vertica.py
+++ b/fireant/tests/database/test_vertica.py
@@ -24,7 +24,7 @@ class TestVertica(TestCase):
         self.assertEqual('vertica', vertica.database)
         self.assertEqual('vertica', vertica.user)
         self.assertIsNone(vertica.password)
-        self.assertIsNone(vertica.read_timeout)
+        self.assertIsNone(vertica.connection_timeout)
 
     def test_connect(self):
         mock_vertica = Mock()
@@ -42,7 +42,7 @@ class TestVertica(TestCase):
             database='test_database',
             user='test_user',
             password='password',
-            read_timeout=None,
+            connection_timeout=None,
             unicode_error='replace',
             log_level=logging.WARNING,
         )


### PR DESCRIPTION
Some database platforms ignore any query limits, so we strip the data that goes over the limit.

Also update the vertica timeout parameter name.