### PR TITLE
Mysql connector update + setting up timeout and cancel

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -27,7 +27,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install cython
           pip install -r requirements-dev.txt
-          pip install coveralls==3.0.0
+          pip install "coveralls<3.0.0"
 
       - name: Run test suite
         env:
@@ -35,4 +35,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tox
-          coveralls --service=github-actions
+          coveralls

--- a/fireant/database/base.py
+++ b/fireant/database/base.py
@@ -10,6 +10,7 @@ from pypika import (
 )
 from pypika.terms import Function
 
+from fireant.exceptions import QueryCancelled
 from fireant.middleware.decorators import apply_middlewares, connection_middleware
 
 
@@ -49,6 +50,10 @@ class Database(object):
         """
         if hasattr(connection, "cancel"):
             connection.cancel()
+        else:
+            # A default cancel for databases for which no specific cancel is implemented
+            # This will force an exit of the connection context manager
+            raise QueryCancelled("Query was cancelled")
 
     def get_column_definitions(self, schema, table, connection=None):
         """

--- a/fireant/tests/database/test_mysql.py
+++ b/fireant/tests/database/test_mysql.py
@@ -24,24 +24,29 @@ class TestMySQLDatabase(TestCase):
         self.assertIsNone(self.mysql.user)
         self.assertIsNone(self.mysql.password)
 
-    @patch.object(MySQLDatabase, '_get_connection_class')
-    def test_connect(self, mock_connection_class):
+    def test_connect(self):
         mock_pymysql = Mock()
         with patch.dict('sys.modules', pymysql=mock_pymysql):
             mock_pymysql.connect.return_value = 'OK'
 
             mysql = MySQLDatabase(
-                database='test_database', host='test_host', port=1234, user='test_user', password='password'
+                database='test_database',
+                host='test_host',
+                port=1234,
+                user='test_user',
+                password='password',
+                read_timeout=180,
             )
             mysql.connect()
 
-        mock_connection_class.return_value.assert_called_once_with(
+        mock_pymysql.connect.assert_called_once_with(
             host='test_host',
             port=1234,
             db='test_database',
             charset='utf8mb4',
             user='test_user',
             password='password',
+            read_timeout=180,
             cursorclass=ANY,
         )
 

--- a/requirements-extras-mysql.txt
+++ b/requirements-extras-mysql.txt
@@ -1,1 +1,1 @@
-pymysql==0.8.0
+pymysql==1.0.2


### PR DESCRIPTION
I tested this out quite a bit and this seems to do for now. We'll probably have to implement a proper cancel for most databases if they don't implement a cancel operation.