### PR TITLE
SEOD-1531. Fix dataframe sort with a pivot with the new pandas v2 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,18 @@ Changelog is organized by the version of this library, commit date and main poin
 - Important feature
 -----
 
-2023 September
+2023 December
+
+#### [8.0.5] - 2023-12-18
+- Fix dataframe sort with a pivot with the new pandas v2 API
+- Optimize it by getting rid of `reset_index` and `set_index` method calls when sorting 
+
+2023 November
 
 #### [8.0.4] - 2023-11-06
 Make removal of date total when generating highcharts more flexible by localizing the datetime when filtering out the totals. This will work with timezone aware datetimes as well not aware ones. 
+
+2023 September
 
 #### [8.0.3] - 2023-09-06
 - Specify extras dependencies correctly

--- a/fireant/__init__.py
+++ b/fireant/__init__.py
@@ -55,4 +55,4 @@ def __hash__(self) -> int:
 Term.__hash__ = __hash__
 
 
-__version__ = "8.0.4"
+__version__ = "8.0.5"

--- a/fireant/widgets/pandas.py
+++ b/fireant/widgets/pandas.py
@@ -202,15 +202,15 @@ class Pandas(TransformableWidget):
             # If there are no sort arguments or the data frame is a single row, then no need to sort
             return data_frame
 
-        # reset the index so all columns can be sorted together
-        index_names = data_frame.index.names
-        unsorted = data_frame.reset_index()
-        column_names = list(unsorted.columns)
+        # Get the list of index names and column names to be able to sort them together
+        index_names = list(data_frame.index.names)
+        column_names = list(data_frame.columns)
+        all_sort_columns = index_names + column_names
 
         ascending = self.ascending if self.ascending is not None else True
 
         sort = wrap_list(self.sort)
-        sort_columns = [column_names[column] for column in sort if column < len(column_names)]
+        sort_columns = [all_sort_columns[column] for column in sort if column < len(all_sort_columns)]
 
         if not sort_columns:
             return data_frame
@@ -220,13 +220,13 @@ class Pandas(TransformableWidget):
         if isinstance(ascending, list) and len(ascending) != len(sort_columns):
             ascending = ascending[0] if len(ascending) > 0 else None
 
-        sorted = unsorted.sort_values(sort_columns, ascending=ascending).set_index(index_names)
+        data_frame_sorted = data_frame.sort_values(sort_columns, ascending=ascending)
 
         # Maintain the single metric name
         if hasattr(data_frame, "name"):
-            sorted.name = data_frame.name
+            data_frame_sorted.name = data_frame.name
 
-        return sorted
+        return data_frame_sorted
 
     def add_formatting(
         self, dimensions: List[Field], items: List[Field], pivot_df: pd.DataFrame, use_raw_values: bool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fireant"
-version = "8.0.4"
+version = "8.0.5"
 description = ""
 authors = ["Ąžuolas Krušna <akrusna@kayak.com>"]
 readme = "README.rst"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 8.0.4
+current_version = 8.0.5
 commit = True
 tag = True
 


### PR DESCRIPTION
Optimize it by getting rid of `reset_index` and `set_index` method calls when sorting