### PR TITLE
Pandas transformer fixes

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -27,7 +27,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install cython
           pip install -r requirements-dev.txt
-          pip install coveralls
+          pip install coveralls==3.0.0
 
       - name: Run test suite
         env:
@@ -35,4 +35,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tox
-          coveralls --service=github-actions
+          coveralls --service=github

--- a/fireant/tests/widgets/test_pandas.py
+++ b/fireant/tests/widgets/test_pandas.py
@@ -5,7 +5,10 @@ from unittest import TestCase
 import numpy as np
 import pandas as pd
 import pandas.testing
+from pypika import Table
+from pypika.analytics import Sum
 
+from fireant import DataSet, DataType, Field, Rollup
 from fireant.tests.dataset.mocks import (
     CumSum,
     ElectionOverElection,
@@ -19,6 +22,7 @@ from fireant.tests.dataset.mocks import (
     dimx2_date_str_ref_df,
     mock_dataset,
     no_index_df,
+    test_database,
 )
 from fireant.utils import alias_selector as f
 from fireant.widgets.pandas import Pandas
@@ -651,3 +655,35 @@ class PandasTransformerSortTests(TestCase):
         expected = expected.applymap(format_float)
 
         pandas.testing.assert_frame_equal(expected, result)
+
+    def test_pivoted_df_transformation_formats_totals_correctly(self):
+        test_table = Table('test')
+
+        ds = DataSet(
+            table=test_table,
+            database=test_database,
+            fields=[
+                Field('date', label='Date', definition=test_table.date, data_type=DataType.date),
+                Field('locale', label='Locale', definition=test_table.locale, data_type=DataType.text),
+                Field('company', label='Company', definition=test_table.text, data_type=DataType.text),
+                Field('metric1', label='Metric1', definition=Sum(test_table.number), data_type=DataType.number),
+                Field('metric2', label='Metric2', definition=Sum(test_table.number), data_type=DataType.number),
+            ],
+        )
+
+        df = pd.DataFrame.from_dict(
+            {
+                '$metric1': {('~~totals', '~~totals'): 3, ('za', '~~totals'): 3, ('za', 'C1'): 2, ('za', 'C2'): 1},
+                '$metric2': {('~~totals', '~~totals'): 4, ('za', '~~totals'): 4, ('za', 'C1'): 2, ('za', 'C2'): 2},
+            }
+        )
+        df.index.names = [f(ds.fields.locale.alias), f(ds.fields.company.alias)]
+
+        result = Pandas(ds.fields.metric1, ds.fields.metric2, pivot=[ds.fields.company]).transform(
+            df, [Rollup(ds.fields.locale), Rollup(ds.fields.company)], [], use_raw_values=True
+        )
+
+        self.assertEqual(['Metrics', 'Company'], list(result.columns.names))
+        self.assertEqual(['Locale'], list(result.index.names))
+        self.assertEqual(['za', 'Totals'], result.index.values.tolist())
+        self.assertEqual([['2', '1', '3', '2', '2', '4'], ['', '', '3', '', '', '4']], result.values.tolist())

--- a/fireant/tests/widgets/test_pandas.py
+++ b/fireant/tests/widgets/test_pandas.py
@@ -684,6 +684,17 @@ class PandasTransformerSortTests(TestCase):
         )
 
         self.assertEqual(['Metrics', 'Company'], list(result.columns.names))
+        self.assertEqual(
+            [
+                ('Metric1', 'C1'),
+                ('Metric1', 'C2'),
+                ('Metric1', 'Totals'),
+                ('Metric2', 'C1'),
+                ('Metric2', 'C2'),
+                ('Metric2', 'Totals'),
+            ],
+            result.columns.values.tolist(),
+        )
         self.assertEqual(['Locale'], list(result.index.names))
         self.assertEqual(['za', 'Totals'], result.index.values.tolist())
         self.assertEqual([['2', '1', '3', '2', '2', '4'], ['', '', '3', '', '', '4']], result.values.tolist())

--- a/fireant/widgets/reacttable.py
+++ b/fireant/widgets/reacttable.py
@@ -19,7 +19,7 @@ from fireant.dataset.totals import (
 )
 from fireant.formats import (
     RAW_VALUE,
-    TOTALS_VALUE,
+    TOTALS_LABEL,
     display_value,
     json_value,
     raw_value,
@@ -35,11 +35,8 @@ from fireant.utils import (
     wrap_list,
 )
 from .base import ReferenceItem
-from .pandas import Pandas
+from .pandas import F_METRICS_DIMENSION_ALIAS, METRICS_DIMENSION_ALIAS, Pandas, TotalsItem
 
-TOTALS_LABEL = "Totals"
-METRICS_DIMENSION_ALIAS = "metrics"
-F_METRICS_DIMENSION_ALIAS = alias_selector(METRICS_DIMENSION_ALIAS)
 _display_value = partial(display_value, nan_value="", null_value="")
 
 
@@ -206,12 +203,6 @@ def map_index_level(index, level, func):
     assert level == 0
 
     return index.map(func)
-
-
-class TotalsItem:
-    alias = TOTALS_VALUE
-    label = TOTALS_LABEL
-    prefix = suffix = precision = None
 
 
 class ReactTable(Pandas):


### PR DESCRIPTION
* Ensure totals values are reformatted to a human-friendly name, as this had been missed before.
* Ensure set dimensions with custom labels can be transformed. This was causing issues because the set functionality manipulates the dimension label. Previously, the Pandas transformer converted the column names to use the label before pivoting, however, the set label override caused this to break. Now, columns and index names are only converted to the labels after the pivoting has occurred.
