### PR TITLE
Update snowflake and pypika

### DIFF
--- a/requirements-extras-snowflake.txt
+++ b/requirements-extras-snowflake.txt
@@ -1,2 +1,1 @@
-urllib3==1.24.3
-snowflake-connector-python==2.0.3
+snowflake-connector-python==2.3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 six
 pandas==1.1.1
-pypika==0.39.0
+pypika==0.43.0
 toposort==1.5
 python-dateutil==2.8.1
 cryptography==3.2


### PR DESCRIPTION
The current version of the snowflake connector depends on a pinned version of urllib.