### PR TITLE
Fix issues in custom interval references

### DIFF
--- a/fireant/dataset/references.py
+++ b/fireant/dataset/references.py
@@ -87,11 +87,30 @@ class ReferenceType(object):
         return hash("reference" + self.alias)
 
 
-DaysOverDays: Callable[[int], ReferenceType] = lambda interval: ReferenceType("dod", "DoD", "day", interval)
-WeeksOverWeeks: Callable[[int], ReferenceType] = lambda interval: ReferenceType("wow", "WoW", "week", interval)
-MonthsOverMonths: Callable[[int], ReferenceType] = lambda interval: ReferenceType("mom", "MoM", "month", interval)
-QuartersOverQuarters: Callable[[int], ReferenceType] = lambda interval: ReferenceType("qoq", "QoQ", "quarter", interval)
-YearsOverYears: Callable[[int], ReferenceType] = lambda interval: ReferenceType("yoy", "YoY", "year", interval)
+def _over_format(identifier: str, interval: int):
+    reference_format = f'{identifier}o{identifier}'
+
+    if interval > 1:
+        reference_format = f'{identifier}o{interval}{identifier}'
+
+    return reference_format
+
+
+DaysOverDays: Callable[[int], ReferenceType] = lambda interval: ReferenceType(
+    _over_format('d', interval), _over_format('D', interval), 'day', interval
+)
+WeeksOverWeeks: Callable[[int], ReferenceType] = lambda interval: ReferenceType(
+    _over_format('w', interval), _over_format('W', interval), 'week', interval
+)
+MonthsOverMonths: Callable[[int], ReferenceType] = lambda interval: ReferenceType(
+    _over_format('m', interval), _over_format('M', interval), 'month', interval
+)
+QuartersOverQuarters: Callable[[int], ReferenceType] = lambda interval: ReferenceType(
+    _over_format('q', interval), _over_format('Q', interval), 'quarter', interval
+)
+YearsOverYears: Callable[[int], ReferenceType] = lambda interval: ReferenceType(
+    _over_format('y', interval), _over_format('Y', interval), 'year', interval
+)
 
 DayOverDay = DaysOverDays(interval=1)
 WeekOverWeek = WeeksOverWeeks(interval=1)

--- a/fireant/tests/dataset/test_references.py
+++ b/fireant/tests/dataset/test_references.py
@@ -1,0 +1,82 @@
+from fireant.dataset.references import DayOverDay
+from unittest import TestCase
+
+from fireant import (
+    DaysOverDays,
+    DayOverDay,
+    WeeksOverWeeks,
+    WeekOverWeek,
+    MonthsOverMonths,
+    MonthOverMonth,
+    QuartersOverQuarters,
+    QuarterOverQuarter,
+    YearsOverYears,
+    YearOverYear,
+)
+
+
+class CumulativeOperationTests(TestCase):
+    def test_DaysOverDays_with_1_as_interval_is_equal_to_DayOverDay(self):
+        self.assertEqual(DaysOverDays(1), DayOverDay)
+
+    def test_DaysOverDays_returns_the_right_reference_type(self):
+        reference_type = DaysOverDays(2)
+
+        with self.subTest('has alias set'):
+            self.assertEqual(reference_type.alias, 'do2d')
+        with self.subTest('has label set'):
+            self.assertEqual(reference_type.label, 'Do2D')
+        with self.subTest('has interval set to 2'):
+            self.assertEqual(reference_type.interval, 2)
+
+    def test_WeeksOverWeeks_with_1_as_interval_is_equal_to_WeekOverWeek(self):
+        self.assertEqual(WeeksOverWeeks(1), WeekOverWeek)
+
+    def test_WeeksOverWeeks_returns_the_right_reference_type(self):
+        reference_type = WeeksOverWeeks(2)
+
+        with self.subTest('has alias set'):
+            self.assertEqual(reference_type.alias, 'wo2w')
+        with self.subTest('has label set'):
+            self.assertEqual(reference_type.label, 'Wo2W')
+        with self.subTest('has interval set to 2'):
+            self.assertEqual(reference_type.interval, 2)
+
+    def test_MonthsOverMonths_with_1_as_interval_is_equal_to_MonthOverMonth(self):
+        self.assertEqual(MonthsOverMonths(1), MonthOverMonth)
+
+    def test_MonthsOverMonths_returns_the_right_reference_type(self):
+        reference_type = MonthsOverMonths(2)
+
+        with self.subTest('has alias set'):
+            self.assertEqual(reference_type.alias, 'mo2m')
+        with self.subTest('has label set'):
+            self.assertEqual(reference_type.label, 'Mo2M')
+        with self.subTest('has interval set to 2'):
+            self.assertEqual(reference_type.interval, 2)
+
+    def test_QuartersOverQuarters_with_1_as_interval_is_equal_to_QuarterOverQuarter(self):
+        self.assertEqual(QuartersOverQuarters(1), QuarterOverQuarter)
+
+    def test_QuartersOverQuarters_returns_the_right_reference_type(self):
+        reference_type = QuartersOverQuarters(2)
+
+        with self.subTest('has alias set'):
+            self.assertEqual(reference_type.alias, 'qo2q')
+        with self.subTest('has label set'):
+            self.assertEqual(reference_type.label, 'Qo2Q')
+        with self.subTest('has interval set to 2'):
+            self.assertEqual(reference_type.interval, 2)
+
+    def test_YearsOverYears_with_1_as_interval_is_equal_to_YearOverYear(self):
+        self.assertEqual(YearsOverYears(1), YearOverYear)
+
+    def test_YearsOverYears_returns_the_right_reference_type(self):
+        reference_type = YearsOverYears(2)
+
+        with self.subTest('has alias set'):
+            self.assertEqual(reference_type.alias, 'yo2y')
+        with self.subTest('has label set'):
+            self.assertEqual(reference_type.label, 'Yo2Y')
+        with self.subTest('has interval set to 2'):
+            self.assertEqual(reference_type.interval, 2)


### PR DESCRIPTION
This makes makes custom interval references reflect the interval in the label/alias of the ReferenceType.