### PR TITLE
Add hide kwarg to all widgets

### DIFF
--- a/fireant/__init__.py
+++ b/fireant/__init__.py
@@ -35,6 +35,11 @@ from .dataset.references import (
     QuarterOverQuarter,
     WeekOverWeek,
     YearOverYear,
+    DaysOverDays,
+    WeeksOverWeeks,
+    MonthsOverMonths,
+    QuartersOverQuarters,
+    YearsOverYears,
 )
 from .exceptions import DataSetException
 from .widgets import *

--- a/fireant/reference_helpers.py
+++ b/fireant/reference_helpers.py
@@ -1,8 +1,12 @@
+import pandas as pd
+
+from pypika.terms import Field
+from fireant.dataset.references import Reference
 from fireant.dataset.filters import ComparisonOperator
 from fireant.utils import alias_selector
 
 
-def reference_alias(metric, reference):
+def reference_alias(metric: Field, reference: Reference) -> str:
     """
     Format a metric key for a reference.
 
@@ -17,7 +21,7 @@ def reference_alias(metric, reference):
     return '{}_{}'.format(key, reference.alias)
 
 
-def reference_type_alias(metric, reference):
+def reference_type_alias(metric: Field, reference: Reference) -> str:
     """
     Format a metric key for a subquery selection in case of a reference.
 
@@ -32,7 +36,7 @@ def reference_type_alias(metric, reference):
     return '{}_{}'.format(key, reference.reference_type.alias)
 
 
-def reference_label(metric, reference):
+def reference_label(metric: Field, reference: Reference) -> str:
     """
     Format a metric label for a reference.
 
@@ -47,7 +51,7 @@ def reference_label(metric, reference):
     return '{} {}'.format(label, reference.label)
 
 
-def reference_prefix(metric, reference):
+def reference_prefix(metric: Field, reference: Reference) -> str:
     """
     Return the prefix for a metric displayed for a reference (or no Reference)
 
@@ -59,7 +63,7 @@ def reference_prefix(metric, reference):
     return metric.prefix
 
 
-def reference_suffix(metric, reference):
+def reference_suffix(metric: Field, reference: Reference) -> str:
     """
     Return the suffix for a metric displayed for a reference (or no Reference)
 
@@ -71,7 +75,7 @@ def reference_suffix(metric, reference):
     return metric.suffix
 
 
-def apply_reference_filters(df, reference):
+def apply_reference_filters(df: pd.DataFrame, reference: Reference) -> pd.DataFrame:
     for reference_filter in reference.filters:
         df_column_key = alias_selector(reference_alias(reference_filter.metric, reference))
         if df_column_key in df:

--- a/fireant/tests/test_fireant.py
+++ b/fireant/tests/test_fireant.py
@@ -33,7 +33,18 @@ class APITests(TestCase):
                 self.assertIn(element, vars(fireant))
 
     def test_package_exports_references(self):
-        for element in ("DayOverDay", "WeekOverWeek"):
+        for element in (
+            "DayOverDay",
+            "WeekOverWeek",
+            "MonthOverMonth",
+            "QuarterOverQuarter",
+            "YearOverYear",
+            "DaysOverDays",
+            "WeeksOverWeeks",
+            "MonthsOverMonths",
+            "QuartersOverQuarters",
+            "YearsOverYears",
+        ):
             with self.subTest(element):
                 self.assertIn(element, vars(fireant))
 

--- a/fireant/tests/widgets/test_base.py
+++ b/fireant/tests/widgets/test_base.py
@@ -1,0 +1,43 @@
+import pandas as pd
+
+from unittest import TestCase
+
+from fireant.tests.dataset.mocks import (
+    dimx2_date_str_df,
+    mock_dataset,
+)
+from fireant.widgets.base import Widget
+from fireant.utils import alias_selector
+
+
+class ReactTableTransformerTests(TestCase):
+    maxDiff = None
+
+    def test_hide_data_frame_indexes_hides_found_aliases(self):
+        widget = Widget()
+
+        base_df = dimx2_date_str_df.copy()[[alias_selector('wins'), alias_selector('votes')]]
+        result = base_df.copy()
+        widget.hide_data_frame_indexes(
+            result,
+            [
+                alias_selector(mock_dataset.fields.political_party.alias),
+                alias_selector(mock_dataset.fields.votes.alias),
+                alias_selector('unknown'),
+            ],
+        )
+
+        expected = base_df.copy()
+        expected.reset_index('$political_party', inplace=True, drop=True)
+        del expected['$votes']
+
+        pd.testing.assert_frame_equal(expected, result)
+
+    def test_hidden_aliases(self):
+        widget = Widget(hide=[mock_dataset.fields.political_party, mock_dataset.fields.votes, 'field_x'])
+
+        transform_dimensions = [mock_dataset.fields['candidate-name']]
+        self.assertSetEqual(
+            widget.hide_aliases(transform_dimensions),
+            {'$political_party', '$votes', '$field_x'},
+        )

--- a/fireant/tests/widgets/test_csv.py
+++ b/fireant/tests/widgets/test_csv.py
@@ -117,6 +117,36 @@ class CSVWidgetTests(TestCase):
 
         self.assertEqual(expected.to_csv(**csv_options), result)
 
+    def test_hidden_metric_dimx2_date_str(self):
+        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
+        references = [ElectionOverElection(mock_dataset.fields.timestamp)]
+        result = CSV(mock_dataset.fields.votes, hide=[mock_dataset.fields.votes]).transform(
+            dimx2_date_str_ref_df, dimensions, references
+        )
+
+        expected = dimx2_date_str_ref_df.copy()[[f('votes_eoe')]]
+        expected.index.names = ['Timestamp', 'Party']
+        expected.columns = ['Votes EoE']
+        expected.columns.name = 'Metrics'
+        expected = expected.applymap(format_float_raw)
+
+        self.assertEqual(expected.to_csv(**csv_options), result)
+
+    def test_hidden_ref_dimx2_date_str(self):
+        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
+        references = [ElectionOverElection(mock_dataset.fields.timestamp)]
+        result = CSV(mock_dataset.fields.votes, hide=['votes_eoe']).transform(
+            dimx2_date_str_ref_df, dimensions, references
+        )
+
+        expected = dimx2_date_str_ref_df.copy()[[f('votes')]]
+        expected.index.names = ['Timestamp', 'Party']
+        expected.columns = ['Votes']
+        expected.columns.name = 'Metrics'
+        expected = expected.applymap(format_float_raw)
+
+        self.assertEqual(expected.to_csv(**csv_options), result)
+
     def test_fetch_only_dimx2_date_str(self):
         dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
         dimensions[1].fetch_only = True

--- a/fireant/tests/widgets/test_highcharts.py
+++ b/fireant/tests/widgets/test_highcharts.py
@@ -959,6 +959,221 @@ class HighChartsLineChartTransformerTests(TestCase):
             result,
         )
 
+    def test_hidden_dim_with_single_metric_line_chart(self):
+        result = (
+            HighCharts(
+                title="Time Series with Hidden Dimension and Single Metric",
+                hide=[mock_dataset.fields.political_party],
+            )
+            .axis(self.chart_class(mock_dataset.fields.votes))
+            .transform(
+                dimx2_date_str_df,
+                [mock_dataset.fields.timestamp, mock_dataset.fields.political_party],
+                [],
+            )
+        )
+
+        self.assertEqual(
+            {
+                "title": {"text": "Time Series with Hidden Dimension and Single Metric"},
+                "xAxis": {"type": "datetime", "visible": True},
+                "yAxis": [
+                    {
+                        "id": "0",
+                        "labels": {"style": {"color": None}},
+                        "title": {"text": None},
+                        "visible": True,
+                    },
+                ],
+                "tooltip": {"shared": True, "useHTML": True, "enabled": True},
+                "legend": {"useHTML": True},
+                "series": [
+                    {
+                        "color": "#DDDF0D",
+                        "dashStyle": "Solid",
+                        "data": [
+                            (820454400000, 7579518),
+                            (820454400000, 1076384),
+                            (820454400000, 6564547),
+                            (946684800000, 8294949),
+                            (946684800000, 8367068),
+                            (1072915200000, 9578189),
+                            (1072915200000, 10036743),
+                            (1199145600000, 11803106),
+                            (1199145600000, 9491109),
+                            (1325376000000, 12424128),
+                            (1325376000000, 8148082),
+                            (1451606400000, 4871678),
+                            (1451606400000, 13438835),
+                        ],
+                        "marker": {"fillColor": "#DDDF0D", "symbol": "circle"},
+                        "name": "Votes",
+                        "stacking": self.stacking,
+                        "tooltip": {
+                            "valueDecimals": None,
+                            "valuePrefix": None,
+                            "valueSuffix": None,
+                        },
+                        "type": self.chart_type,
+                        "yAxis": "0",
+                    },
+                ],
+                "annotations": [],
+                "colors": DEFAULT_COLORS,
+            },
+            result,
+        )
+
+    def test_hidden_metric_with_single_metric_line_chart(self):
+        result = (
+            HighCharts(
+                title="Time Series with Hidden Metric and Single Metric",
+                hide=[mock_dataset.fields.votes],
+            )
+            .axis(self.chart_class(mock_dataset.fields.votes))
+            .transform(
+                dimx2_date_str_ref_df,
+                [mock_dataset.fields.timestamp, mock_dataset.fields.political_party],
+                [ElectionOverElection(mock_dataset.fields.timestamp)],
+            )
+        )
+
+        self.assertEqual(
+            {
+                "title": {"text": "Time Series with Hidden Metric and Single Metric"},
+                "xAxis": {"type": "datetime", "visible": True},
+                "yAxis": [
+                    {
+                        "id": "0",
+                        "labels": {"style": {"color": None}},
+                        "title": {"text": None},
+                        "visible": True,
+                    },
+                ],
+                "tooltip": {"shared": True, "useHTML": True, "enabled": True},
+                "legend": {"useHTML": True},
+                "series": [
+                    {
+                        "color": "#DDDF0D",
+                        "dashStyle": "Dash",
+                        "data": [
+                            (820454400000, 7579518.0),
+                            (946684800000, 6564547.0),
+                            (1072915200000, 8367068.0),
+                            (1199145600000, 10036743.0),
+                            (1325376000000, 9491109.0),
+                            (1451606400000, 8148082.0),
+                        ],
+                        "marker": {"fillColor": "#DDDF0D", "symbol": "circle"},
+                        "name": "Votes EoE (Republican)",
+                        "stacking": self.stacking,
+                        "tooltip": {
+                            "valueDecimals": None,
+                            "valuePrefix": None,
+                            "valueSuffix": None,
+                        },
+                        "type": self.chart_type,
+                        "yAxis": "0",
+                    },
+                    {
+                        'color': '#55BF3B',
+                        'dashStyle': 'Dash',
+                        'data': [
+                            (946684800000, 1076384.0),
+                            (1072915200000, 8294949.0),
+                            (1199145600000, 9578189.0),
+                            (1325376000000, 11803106.0),
+                            (1451606400000, 12424128.0),
+                        ],
+                        'marker': {'fillColor': '#DDDF0D', 'symbol': 'square'},
+                        'name': 'Votes EoE (Democrat)',
+                        'stacking': self.stacking,
+                        'tooltip': {'valueDecimals': None, 'valuePrefix': None, 'valueSuffix': None},
+                        'type': self.chart_type,
+                        'yAxis': '0',
+                    },
+                ],
+                "annotations": [],
+                "colors": DEFAULT_COLORS,
+            },
+            result,
+        )
+
+    def test_hidden_ref_with_single_metric_line_chart(self):
+        result = (
+            HighCharts(
+                title="Time Series with Hidden Reference and Single Metric",
+                hide=['votes_eoe'],
+            )
+            .axis(self.chart_class(mock_dataset.fields.votes))
+            .transform(
+                dimx2_date_str_ref_df,
+                [mock_dataset.fields.timestamp, mock_dataset.fields.political_party],
+                [ElectionOverElection(mock_dataset.fields.timestamp)],
+            )
+        )
+
+        self.assertEqual(
+            {
+                "title": {"text": "Time Series with Hidden Reference and Single Metric"},
+                "xAxis": {"type": "datetime", "visible": True},
+                "yAxis": [
+                    {
+                        "id": "0",
+                        "labels": {"style": {"color": None}},
+                        "title": {"text": None},
+                        "visible": True,
+                    },
+                ],
+                "tooltip": {"shared": True, "useHTML": True, "enabled": True},
+                "legend": {"useHTML": True},
+                "series": [
+                    {
+                        "color": "#DDDF0D",
+                        "dashStyle": "Solid",
+                        "data": [
+                            (820454400000, 6564547),
+                            (946684800000, 8367068),
+                            (1072915200000, 10036743),
+                            (1199145600000, 9491109),
+                            (1325376000000, 8148082),
+                            (1451606400000, 13438835),
+                        ],
+                        "marker": {"fillColor": "#DDDF0D", "symbol": "circle"},
+                        "name": "Votes (Republican)",
+                        "stacking": self.stacking,
+                        "tooltip": {
+                            "valueDecimals": None,
+                            "valuePrefix": None,
+                            "valueSuffix": None,
+                        },
+                        "type": self.chart_type,
+                        "yAxis": "0",
+                    },
+                    {
+                        'color': '#55BF3B',
+                        'dashStyle': 'Solid',
+                        'data': [
+                            (946684800000, 8294949),
+                            (1072915200000, 9578189),
+                            (1199145600000, 11803106),
+                            (1325376000000, 12424128),
+                            (1451606400000, 4871678),
+                        ],
+                        'marker': {'fillColor': '#DDDF0D', 'symbol': 'square'},
+                        'name': 'Votes (Democrat)',
+                        'stacking': self.stacking,
+                        'tooltip': {'valueDecimals': None, 'valuePrefix': None, 'valueSuffix': None},
+                        'type': self.chart_type,
+                        'yAxis': '0',
+                    },
+                ],
+                "annotations": [],
+                "colors": DEFAULT_COLORS,
+            },
+            result,
+        )
+
     def test_multi_dim_with_totals_line_chart_and_empty_data(self):
         dataframe = (
             pd.DataFrame()

--- a/fireant/tests/widgets/test_pandas.py
+++ b/fireant/tests/widgets/test_pandas.py
@@ -191,6 +191,36 @@ class PandasTransformerTests(TestCase):
 
         pandas.testing.assert_frame_equal(expected, result)
 
+    def test_hidden_metric_dimx2_date_str(self):
+        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
+        references = [ElectionOverElection(mock_dataset.fields.timestamp)]
+        result = Pandas(mock_dataset.fields.votes, hide=[mock_dataset.fields.votes]).transform(
+            dimx2_date_str_ref_df, dimensions, references
+        )
+
+        expected = dimx2_date_str_ref_df.copy()[[f('votes_eoe')]]
+        expected.index.names = ['Timestamp', 'Party']
+        expected.columns = ['Votes EoE']
+        expected.columns.name = 'Metrics'
+        expected = expected.applymap(format_float)
+
+        pandas.testing.assert_frame_equal(expected, result)
+
+    def test_hidden_ref_dimx2_date_str(self):
+        dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
+        references = [ElectionOverElection(mock_dataset.fields.timestamp)]
+        result = Pandas(mock_dataset.fields.votes, hide=['votes_eoe']).transform(
+            dimx2_date_str_ref_df, dimensions, references
+        )
+
+        expected = dimx2_date_str_ref_df.copy()[[f('votes')]]
+        expected.index.names = ['Timestamp', 'Party']
+        expected.columns = ['Votes']
+        expected.columns.name = 'Metrics'
+        expected = expected.applymap(format_float)
+
+        pandas.testing.assert_frame_equal(expected, result)
+
     def test_fetch_only_dimx2_date_str(self):
         dimensions = [mock_dataset.fields.timestamp, mock_dataset.fields.political_party]
         dimensions[1].fetch_only = True

--- a/fireant/tests/widgets/test_reacttable.py
+++ b/fireant/tests/widgets/test_reacttable.py
@@ -1050,6 +1050,59 @@ class ReactTableTransformerTests(TestCase):
             result,
         )
 
+    def test_dimx2_metricx2_refx2_hide_metrics(self):
+        dimensions = [
+            day(mock_dataset.fields.timestamp),
+            mock_dataset.fields.political_party,
+        ]
+        references = [ElectionOverElection(mock_dataset.fields.timestamp)]
+        result = ReactTable(
+            mock_dataset.fields.votes,
+            mock_dataset.fields.wins,
+            hide=[mock_dataset.fields.votes, mock_dataset.fields.wins],
+        ).transform(dimx2_date_str_ref_df, dimensions, references)
+
+        self.assertIn("data", result)
+        result["data"] = result["data"][:2]  # shorten the results to make the test easier to read
+
+        self.assertEqual(
+            {
+                "columns": [
+                    {"Header": "Timestamp", "accessor": "$timestamp"},
+                    {"Header": "Party", "accessor": "$political_party"},
+                    {"Header": "Votes EoE", "accessor": "$votes_eoe", 'path_accessor': ['$votes_eoe']},
+                    {"Header": "Wins EoE", "accessor": "$wins_eoe", 'path_accessor': ['$wins_eoe']},
+                ],
+                "data": [
+                    {
+                        "$political_party": {
+                            "raw": "Republican",
+                            "hyperlink": "http://example.com/Republican",
+                        },
+                        "$timestamp": {
+                            "display": "1996-01-01",
+                            "raw": "1996-01-01T00:00:00",
+                        },
+                        "$votes_eoe": {"display": "7,579,518", "raw": 7579518.0},
+                        "$wins_eoe": {"display": "2", "raw": 2.0},
+                    },
+                    {
+                        "$political_party": {
+                            "raw": "Democrat",
+                            "hyperlink": "http://example.com/Democrat",
+                        },
+                        "$timestamp": {
+                            "display": "2000-01-01",
+                            "raw": "2000-01-01T00:00:00",
+                        },
+                        "$votes_eoe": {"display": "1,076,384", "raw": 1076384.0},
+                        "$wins_eoe": {"display": "0", "raw": 0.0},
+                    },
+                ],
+            },
+            result,
+        )
+
     def test_dimx2_fetch_only_dim1(self):
         dimensions = [
             day(mock_dataset.fields.timestamp),

--- a/fireant/widgets/base.py
+++ b/fireant/widgets/base.py
@@ -1,9 +1,9 @@
-from typing import Union
-
 import pandas as pd
 
+from typing import FrozenSet, List, Optional, Union
+
 from fireant.dataset.fields import Field
-from fireant.dataset.operations import Operation
+from fireant.dataset.operations import Operation, _BaseOperation
 from fireant.dataset.references import Reference
 from fireant.exceptions import DataSetException
 from fireant.reference_helpers import (
@@ -23,12 +23,16 @@ class MetricRequiredException(DataSetException):
     pass
 
 
+HideField = Union[Field, _BaseOperation, str]
+
+
 class Widget:
-    def __init__(self, *items: Union[Field, Operation]):
+    def __init__(self, *items: Union[Field, Operation], hide: List[HideField] = None):
         self.items = list(items)
+        self.hide = hide or tuple()
 
     @immutable
-    def item(self, item):
+    def item(self, item: Union[Field, Operation]):
         self.items.append(item)
 
     @property
@@ -44,8 +48,35 @@ class Widget:
         return deepcopy(self, memodict)
 
     @property
-    def operations(self):
+    def operations(self) -> List[Operation]:
         return [item for item in self.items if isinstance(item, Operation)]
+
+    def hide_aliases(
+        self,
+        fields: List[HideField],
+    ) -> FrozenSet[str]:
+        hide_aliases = {alias_selector(item if isinstance(item, str) else item.alias) for item in self.hide}
+
+        for field in fields:
+            if field.fetch_only:
+                hide_aliases.add(alias_selector(field.alias))
+
+        return hide_aliases
+
+    @staticmethod
+    def hide_data_frame_indexes(
+        data_frame: pd.DataFrame,
+        aliases_to_hide: List[str],
+    ) -> None:
+        data_frame_indexes = (
+            [data_frame.index.name] if not isinstance(data_frame.index, pd.MultiIndex) else data_frame.index.names
+        )
+
+        for alias_to_hide in aliases_to_hide:
+            if alias_to_hide in data_frame_indexes:
+                data_frame.reset_index(level=alias_to_hide, drop=True, inplace=True)
+            elif alias_to_hide in data_frame:
+                del data_frame[alias_to_hide]
 
     def __eq__(self, other):
         return isinstance(other, self.__class__) and self.items == other.items
@@ -59,18 +90,13 @@ class TransformableWidget(Widget):
     # should be applied to the number of series rather than the number of data points.
     group_pagination = False
 
-    @staticmethod
-    def hide_data_frame_indexes(data_frame, dimensions_to_hide):
-        data_frame_indexes = (
-            [data_frame.index.name] if not isinstance(data_frame.index, pd.MultiIndex) else data_frame.index.names
-        )
-
-        for dimension in dimensions_to_hide:
-            dimesion_alias = alias_selector(dimension.alias)
-            if dimesion_alias in data_frame_indexes:
-                data_frame.reset_index(level=dimesion_alias, drop=True, inplace=True)
-
-    def transform(self, data_frame, dimensions, references, annotation_frame=None):
+    def transform(
+        self,
+        data_frame: pd.DataFrame,
+        dimensions: List[Field],
+        references: List[Reference],
+        annotation_frame: Optional[pd.DataFrame] = None,
+    ) -> dict:
         """
         - Main entry point -
 
@@ -92,7 +118,7 @@ class TransformableWidget(Widget):
 
 
 class ReferenceItem:
-    def __init__(self, item, reference):
+    def __init__(self, item: Union[Field, Operation], reference: Reference):
         assert isinstance(reference, Reference)
         self.data_type = item.data_type
         self.alias = reference_alias(item, reference)

--- a/fireant/widgets/csv.py
+++ b/fireant/widgets/csv.py
@@ -1,22 +1,25 @@
+import pandas as pd
+
 from _csv import QUOTE_MINIMAL
-from typing import Iterable
+from typing import Iterable, List, Optional
 
 from fireant.dataset.fields import Field
+from fireant.dataset.references import Reference
 from .pandas import Pandas
 
 
 class CSV(Pandas):
-    def __init__(self, metric: Field, *metrics: Iterable[Field], group_pagination=False, **kwargs):
+    def __init__(self, metric: Field, *metrics: Iterable[Field], group_pagination: bool = False, **kwargs):
         super().__init__(metric, *metrics, **kwargs)
         self.group_pagination = group_pagination
 
     def transform(
         self,
-        data_frame,
-        dimensions,
-        references,
-        annotation_frame=None,
-        use_raw_values=None,
+        data_frame: pd.DataFrame,
+        dimensions: List[Field],
+        references: List[Reference],
+        annotation_frame: Optional[pd.DataFrame] = None,
+        use_raw_values: bool = None,
     ):
         result_df = super(CSV, self).transform(data_frame, dimensions, references, use_raw_values=True)
         # Unset the column level names because they're a bit confusing in a csv file


### PR DESCRIPTION
That way we can hide dimensions/metrics/referenced metrics. That makes sense in a few cases, like when using hyperlink templates in ReactTable but not wanting to display dependencies, when using references but wanting to display it for just a subset of the metrics or the counterpart.

This PR also introduces, DaysOverDays, WeeksOverWeeks, MonthsOverMonths, QuartersOverQuarters, and YearsOverYears as ReferenceType builders, which accept a custom interval. The original DayOverDay and so on are now relying on those newly created ReferenceType builders.