### PR TITLE
Fix the usage of set dimensions along with refs for data blending

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,4 +35,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tox
-          coveralls --service=github
+          coveralls --service=github-actions


### PR DESCRIPTION
This fixes an underlying issue, in which dimensions/metrics in data blending query builder, were not properly cloned. As a result of that, subsequent sql method calls could produce the wrong output. The as_ calls in _get_sq_field_for_blender_field were the main culprit. Even one of the tests were actually producing the right output, when run in conjunction with other tests, but failed when run individually. That's all fixed now.