### PR TITLE
Use DB-specific pypika class in datablending

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,7 @@
 [report]
 omit = */tests/*
+
+[run]
+source = fireant
+relative_files = True
+command_line = -m unittest discover

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,11 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: psf/black@stable

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,0 +1,37 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install coveralls
+
+      - name: Run test suite
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tox
+          coveralls

--- a/fireant/queries/builder/dataset_blender_query_builder.py
+++ b/fireant/queries/builder/dataset_blender_query_builder.py
@@ -1,8 +1,9 @@
 import copy
 from typing import List
 
-from pypika import JoinType, Query
+from pypika import JoinType
 
+from fireant.dataset.fields import is_metric_field
 from fireant.queries.builder.dataset_query_builder import DataSetQueryBuilder
 from fireant.queries.finders import (
     find_dataset_fields,
@@ -13,15 +14,9 @@ from fireant.queries.finders import (
 )
 from fireant.queries.sql_transformer import make_slicer_query_with_totals_and_references
 from fireant.reference_helpers import reference_type_alias
-from fireant.utils import (
-    alias_selector,
-    listify,
-    ordered_distinct_list_by_attr,
-    filter_nones,
-)
+from fireant.utils import alias_selector, filter_nones, listify, ordered_distinct_list_by_attr
 from fireant.widgets.base import Widget
 from ..sets import apply_set_dimensions, omit_set_filters
-from fireant.dataset.fields import is_metric_field
 
 
 @listify
@@ -286,9 +281,9 @@ def _get_sq_field_for_blender_field(field, queries, field_maps, reference=None):
 
 
 def _perform_join_operations(
-    dimensions, base_query, base_field_map, join_queries, join_field_maps
+    base_query_cls, dimensions, base_query, base_field_map, join_queries, join_field_maps
 ):
-    blender_query = Query.from_(base_query, immutable=False)
+    blender_query = base_query_cls.from_(base_query, immutable=False)
     for join_sql, join_field_map in zip(join_queries, join_field_maps):
         if join_sql is None:
             continue
@@ -310,14 +305,14 @@ def _perform_join_operations(
     return blender_query
 
 
-def _blend_query(dimensions, metrics, orders, field_maps, queries):
+def _blend_query(base_query_cls, dimensions, metrics, orders, field_maps, queries):
     base_query, *join_queries = queries
     base_field_map, *join_field_maps = field_maps
 
     reference = base_query._references[0] if base_query._references else None
 
     blender_query = _perform_join_operations(
-        dimensions, base_query, base_field_map, join_queries, join_field_maps
+        base_query_cls, dimensions, base_query, base_field_map, join_queries, join_field_maps
     )
 
     # WARNING: In order to make complex fields work, the get_sql for each field is monkey patched in. This must
@@ -550,6 +545,7 @@ class DataSetBlenderQueryBuilder(DataSetQueryBuilder):
         blended_queries = []
         for queryset in query_sets:
             blended_query = _blend_query(
+                self.dataset.database.query_cls,
                 selected_blender_dimensions,
                 selected_blender_metrics,
                 self.orders,

--- a/fireant/tests/dataset/mocks.py
+++ b/fireant/tests/dataset/mocks.py
@@ -3,26 +3,34 @@ from datetime import datetime
 from unittest.mock import MagicMock, Mock
 
 import pandas as pd
+from pypika import Case, JoinType, Table, functions as fn
 
 from fireant import *
 from fireant.dataset.annotations import Annotation
 from fireant.dataset.references import ReferenceType
 from fireant.dataset.totals import get_totals_marker_for_dtype
 from fireant.utils import alias_selector as f
-from pypika import Case, JoinType, Table, functions as fn
 
 
-class TestDatabase(VerticaDatabase):
+class TestDatabaseMixin:
     # Vertica client that uses the vertica_python driver.
 
     connect = Mock()
     get_column_definitions = MagicMock(return_value=[])
 
     def __eq__(self, other):
-        return isinstance(other, TestDatabase)
+        return isinstance(other, TestDatabaseMixin)
 
 
-test_database = TestDatabase()
+class TestVerticaDatabase(TestDatabaseMixin, VerticaDatabase):
+    pass
+
+
+class TestMySQLDatabase(TestDatabaseMixin, MySQLDatabase):
+    pass
+
+
+test_database = TestVerticaDatabase()
 politicians_table = Table("politician", schema="politics")
 politicians_spend_table = Table("politician_spend", schema="politics")
 politicians_staff_table = Table("politician_staff", schema="politics")

--- a/fireant/tests/queries/test_build_data_blending.py
+++ b/fireant/tests/queries/test_build_data_blending.py
@@ -1,3 +1,4 @@
+import copy
 from unittest import TestCase
 
 from pypika import Order
@@ -75,15 +76,16 @@ class DataSetBlenderQueryBuilderTests(TestCase):
         )
 
     def test_db_specific_querybuilder_class_used_when_needed(self):
+        dataset_blender = copy.deepcopy(mock_dataset_blender)
         blender = (
-            mock_dataset_blender.query()
+            dataset_blender.query()
             .widget(
                 f.ReactTable(
-                    mock_dataset_blender.fields["candidate-spend"],
-                    mock_dataset_blender.fields["voters"],
+                    dataset_blender.fields["candidate-spend"],
+                    dataset_blender.fields["voters"],
                 )
             )
-            .dimension(f.day(mock_dataset_blender.fields.timestamp))
+            .dimension(f.day(dataset_blender.fields.timestamp))
         )
 
         # Given all mocks are based on the Vertica database, this is a quick override to avoid a lot of duplicate mocks!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.black]
+line-length = 120
+skip-string-normalization = true
+target-version = ['py36', 'py37', 'py38']
+exclude = '''
+(
+  /(
+      \.eggs         # exclude a few common directories in the
+    | \.git          # root of the project
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | _build
+    | buck-out
+    | build
+    | dist
+    | docs
+  )/
+  | setup.py
+)
+'''

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,11 +6,24 @@
 -r requirements-extras-postgresql.txt
 -r requirements-extras-mssql.txt
 -r requirements-extras-ipython.txt
-mock
-bumpversion
-black
+
+# Builds
 wheel==0.30.0
+
+# Testing / CI
+mock
+tox==3.14.3
+tox-venv==0.4.0
+tox-gh-actions==0.3.0
+coverage==5.1
+
+# Utilities
+bumpversion==0.5.3
 watchdog==0.8.3
-flake8==3.5.0
+
+# Docs
 sphinx==2.2.0
 sphinx-rtd-theme==0.4.3
+
+# Formatting
+black==20.8b1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 six
 pandas==1.1.1
-pypika==0.43.0
+pypika==0.46.0
 toposort==1.5
 python-dateutil==2.8.1
 cryptography==3.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,13 @@
 [tox]
-envlist = py36,py37,py38
+envlist = py36,py37,py38,py39
 [testenv]
 deps = -r requirements-dev.txt
-commands = python setup.py build test
+commands =
+    coverage run
+    coverage xml
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39


### PR DESCRIPTION
Previously, the generic Query class was imported and used when constructing data blending queries. This change ensures that the correct query class is used if a database that is not compatible with the Query class is used e.g. MSSQL/MySQL.

I could also look at changing pypika so each query builder class has a reference to its relevant query class if that approach is deemed better.