### PR TITLE
Fix Snowflake database ISO week truncation

### DIFF
--- a/fireant/database/snowflake.py
+++ b/fireant/database/snowflake.py
@@ -35,7 +35,7 @@ class SnowflakeDatabase(Database):
     # The pypika query class to use for constructing queries
     query_cls = SnowflakeQuery
 
-    DATETIME_INTERVALS = {'hour': 'HH', 'day': 'DD', 'week': 'IW', 'month': 'MM', 'quarter': 'Q', 'year': 'Y'}
+    DATETIME_INTERVALS = {'hour': 'HH', 'day': 'DD', 'week': 'W', 'month': 'MM', 'quarter': 'Q', 'year': 'Y'}
     _private_key = None
 
     def __init__(

--- a/fireant/tests/database/test_snowflake.py
+++ b/fireant/tests/database/test_snowflake.py
@@ -96,7 +96,7 @@ class TestSnowflake(TestCase):
     def test_trunc_week(self):
         result = SnowflakeDatabase().trunc_date(Field('date'), 'week')
 
-        self.assertEqual('TRUNC("date",\'IW\')', str(result))
+        self.assertEqual('TRUNC("date",\'W\')', str(result))
 
     def test_trunc_quarter(self):
         result = SnowflakeDatabase().trunc_date(Field('date'), 'quarter')


### PR DESCRIPTION
The use of IW was probably carried over from the Vertica implementation, but it is invalid. More info can be found here: https://docs.snowflake.com/en/sql-reference/functions-date-time.html#label-supported-date-time-parts