### PR TITLE
Snowflake raises KeyboardInterrupt on cancel

### DIFF
--- a/fireant/exceptions.py
+++ b/fireant/exceptions.py
@@ -1,2 +1,6 @@
 class DataSetException(Exception):
     pass
+
+
+class QueryCancelled(Exception):
+    pass

--- a/fireant/middleware/decorators.py
+++ b/fireant/middleware/decorators.py
@@ -2,6 +2,7 @@ import signal
 import time
 from functools import wraps
 
+from fireant.exceptions import QueryCancelled
 from fireant.middleware.slow_query_logger import (
     query_logger,
     slow_query_logger,
@@ -65,6 +66,9 @@ class CancelableConnection:
         self.connection_context_manager.__exit__(exception_type, exception_value, traceback)
         if self.wait_time_after_close:
             time.sleep(self.wait_time_after_close)
+
+        if exception_type is KeyboardInterrupt:
+            raise QueryCancelled("The query was cancelled")
 
     def _handle_interrupt_signal(self, sig_num, frame):
         """

--- a/fireant/tests/test_middleware.py
+++ b/fireant/tests/test_middleware.py
@@ -7,6 +7,7 @@ from unittest.mock import (
     patch,
 )
 
+from fireant.exceptions import QueryCancelled
 from fireant.middleware.concurrency import ThreadPoolConcurrencyMiddleware
 from fireant.middleware.decorators import connection_middleware, CancelableConnection
 
@@ -64,6 +65,23 @@ class TestConnectionMiddleware(TestCase):
             call(signal.SIGINT, cancelable_connection_manager._handle_interrupt_signal),
             call(signal.SIGINT, signal.default_int_handler),
         ])
+
+    @patch("fireant.middleware.decorators.signal.signal")
+    def test_cancelable_connection_transforms_keyboard_intterupt_in_cancelled_query(self, mock_attach_signal):
+        mock_connection = MagicMock()
+        mock_database_object = MagicMock()
+        mock_database_object.connect.return_value.__enter__.return_value = mock_connection
+
+        cancelable_connection_manager = CancelableConnection(mock_database_object)
+        with self.assertRaises(QueryCancelled):
+            with cancelable_connection_manager:
+                raise KeyboardInterrupt()
+
+        mock_attach_signal.assert_has_calls([
+            call(signal.SIGINT, cancelable_connection_manager._handle_interrupt_signal),
+            call(signal.SIGINT, signal.default_int_handler),
+        ])
+
 
     @patch("fireant.middleware.decorators.time")
     def test_cancelable_connection_sleeps_if_wait_time_after_close_is_set(self, mock_time):


### PR DESCRIPTION
We need to catch the KeyboardInterrupt and raise a different exception as a KeyboardInterrupt causes a Huey worker to end.
Only the snowflake connector has this issue as this connector attaches signal handlers itself to detect for cancellation.

We could make this behaviour database specific in the future, but I think for now this is fine.